### PR TITLE
Fix stream cancelling for FetchPolicy.CacheAndNetwork, too

### DIFF
--- a/ferry/lib/src/client.dart
+++ b/ferry/lib/src/client.dart
@@ -171,38 +171,30 @@ class Client {
   /// [QueryResponse].
   Stream<QueryResponse<T>> _networkResponseStream<T>(
       QueryRequest<T> queryRequest) {
-    try {
-      return link.request(queryRequest).transform(
-            StreamTransformer.fromHandlers(
-              handleData: (response, sink) => sink.add(
-                QueryResponse(
-                  queryRequest: queryRequest,
-                  data: (response.data == null || response.data.isEmpty)
-                      ? null
-                      : queryRequest.parseData(response.data),
-                  graphqlErrors: response.errors,
-                  dataSource: DataSource.Link,
-                ),
-              ),
-              handleError: (error, stackTrace, sink) => sink.add(
-                QueryResponse<T>(
-                  queryRequest: queryRequest,
-                  linkException: error is LinkException
-                      ? error
-                      : ServerException(
-                          originalException: error, parsedResponse: null),
-                  dataSource: DataSource.Link,
-                ),
+    return link.request(queryRequest).transform(
+          StreamTransformer.fromHandlers(
+            handleData: (response, sink) => sink.add(
+              QueryResponse(
+                queryRequest: queryRequest,
+                data: (response.data == null || response.data.isEmpty)
+                    ? null
+                    : queryRequest.parseData(response.data),
+                graphqlErrors: response.errors,
+                dataSource: DataSource.Link,
               ),
             ),
-          );
-    } on LinkException catch (e) {
-      return Stream.value(QueryResponse(
-        queryRequest: queryRequest,
-        linkException: e,
-        dataSource: DataSource.Link,
-      ));
-    }
+            handleError: (error, stackTrace, sink) => sink.add(
+              QueryResponse<T>(
+                queryRequest: queryRequest,
+                linkException: error is LinkException
+                    ? error
+                    : ServerException(
+                        originalException: error, parsedResponse: null),
+                dataSource: DataSource.Link,
+              ),
+            ),
+          ),
+        );
   }
 
   /// Fetches the query from the cache, mapping the result to a

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -124,9 +124,3 @@ void main() {
     });
   });
 }
-
-abstract class Mockable {
-  int stream();
-}
-
-class MyMock extends Mock implements Mockable {}

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -78,7 +78,7 @@ void main() {
       final exception = ServerException(parsedResponse: Response());
 
       when(mockLink.request(allPokemonReq, any))
-          .thenAnswer((_) =>Stream.error(exception));
+          .thenAnswer((_) => Stream.error(exception));
 
       final client = Client(
         link: mockLink,

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -83,7 +83,6 @@ void main() {
         final controller = StreamController<Response>();
 
         controller.addError("error");
-
         controller.add(Response(data: {}));
         controller.close();
 

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -47,7 +47,9 @@ void main() {
         () async {
       final mockLink = MockLink();
 
-      final allPokemonReq = AllPokemon(buildVars: (b) => b..first = 3);
+      final allPokemonReq = AllPokemon(
+        buildVars: (b) => b..first = 3,
+      );
 
       final exception = ServerException(parsedResponse: Response());
 
@@ -72,7 +74,9 @@ void main() {
       final mockLink = MockLink();
 
       final allPokemonReq = AllPokemon(
-          buildVars: (b) => b..first = 3, fetchPolicy: FetchPolicy.NetworkOnly);
+        buildVars: (b) => b..first = 3,
+        fetchPolicy: FetchPolicy.NetworkOnly,
+      );
 
       final exception = ServerException(parsedResponse: Response());
 

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -47,8 +47,7 @@ void main() {
         () async {
       final mockLink = MockLink();
 
-      final allPokemonReq = AllPokemon(
-          buildVars: (b) => b..first = 3, fetchPolicy: FetchPolicy.NetworkOnly);
+      final allPokemonReq = AllPokemon(buildVars: (b) => b..first = 3);
 
       final exception = ServerException(parsedResponse: Response());
 

--- a/ferry/test/error_test.dart
+++ b/ferry/test/error_test.dart
@@ -70,7 +70,7 @@ void main() {
   });
 
   group('Behavior after receiving errors', () {
-    test('Can emit data after emitting errors', () async {
+    test('Can emit data after emitting errors', () {
       final mockLink = MockLink();
 
       final allPokemonReq = AllPokemon(
@@ -79,18 +79,15 @@ void main() {
               .CacheAndNetwork // default is CacheFirst, which allows only 1 item from Link
           );
 
-      when(mockLink.request(allPokemonReq, any)).thenAnswer((_) {
+      when(mockLink.request(allPokemonReq, any)).thenAnswer((_) async* {
         final controller = StreamController<Response>();
 
-        Future.delayed((Duration(microseconds: 1)))
-            .then((value) => controller.addError("error"));
+        controller.addError("error");
 
-        Future.delayed((Duration(milliseconds: 100))).then((value) {
-          controller.add(Response(data: {}));
-          controller.close();
-        });
+        controller.add(Response(data: {}));
+        controller.close();
 
-        return controller.stream;
+        yield* controller.stream;
       });
 
       final client = Client(

--- a/ferry/test/link_subscription_cancel_test.dart
+++ b/ferry/test/link_subscription_cancel_test.dart
@@ -37,7 +37,7 @@ class _StreamCancelTestLink extends Link {
 
 void main() {
   test(
-      "Steam in Link is cancelled when no one is listening - for all FetchPolicies",
+      "Stream in Link is cancelled when no one is listening - for all FetchPolicies",
       () async {
     final link = _StreamCancelTestLink();
     final client = Client(link: link);
@@ -68,7 +68,7 @@ void main() {
         expect(link.hasCanceledStreamCompleter.isCompleted, isTrue);
         link.reset();
       } on TimeoutException {
-        fail("Stream from link was not cancelledo when using $fetchPolicy");
+        fail("Stream from link was not cancelled when using $fetchPolicy");
       }
     }
   });


### PR DESCRIPTION
This fixes #51 .

This includes the changes in #52, and fixes for `FetchPolicy.cacheAndNetwork` policy, and extends the test for canceling the streams when they are not listened to anymore for all FetchPolicies.

I am not really sure why these fixes to `FetchPolicy.cacheAndNetwork` are necessary, I know too little about rxdart for this. But with wrapping the network stream in a new StreamController and manually canceling it, the canceling of the stream is passed on the Link, too.

There might be a better with rxdart, which is why I put this fix in a separate PR.
