### PR TITLE
Fix for rebuilding outside StreamBuilder

### DIFF
--- a/ferry_flutter/lib/src/query.dart
+++ b/ferry_flutter/lib/src/query.dart
@@ -18,15 +18,13 @@ class Query<T> extends StatefulWidget {
   });
 
   @override
-  _QueryState<T> createState() => _QueryState(builder: builder);
+  _QueryState<T> createState() => _QueryState();
 }
 
 class _QueryState<T> extends State<Query> {
-  final QueryResponseBuilder<T> builder;
 
   Stream<QueryResponse<T>> stream;
 
-  _QueryState({this.builder});
 
   @override
   void initState() {
@@ -52,7 +50,7 @@ class _QueryState<T> extends State<Query> {
         dataSource: DataSource.None,
       ),
       stream: stream,
-      builder: (context, snapshot) => builder(
+      builder: (context, snapshot) => widget.builder(
         context,
         snapshot.data,
       ),

--- a/ferry_flutter/lib/src/query.dart
+++ b/ferry_flutter/lib/src/query.dart
@@ -21,7 +21,7 @@ class Query<T> extends StatefulWidget {
   _QueryState<T> createState() => _QueryState();
 }
 
-class _QueryState<T> extends State<Query> {
+class _QueryState<T> extends State<Query<T>> {
 
   Stream<QueryResponse<T>> stream;
 


### PR DESCRIPTION
I've detailed the following in an example repository here https://github.com/aaahrens/example_bug.

While wrapping the Query widget with a StreamBuilder it wont update children that use out of scope variables from the builder.

I think this might have something to do with GC or how states are diffed.

Using the builder from the widget and not the state fixes this problem. 

Also: my flutter channel is on dev.