### PR TITLE
More robust partial data handling

### DIFF
--- a/normalize/lib/src/config/normalization_config.dart
+++ b/normalize/lib/src/config/normalization_config.dart
@@ -6,12 +6,26 @@ import 'package:normalize/src/utils/resolve_data_id.dart';
 
 class NormalizationConfig {
   final Map<String, dynamic> Function(String dataId) read;
+
+  /// Fragment or operation variables that parameterize the document.
   final Map<String, dynamic> variables;
+
+  /// Mapping of `__typename` to custom [TypePolicy] to use, if any.
   final Map<String, TypePolicy> typePolicies;
   final String referenceKey;
+
+  /// Mapping of fragment names to their definitions for spread resolution.
   final Map<String, FragmentDefinitionNode> fragmentMap;
+
+  /// Resolves a data id [String] for a given object [Map],
+  /// or returns `null` if the [Map] should not be normalized.
   final DataIdResolver dataIdFromObject;
+
+  /// Whether to add a `__typename` field to every selection set in the document.
   final bool addTypename;
+
+  /// Whether to accept or return partial data.
+  final bool allowPartialData;
 
   NormalizationConfig({
     @required this.read,
@@ -21,5 +35,6 @@ class NormalizationConfig {
     @required this.fragmentMap,
     @required this.dataIdFromObject,
     @required this.addTypename,
+    @required this.allowPartialData,
   });
 }

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -35,6 +35,7 @@ Map<String, dynamic> denormalizeFragment({
   DataIdResolver dataIdFromObject,
   bool addTypename = false,
   bool returnPartialData = false,
+  bool handleException = true,
   String referenceKey = '\$ref',
 }) {
   if (addTypename) {
@@ -89,6 +90,9 @@ Map<String, dynamic> denormalizeFragment({
       config: config,
     );
   } on PartialDataException {
-    return null;
+    if (handleException) {
+      return null;
+    }
+    rethrow;
   }
 }

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -79,6 +79,7 @@ Map<String, dynamic> denormalizeFragment({
     fragmentMap: fragmentMap,
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
+    allowPartialData: returnPartialData,
   );
 
   try {
@@ -86,7 +87,6 @@ Map<String, dynamic> denormalizeFragment({
       selectionSet: fragmentDefinition.selectionSet,
       dataForNode: read(dataId),
       config: config,
-      returnPartialData: returnPartialData,
     );
   } on PartialDataException {
     return null;

--- a/normalize/lib/src/denormalize_operation.dart
+++ b/normalize/lib/src/denormalize_operation.dart
@@ -30,6 +30,7 @@ Map<String, dynamic> denormalizeOperation({
   DataIdResolver dataIdFromObject,
   bool addTypename = false,
   bool returnPartialData = false,
+  bool handleException = true,
   String referenceKey = '\$ref',
 }) {
   if (addTypename) {
@@ -64,6 +65,9 @@ Map<String, dynamic> denormalizeOperation({
       config: config,
     );
   } on PartialDataException {
-    return null;
+    if (handleException) {
+      return null;
+    }
+    rethrow;
   }
 }

--- a/normalize/lib/src/denormalize_operation.dart
+++ b/normalize/lib/src/denormalize_operation.dart
@@ -54,6 +54,7 @@ Map<String, dynamic> denormalizeOperation({
     fragmentMap: getFragmentMap(document),
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
+    allowPartialData: returnPartialData,
   );
 
   try {
@@ -61,7 +62,6 @@ Map<String, dynamic> denormalizeOperation({
       selectionSet: operationDefinition.selectionSet,
       dataForNode: read(rootTypename) ?? const {},
       config: config,
-      returnPartialData: returnPartialData,
     );
   } on PartialDataException {
     return null;

--- a/normalize/lib/src/normalize_fragment.dart
+++ b/normalize/lib/src/normalize_fragment.dart
@@ -39,6 +39,7 @@ void normalizeFragment({
   DataIdResolver dataIdFromObject,
   bool addTypename = false,
   String referenceKey = '\$ref',
+  bool acceptPartialData = true,
 }) {
   // Always add typenames to ensure data is stored with typename
   document = transform(
@@ -74,6 +75,7 @@ void normalizeFragment({
     fragmentMap: fragmentMap,
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
+    allowPartialData: acceptPartialData,
   );
 
   final dataId = resolveDataId(

--- a/normalize/lib/src/normalize_node.dart
+++ b/normalize/lib/src/normalize_node.dart
@@ -72,7 +72,7 @@ Object normalizeNode({
         /// If the policy can't merge or read,
         /// And the key is missing from the data,
         /// we have partial data
-        if (!policyCanMergeOrRead && !dataForNode.containsKey(fieldName)) {
+        if (!policyCanMergeOrRead && !dataForNode.containsKey(inputKey)) {
           // if partial data is accepted, we proceed as usual
           // and just write nulls where data is missing
           if (!config.allowPartialData) {

--- a/normalize/lib/src/normalize_operation.dart
+++ b/normalize/lib/src/normalize_operation.dart
@@ -34,6 +34,7 @@ void normalizeOperation({
   Map<String, TypePolicy> typePolicies = const {},
   DataIdResolver dataIdFromObject,
   bool addTypename = false,
+  bool acceptPartialData = true,
   String referenceKey = '\$ref',
 }) {
   if (addTypename) {
@@ -58,6 +59,7 @@ void normalizeOperation({
     fragmentMap: getFragmentMap(document),
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
+    allowPartialData: acceptPartialData,
   );
 
   write(

--- a/normalize/lib/src/policies/field_policy.dart
+++ b/normalize/lib/src/policies/field_policy.dart
@@ -50,8 +50,8 @@ class FieldFunctionOptions {
           fragmentMap: _config.fragmentMap,
           dataIdFromObject: _config.dataIdFromObject,
           addTypename: _config.addTypename,
+          allowPartialData: true,
         ),
-        returnPartialData: true,
       );
 }
 

--- a/normalize/lib/src/utils/exceptions.dart
+++ b/normalize/lib/src/utils/exceptions.dart
@@ -1,3 +1,19 @@
-class PartialDataException implements Exception {}
+import 'package:meta/meta.dart';
+import 'package:normalize/utils.dart';
+
+/// Exception occurring when structurally valid data cannot be resolved
+/// for an expected field.
+@immutable
+class PartialDataException implements Exception {
+  PartialDataException({@required this.path});
+
+  /// Path to the first unfound subfield.
+  ///
+  /// Is a list of field names stringified with [FieldKey]
+  final List<String> path;
+
+  @override
+  String toString() => 'PartialDataException(path: ${path.join(".")})';
+}
 
 class MissingKeyFieldException implements Exception {}

--- a/normalize/lib/src/utils/resolve_data_id.dart
+++ b/normalize/lib/src/utils/resolve_data_id.dart
@@ -16,7 +16,7 @@ typedef DataIdResolver = String Function(Map<String, dynamic> object);
 ///
 /// Returns [null] if this type should not be normalized.
 String resolveDataId({
-  @required Map data,
+  @required Map<String, dynamic> data,
   Map<String, TypePolicy> typePolicies,
   DataIdResolver dataIdFromObject,
 }) {

--- a/normalize/lib/src/utils/resolve_data_id.dart
+++ b/normalize/lib/src/utils/resolve_data_id.dart
@@ -11,8 +11,8 @@ typedef DataIdResolver = String Function(Map<String, dynamic> object);
 /// Returns a unique ID to use to reference this normalized object.
 ///
 /// First checks if a [TypePolicy] exists for the given type. Next,
-/// calls the [dataIdFromObject] function if one is specified. Finally,
-/// falls back to the 'id' or '_id' field, respectively.
+/// calls the [dataIdFromObject] function if one is specified.
+/// If none is provided, falls back to the 'id' or '_id' field, respectively.
 ///
 /// Returns [null] if this type should not be normalized.
 String resolveDataId({

--- a/normalize/lib/src/utils/validate_structure.dart
+++ b/normalize/lib/src/utils/validate_structure.dart
@@ -1,0 +1,58 @@
+import 'package:gql/ast.dart';
+import 'package:meta/meta.dart';
+
+import 'package:normalize/src/utils/add_typename_visitor.dart';
+import 'package:normalize/src/utils/exceptions.dart';
+import 'package:normalize/src/utils/get_operation_definition.dart';
+import 'package:normalize/src/denormalize_node.dart';
+import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/utils/get_fragment_map.dart';
+
+/// Validates the structure of [data] against the operation [operationName] in [document].
+///
+/// Throws a [PartialDataException] if the data is invalid,
+/// unless [handleException] is specified, in which case it returns `false`
+///
+/// This is essentially a simplified version of [denormalizeOperation],
+/// but without any real denormalization logic
+bool validateOperationDataStructure({
+  @required DocumentNode document,
+  String operationName,
+  Map<String, dynamic> variables = const {},
+  Map<String, dynamic> data,
+  bool addTypename = false,
+  bool handleException = false,
+}) {
+  if (addTypename) {
+    document = transform(
+      document,
+      [AddTypenameVisitor()],
+    );
+  }
+
+  final operationDefinition = getOperationDefinition(document, operationName);
+
+  final config = NormalizationConfig(
+    read: (_) => data,
+    variables: variables,
+    typePolicies: const {},
+    referenceKey: '\$ref',
+    fragmentMap: getFragmentMap(document),
+    dataIdFromObject: (_) => null,
+    addTypename: addTypename,
+    allowPartialData: false,
+  );
+  try {
+    denormalizeNode(
+      selectionSet: operationDefinition.selectionSet,
+      dataForNode: data,
+      config: config,
+    );
+  } on PartialDataException {
+    if (handleException) {
+      return false;
+    }
+    rethrow;
+  }
+  return true;
+}

--- a/normalize/lib/src/utils/validate_structure.dart
+++ b/normalize/lib/src/utils/validate_structure.dart
@@ -10,7 +10,12 @@ import 'package:normalize/src/utils/exceptions.dart';
 /// Throws a [PartialDataException] if the data is invalid,
 /// unless `handleException=true`, in which case it returns `false`.
 ///
+/// Treats `null` data as invalid, thus distinguishing between _valid_ data,
+/// and data which is simply _not present_ as defined by the [spec].
+///
 /// Calls [denormalizeOperation] internally.
+///
+/// [spec]: https://spec.graphql.org/June2018/#sec-Data
 bool validateOperationDataStructure({
   @required DocumentNode document,
   @required Map<String, dynamic> data,
@@ -45,7 +50,7 @@ bool validateOperationDataStructure({
 /// unless `handleException=true`, in which case it returns `false`.
 ///
 /// **NOTE:** while `null` data is a theoretically acceptable value for any fragment in isolation,
-/// we treat it as invalid here.
+/// we treat it as invalid here, maintaining consistency with [denormalizeOperation].
 ///
 /// Calls [denormalizeFragment] internally.
 bool validateFragmentDataStructure({

--- a/normalize/lib/utils.dart
+++ b/normalize/lib/utils.dart
@@ -10,3 +10,4 @@ export 'src/utils/identify.dart';
 export 'src/utils/reachable_ids.dart';
 export 'src/utils/get_fragment_map.dart';
 export 'src/utils/operation_field_names.dart';
+export 'src/utils/validate_structure.dart';

--- a/normalize/test/partial_input_test.dart
+++ b/normalize/test/partial_input_test.dart
@@ -1,0 +1,140 @@
+import 'package:test/test.dart';
+import 'package:gql/language.dart';
+
+import 'package:normalize/normalize.dart';
+
+void main() {
+  test('Accepts partial data by default', () {
+    final normalizedResult = {};
+
+    final data = {
+      '__typename': 'Query',
+      'posts': [
+        {
+          'id': '123',
+          '__typename': 'Post',
+        }
+      ]
+    };
+
+    final query = parseString('''
+      query TestQuery {
+        posts {
+          __typename
+          id
+          title
+        }
+      }
+    ''');
+
+    normalizeOperation(
+      read: (dataId) => normalizedResult[dataId],
+      write: (dataId, value) => normalizedResult[dataId] = value,
+      document: query,
+      data: data,
+    );
+
+    expect(
+      normalizedResult,
+      equals({
+        'Query': {
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+          'title': null,
+        },
+      }),
+    );
+  });
+
+  test('Rejects partial data when acceptPartialData=false', () {
+    final normalizedResult = {};
+
+    final data = {
+      '__typename': 'Query',
+      'posts': [
+        {
+          'id': '123',
+          '__typename': 'Post',
+        }
+      ]
+    };
+
+    final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          title
+        }
+      }
+    ''');
+
+    expect(
+      () => normalizeOperation(
+        read: (dataId) => normalizedResult[dataId],
+        write: (dataId, value) => normalizedResult[dataId] = value,
+        document: query,
+        acceptPartialData: false,
+        data: data,
+      ),
+      throwsA(isA<PartialDataException>().having(
+        (e) => e.path,
+        'An accurate path',
+        ['posts', 'title'],
+      )),
+    );
+  });
+
+  test('Accepts explicit null when acceptPartialData=false', () {
+    final normalizedResult = {};
+
+    final data = {
+      '__typename': 'Query',
+      'posts': [
+        {
+          'id': '123',
+          '__typename': 'Post',
+          'title': null,
+        }
+      ]
+    };
+
+    final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          __typename
+          title
+        }
+      }
+    ''');
+
+    normalizeOperation(
+      read: (dataId) => normalizedResult[dataId],
+      write: (dataId, value) => normalizedResult[dataId] = value,
+      document: query,
+      data: data,
+      acceptPartialData: false,
+    );
+
+    expect(
+      normalizedResult,
+      equals({
+        'Query': {
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+          'title': null,
+        },
+      }),
+    );
+  });
+}


### PR DESCRIPTION
* Adds a `path` to `PartialDataException` to surface invalid paths
* Adds `acceptPartialData=true` to `normalizeFragment` and `normalizeOperation`
  to allow for the rejection of structurally incomplete results (i.e. `{}` != '{ foo: null }')
* `denormalizeFragment` and `denormalizeOperation` now have a `handleException=true` flag which can be disabled to throw rather than return null
* Adds a `validateOperationDataStructure` closing #102 (`handleException=false` by default)
* moved `returnPartialData` to `config.allowPartialData` in `denormalizeNode` as partial data is now a cross cutting concern
* add tests and a few docstrings elsewhere
