### PR TITLE
Copy list of Plugins from defaultPlugins when instantiating a client

### DIFF
--- a/ferry/lib/src/client.dart
+++ b/ferry/lib/src/client.dart
@@ -30,7 +30,7 @@ class Client {
   final Link link;
   final Cache cache;
   final Map<OperationType, FetchPolicy> defaultFetchPolicies;
-  final List<Plugin> plugins = defaultPlugins;
+  final List<Plugin> plugins = List.of(defaultPlugins);
 
   /// A stream controller that handles all [OperationRequest]s.
   final requestController = StreamController<OperationRequest>.broadcast();

--- a/ferry/test/plugins/plugins_list_mutation_test.dart
+++ b/ferry/test/plugins/plugins_list_mutation_test.dart
@@ -1,0 +1,30 @@
+import 'package:mockito/mockito.dart';
+import 'package:gql_link/gql_link.dart';
+import 'package:ferry/ferry.dart';
+import 'package:test/test.dart';
+
+
+class MockLink extends Mock implements Link {}
+
+void main() {
+  final mockLink = MockLink();
+
+  test(
+      'modifying the plugins of a client does not mutate the global defaultPlugins variable',
+      () {
+    final defaultPluginsAtBeginning = List.of(defaultPlugins);
+
+    final client1 = Client(
+      link: mockLink,
+    )..plugins.removeAt(0);
+
+    expect(defaultPluginsAtBeginning, equals(defaultPlugins));
+    expect(client1.plugins, isNot(defaultPluginsAtBeginning));
+
+    final client2 = Client(
+      link: mockLink,
+    );
+
+    expect(client2.plugins, equals(defaultPluginsAtBeginning));
+  });
+}

--- a/ferry/test/plugins/plugins_list_mutation_test.dart
+++ b/ferry/test/plugins/plugins_list_mutation_test.dart
@@ -3,7 +3,6 @@ import 'package:gql_link/gql_link.dart';
 import 'package:ferry/ferry.dart';
 import 'package:test/test.dart';
 
-
 class MockLink extends Mock implements Link {}
 
 void main() {


### PR DESCRIPTION
Currently, the reference to the list of `plugins` of a client is a reference to the global `defaultPlugins` variable by default.
This means, mutating this list also mutates the `defaultPlugins` variable.

This is probably unexpected behavior for most users.

I would assume, that if I created 2 clients and mutate the list of plugins of one client, that this has no effect on the second client.

This PR changes this behavior, the client now copies its `plugins` list from `defaultPlugins` and adds a test that verifies this.