### PR TITLE
Notify Link when stream isn't being listened to anymore

### DIFF
--- a/ferry/lib/src/client.dart
+++ b/ferry/lib/src/client.dart
@@ -160,24 +160,22 @@ class Client {
   /// Fetches the query from the network, mapping the result to a
   /// [QueryResponse].
   Stream<QueryResponse<T>> _networkResponseStream<T>(
-      QueryRequest<T> queryRequest) async* {
+      QueryRequest<T> queryRequest) {
     try {
-      await for (var response in link.request(queryRequest)) {
-        yield QueryResponse(
-          queryRequest: queryRequest,
-          data: (response.data == null || response.data.isEmpty)
-              ? null
-              : queryRequest.parseData(response.data),
-          graphqlErrors: response.errors,
-          dataSource: DataSource.Link,
-        );
-      }
+      return link.request(queryRequest).map((response) => QueryResponse(
+            queryRequest: queryRequest,
+            data: (response.data == null || response.data.isEmpty)
+                ? null
+                : queryRequest.parseData(response.data),
+            graphqlErrors: response.errors,
+            dataSource: DataSource.Link,
+          ));
     } on LinkException catch (e) {
-      yield QueryResponse(
+      return Stream.value(QueryResponse(
         queryRequest: queryRequest,
         linkException: e,
         dataSource: DataSource.Link,
-      );
+      ));
     }
   }
 

--- a/ferry/test/link_subscription_cancel_test.dart
+++ b/ferry/test/link_subscription_cancel_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:ferry/ferry.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:gql_exec/src/response.dart';
+import 'package:test/test.dart';
+
+import './graphql/all_pokemon.req.gql.dart';
+
+class _StreamCancelTestLink extends Link {
+  final Completer hasCanceledStreamCompleter = Completer();
+
+  @override
+  Stream<Response> request(Request request, [forward]) async* {
+    StreamController<Response> controller = StreamController();
+    StreamSubscription sub;
+    try {
+      //simulate events coming in, e.g. from a websocket
+      sub =
+          Stream.periodic(Duration(microseconds: 1), (_) => Response(data: {}))
+              .listen(controller.add);
+      //yield* should finish when the client stops listening
+      yield* controller.stream;
+    } finally {
+      //this gets called when the client stops listening to the stream
+      sub?.cancel();
+      controller.close();
+
+      hasCanceledStreamCompleter.complete();
+    }
+  }
+}
+
+void main() {
+  test("Steam in Link is cancelled when no one is listening", () async {
+    final link = _StreamCancelTestLink();
+
+    final client = Client(link: link);
+    final request = AllPokemon(
+        fetchPolicy: FetchPolicy.NetworkOnly, buildVars: (b) => b..first = 3);
+    expect(link.hasCanceledStreamCompleter.isCompleted, isFalse);
+    StreamSubscription subscription;
+    subscription = client
+        .responseStream(request)
+        .where((event) => event.dataSource == DataSource.Link)
+        .listen((event) async {
+      //cancel subscription after first item
+      //this ensures the the link.request() method is entered
+      await subscription.cancel();
+    });
+    // the link should complete its "yield*" statement when the subscription is cancelled
+    // and complete its completer
+    await link.hasCanceledStreamCompleter.future;
+
+    expect(link.hasCanceledStreamCompleter.isCompleted, isTrue);
+  });
+}


### PR DESCRIPTION
This is a partial fix for #51.
This will fix #51 in all cases except when the Client uses FetchPolicy.CacheAndNetwork.

For FetchPolicy.CacheAndNetwork, a separate fix is needed. I will suggest a fix for this in a separate PR, because I am not really sure why it happens and not confident in my fix, so maybe someone with a better knowledge of rxdart can find a better solution.