### PR TITLE
Refactor TypePolicy.keyFields to allow for child keyFields

### DIFF
--- a/ferry/CHANGELOG.md
+++ b/ferry/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] - 2020-09-10
+
+### Changed
+- Bump `normalize` version
+
 ## [0.7.3] - 2020-09-09
 
 ### Changed

--- a/ferry/pubspec.yaml
+++ b/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.7.3
+version: 0.7.4
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry
@@ -11,7 +11,7 @@ dependencies:
   gql_link: ^0.3.0
   gql_exec: ^0.2.4
   meta: ^1.1.8
-  normalize: ^0.3.4
+  normalize: ^0.4.0
   collection: ^1.14.12
   ferry_store: ^0.2.1
   hive: ^1.4.4

--- a/normalize/CHANGELOG.md
+++ b/normalize/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2020-09-10
+
+### Changed
+
+- update `TypePolicy.keyFields` API to allow subfields
+
 ## [0.3.4] - 2020-09-09
 
 ### Added

--- a/normalize/lib/src/policies/type_policy.dart
+++ b/normalize/lib/src/policies/type_policy.dart
@@ -3,18 +3,32 @@ import './field_policy.dart';
 class TypePolicy {
   /// Allows defining the primary key fields for this type.
   ///
-  /// If you don't wish to normalize this type, simply pass an empty list. In
+  /// Pass a `true` value for any fields you wish to use as key fields. You can
+  /// also use child fields.
+  ///
+  /// ```dart
+  /// final bookTypePolicy = TypePolicy(
+  ///   keyFields: {
+  ///     'title': true,
+  ///     'author': {
+  ///       'name': true,
+  ///     }
+  ///   },
+  /// );
+  /// ```
+  ///
+  /// If you don't wish to normalize this type, simply pass an empty `Map`. In
   /// that case, we won't normalize this type and it will be reachable from its
   /// parent.
-  ///
-  /// Unlike the Apollo Client, nested keyFields are not currently allowed.
-  List<String> keyFields;
+  Map<String, dynamic> keyFields;
 
-  /// If your schema uses a custom __typename for any of the root Query,
-  /// Mutation, and/or Subscription types (rare), set the corresponding
-  /// field below to true to indicate that this type serves as that type.
+  /// Set to `true` if this type is the root Query in your schema.
   bool queryType;
+
+  /// Set to `true` if this type is the root Mutation in your schema.
   bool mutationType;
+
+  /// Set to `true` if this type is the root Subscription in your schema.
   bool subscriptionType;
 
   /// Allows defining [FieldPolicy]s for this type.

--- a/normalize/lib/src/utils/exceptions.dart
+++ b/normalize/lib/src/utils/exceptions.dart
@@ -1,1 +1,3 @@
 class PartialDataException implements Exception {}
+
+class MissingKeyFieldException implements Exception {}

--- a/normalize/pubspec.yaml
+++ b/normalize/pubspec.yaml
@@ -1,5 +1,5 @@
 name: normalize
-version: 0.3.4
+version: 0.3.5
 homepage: https://github.com/gql-dart/ferry/tree/master/normalize
 description: Normalization and denormalization of GraphQL responses in Dart
 repository: https://github.com/gql-dart/ferry


### PR DESCRIPTION
This PR refactors the TypePolicy.keyFIelds API. It now accepts a Map of fields (and subfields) and can be used like this:

```dart
      final typePolicies = {
        'Post': TypePolicy(
          keyFields: {
            'id': true,
            'title': true,
            'author': {
              'name': true,
            },
          },
        )
      };
```

Any values other than `true` will be ignored.