### PR TITLE
fix #110

### DIFF
--- a/examples/pokemon_explorer/lib/src/graphql/all_pokemon.req.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/all_pokemon.req.gql.dart
@@ -4,11 +4,10 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_exec/ferry_exec.dart' as _i1;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:pokemon_explorer/serializers.gql.dart' as _i7;
+import 'package:pokemon_explorer/serializers.gql.dart' as _i6;
 import 'package:pokemon_explorer/src/graphql/all_pokemon.ast.gql.dart' as _i5;
 import 'package:pokemon_explorer/src/graphql/all_pokemon.data.gql.dart' as _i2;
 import 'package:pokemon_explorer/src/graphql/all_pokemon.var.gql.dart' as _i3;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'all_pokemon.req.gql.g.dart';
 
@@ -24,7 +23,6 @@ abstract class GAllPokemonReq
   static void _initializeBuilder(GAllPokemonReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'AllPokemon')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GAllPokemonVars get vars;
   _i4.Operation get operation;
@@ -52,7 +50,7 @@ abstract class GAllPokemonReq
   static Serializer<GAllPokemonReq> get serializer =>
       _$gAllPokemonReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GAllPokemonReq.serializer, this);
+      _i6.serializers.serializeWith(GAllPokemonReq.serializer, this);
   static GAllPokemonReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GAllPokemonReq.serializer, json);
+      _i6.serializers.deserializeWith(GAllPokemonReq.serializer, json);
 }

--- a/examples/pokemon_explorer/lib/src/graphql/pokemon_detail.req.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/pokemon_detail.req.gql.dart
@@ -4,14 +4,13 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_exec/ferry_exec.dart' as _i1;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:pokemon_explorer/serializers.gql.dart' as _i7;
+import 'package:pokemon_explorer/serializers.gql.dart' as _i6;
 import 'package:pokemon_explorer/src/graphql/pokemon_detail.ast.gql.dart'
     as _i5;
 import 'package:pokemon_explorer/src/graphql/pokemon_detail.data.gql.dart'
     as _i2;
 import 'package:pokemon_explorer/src/graphql/pokemon_detail.var.gql.dart'
     as _i3;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'pokemon_detail.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GPokemonDetailReq
   static void _initializeBuilder(GPokemonDetailReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'PokemonDetail')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GPokemonDetailVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GPokemonDetailReq
   static Serializer<GPokemonDetailReq> get serializer =>
       _$gPokemonDetailReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GPokemonDetailReq.serializer, this);
+      _i6.serializers.serializeWith(GPokemonDetailReq.serializer, this);
   static GPokemonDetailReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GPokemonDetailReq.serializer, json);
+      _i6.serializers.deserializeWith(GPokemonDetailReq.serializer, json);
 }

--- a/examples/pokemon_explorer/pubspec.lock
+++ b/examples/pokemon_explorer/pubspec.lock
@@ -224,7 +224,7 @@ packages:
       path: "../../ferry_generator"
       relative: true
     source: path
-    version: "0.3.0"
+    version: "0.3.1"
   ferry_hive_store:
     dependency: "direct main"
     description:
@@ -246,6 +246,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1+2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   file:
     dependency: transitive
     description:
@@ -472,7 +479,7 @@ packages:
       path: "ios/.symlinks/plugins/path_provider"
       relative: true
     source: path
-    version: "1.6.14"
+    version: "1.6.21"
   path_provider_example:
     dependency: "direct overridden"
     description:
@@ -493,7 +500,7 @@ packages:
       path: "ios/.symlinks/plugins/path_provider_macos"
       relative: true
     source: path
-    version: "0.0.4+3"
+    version: "0.0.4+4"
   path_provider_platform_interface:
     dependency: transitive
     description:
@@ -501,6 +508,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  path_provider_windows:
+    dependency: "direct overridden"
+    description:
+      path: "ios/.symlinks/plugins/path_provider_windows"
+      relative: true
+    source: path
+    version: "0.0.4+1"
   pathproviderexample:
     dependency: "direct overridden"
     description:
@@ -667,13 +681,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.3"
-  uuid:
-    dependency: transitive
-    description:
-      name: uuid
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0"
   vector_math:
     dependency: transitive
     description:
@@ -695,6 +702,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/ferry/lib/src/fetch_policy_typed_link.dart
+++ b/ferry/lib/src/fetch_policy_typed_link.dart
@@ -111,7 +111,7 @@ class FetchPolicyTypedLink extends TypedLink {
   ) {
     if (response.dataSource != DataSource.Optimistic) {
       cache.removeOptimisticPatch(
-        response.operationRequest.requestId,
+        response.operationRequest,
       );
     }
   }
@@ -124,8 +124,9 @@ class FetchPolicyTypedLink extends TypedLink {
       cache.writeQuery(
         response.operationRequest,
         response.data,
-        optimistic: response.dataSource == DataSource.Optimistic,
-        requestId: response.operationRequest.requestId,
+        optimisticRequest: response.dataSource == DataSource.Optimistic
+            ? response.operationRequest
+            : null,
       );
     }
   }

--- a/ferry/lib/src/request_controller_typed_link.dart
+++ b/ferry/lib/src/request_controller_typed_link.dart
@@ -30,7 +30,11 @@ class RequestControllerTypedLink extends TypedLink {
 
     return requestController.stream
         .whereType<OperationRequest<TData, TVars>>()
-        .where((req) => request.requestId == req.requestId)
+        .where(
+          (req) => req.requestId == null
+              ? req == request
+              : req.requestId == request.requestId,
+        )
         .doOnData(
       (_) {
         /// Temporarily add a listener so that [prev] doesn't shut down when

--- a/ferry/test/typed_links/update_cache_typed_link_test.dart
+++ b/ferry/test/typed_links/update_cache_typed_link_test.dart
@@ -58,7 +58,7 @@ void main() {
           ..human.height = 1.85,
       );
 
-      final cacheProxy = CacheProxy(cache, true, req.requestId);
+      final cacheProxy = CacheProxy(cache, req);
       test('can write queries', () {
         expect(cacheProxy.readQuery(req), equals(null));
         cacheProxy.writeQuery(req, data);

--- a/ferry_cache/lib/src/utils/data_ids_change_stream.dart
+++ b/ferry_cache/lib/src/utils/data_ids_change_stream.dart
@@ -12,7 +12,7 @@ Stream<Set<String>> dataIdsChangeStream<TData, TVars>(
   OperationRequest<TData, TVars> request,
   TData existingData,
   bool optimistic,
-  Stream<Map<String, Map<String, Map<String, dynamic>>>>
+  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>>>>
       optimisticPatchesStream,
   Map<String, dynamic> Function(String dataId) optimisticReader,
   Store store,
@@ -94,7 +94,7 @@ Stream<Map<String, dynamic>> dataForIdStream(
   String dataId,
   Store store,
   bool optimistic,
-  Stream<Map<String, Map<String, Map<String, dynamic>>>>
+  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>>>>
       optimisticPatchesStream,
   Map<String, dynamic> Function(String dataId) optimisticReader,
 ) =>

--- a/ferry_cache/test/data_ids_change_stream_test.dart
+++ b/ferry_cache/test/data_ids_change_stream_test.dart
@@ -223,7 +223,7 @@ void main() {
 
         await Future.delayed(Duration.zero);
         cache.optimisticPatchesStream.add({
-          'patch-1': {
+          reviewsReq: {
             'Query': {
               'someQuery': [
                 {'\$ref': 'Review:123'},
@@ -262,7 +262,7 @@ void main() {
 
         await Future.delayed(Duration.zero);
         cache.optimisticPatchesStream.add({
-          'patch-2': {
+          reviewsReq: {
             'Query': {
               'reviews({"episode":null,"first":null,"offset":null})': [
                 {'\$ref': 'Review:456'},
@@ -301,7 +301,7 @@ void main() {
 
         await Future.delayed(Duration.zero);
         cache.optimisticPatchesStream.add({
-          'patch-2': {
+          reviewsReq: {
             'Review:123': {
               '__typename': 'Review',
               'id': '123',

--- a/ferry_cache/test/optimism_test.dart
+++ b/ferry_cache/test/optimism_test.dart
@@ -43,8 +43,7 @@ void main() {
       cache.writeQuery(
         mutation1,
         mutation1data,
-        optimistic: true,
-        requestId: mutation1.requestId,
+        optimisticRequest: mutation1,
       );
 
       test('data exists optimistically', () {
@@ -72,15 +71,13 @@ void main() {
       cache.writeQuery(
         mutation1,
         mutation1data,
-        optimistic: true,
-        requestId: mutation1.requestId,
+        optimisticRequest: mutation1,
       );
 
       cache.writeQuery(
         mutation2,
         mutation2data,
-        optimistic: true,
-        requestId: mutation2.requestId,
+        optimisticRequest: mutation2,
       );
       test('data exists optimistically', () {
         expect(
@@ -109,7 +106,7 @@ void main() {
       });
 
       test('can remove a single optimistic patch', () {
-        cache.removeOptimisticPatch(mutation1.requestId);
+        cache.removeOptimisticPatch(mutation1);
 
         expect(
           cache.readQuery(mutation1, optimistic: true),

--- a/ferry_generator/lib/src/req/operation_req.dart
+++ b/ferry_generator/lib/src/req/operation_req.dart
@@ -146,10 +146,6 @@ Class _buildOperationReqClass(
           'operationName': literalString(node.name.value),
         },
       ),
-      'requestId': refer('Uuid', 'package:uuid/uuid.dart')
-          .call([])
-          .property('v1')
-          .call([]),
       'executeOnListen': literalTrue,
     },
   ).rebuild(

--- a/ferry_generator/pubspec.yaml
+++ b/ferry_generator/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   built_collection: ^4.3.2
   code_builder: ^3.2.1
   build: ^1.2.2
-  uuid: ^2.2.0
   path: ^1.7.0
   ferry_exec: ^0.0.1
 dev_dependencies: 

--- a/ferry_test_graphql/lib/mutations/scalars/review_with_date.req.gql.dart
+++ b/ferry_test_graphql/lib/mutations/scalars/review_with_date.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/mutations/scalars/review_with_date.data.gql.d
     as _i2;
 import 'package:ferry_test_graphql/mutations/scalars/review_with_date.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'review_with_date.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GReviewWithDateReq
   static void _initializeBuilder(GReviewWithDateReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'ReviewWithDate')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GReviewWithDateVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GReviewWithDateReq
   static Serializer<GReviewWithDateReq> get serializer =>
       _$gReviewWithDateReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GReviewWithDateReq.serializer, this);
+      _i6.serializers.serializeWith(GReviewWithDateReq.serializer, this);
   static GReviewWithDateReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GReviewWithDateReq.serializer, json);
+      _i6.serializers.deserializeWith(GReviewWithDateReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/mutations/variables/create_review.req.gql.dart
+++ b/ferry_test_graphql/lib/mutations/variables/create_review.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/mutations/variables/create_review.data.gql.da
     as _i2;
 import 'package:ferry_test_graphql/mutations/variables/create_review.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'create_review.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GCreateReviewReq
   static void _initializeBuilder(GCreateReviewReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'CreateReview')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GCreateReviewVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GCreateReviewReq
   static Serializer<GCreateReviewReq> get serializer =>
       _$gCreateReviewReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GCreateReviewReq.serializer, this);
+      _i6.serializers.serializeWith(GCreateReviewReq.serializer, this);
   static GCreateReviewReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GCreateReviewReq.serializer, json);
+      _i6.serializers.deserializeWith(GCreateReviewReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/aliases/aliased_hero.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/aliases/aliased_hero.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/queries/aliases/aliased_hero.data.gql.dart'
     as _i2;
 import 'package:ferry_test_graphql/queries/aliases/aliased_hero.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'aliased_hero.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GAliasedHeroReq
   static void _initializeBuilder(GAliasedHeroReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'AliasedHero')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GAliasedHeroVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GAliasedHeroReq
   static Serializer<GAliasedHeroReq> get serializer =>
       _$gAliasedHeroReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GAliasedHeroReq.serializer, this);
+      _i6.serializers.serializeWith(GAliasedHeroReq.serializer, this);
   static GAliasedHeroReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GAliasedHeroReq.serializer, json);
+      _i6.serializers.deserializeWith(GAliasedHeroReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/fragments/hero_with_fragments.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/fragments/hero_with_fragments.req.gql.dart
@@ -9,10 +9,9 @@ import 'package:ferry_test_graphql/queries/fragments/hero_with_fragments.data.gq
     as _i2;
 import 'package:ferry_test_graphql/queries/fragments/hero_with_fragments.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
-import 'package:gql/ast.dart' as _i8;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
+import 'package:gql/ast.dart' as _i7;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'hero_with_fragments.req.gql.g.dart';
 
@@ -30,7 +29,6 @@ abstract class GHeroWithFragmentsReq
   static void _initializeBuilder(GHeroWithFragmentsReqBuilder b) => b
     ..operation = _i4.Operation(
         document: _i5.document, operationName: 'HeroWithFragments')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GHeroWithFragmentsVars get vars;
   _i4.Operation get operation;
@@ -58,9 +56,9 @@ abstract class GHeroWithFragmentsReq
   static Serializer<GHeroWithFragmentsReq> get serializer =>
       _$gHeroWithFragmentsReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GHeroWithFragmentsReq.serializer, this);
+      _i6.serializers.serializeWith(GHeroWithFragmentsReq.serializer, this);
   static GHeroWithFragmentsReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GHeroWithFragmentsReq.serializer, json);
+      _i6.serializers.deserializeWith(GHeroWithFragmentsReq.serializer, json);
 }
 
 abstract class GheroDataReq
@@ -76,7 +74,7 @@ abstract class GheroDataReq
     ..document = _i5.document
     ..fragmentName = 'heroData';
   _i3.GheroDataVars get vars;
-  _i8.DocumentNode get document;
+  _i7.DocumentNode get document;
   String get fragmentName;
   Map<String, dynamic> get idFields;
   @override
@@ -84,9 +82,9 @@ abstract class GheroDataReq
       _i2.GheroDataData.fromJson(json);
   static Serializer<GheroDataReq> get serializer => _$gheroDataReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GheroDataReq.serializer, this);
+      _i6.serializers.serializeWith(GheroDataReq.serializer, this);
   static GheroDataReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GheroDataReq.serializer, json);
+      _i6.serializers.deserializeWith(GheroDataReq.serializer, json);
 }
 
 abstract class GcomparisonFieldsReq
@@ -104,7 +102,7 @@ abstract class GcomparisonFieldsReq
     ..document = _i5.document
     ..fragmentName = 'comparisonFields';
   _i3.GcomparisonFieldsVars get vars;
-  _i8.DocumentNode get document;
+  _i7.DocumentNode get document;
   String get fragmentName;
   Map<String, dynamic> get idFields;
   @override
@@ -113,7 +111,7 @@ abstract class GcomparisonFieldsReq
   static Serializer<GcomparisonFieldsReq> get serializer =>
       _$gcomparisonFieldsReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GcomparisonFieldsReq.serializer, this);
+      _i6.serializers.serializeWith(GcomparisonFieldsReq.serializer, this);
   static GcomparisonFieldsReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GcomparisonFieldsReq.serializer, json);
+      _i6.serializers.deserializeWith(GcomparisonFieldsReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/fragments/hero_with_fragments.req.gql.g.dart
+++ b/ferry_test_graphql/lib/queries/fragments/hero_with_fragments.req.gql.g.dart
@@ -147,7 +147,7 @@ class _$GheroDataReqSerializer implements StructuredSerializer<GheroDataReq> {
           specifiedType: const FullType(_i3.GheroDataVars)),
       'document',
       serializers.serialize(object.document,
-          specifiedType: const FullType(_i8.DocumentNode)),
+          specifiedType: const FullType(_i7.DocumentNode)),
       'fragmentName',
       serializers.serialize(object.fragmentName,
           specifiedType: const FullType(String)),
@@ -178,8 +178,8 @@ class _$GheroDataReqSerializer implements StructuredSerializer<GheroDataReq> {
           break;
         case 'document':
           result.document = serializers.deserialize(value,
-                  specifiedType: const FullType(_i8.DocumentNode))
-              as _i8.DocumentNode;
+                  specifiedType: const FullType(_i7.DocumentNode))
+              as _i7.DocumentNode;
           break;
         case 'fragmentName':
           result.fragmentName = serializers.deserialize(value,
@@ -219,7 +219,7 @@ class _$GcomparisonFieldsReqSerializer
           specifiedType: const FullType(_i3.GcomparisonFieldsVars)),
       'document',
       serializers.serialize(object.document,
-          specifiedType: const FullType(_i8.DocumentNode)),
+          specifiedType: const FullType(_i7.DocumentNode)),
       'fragmentName',
       serializers.serialize(object.fragmentName,
           specifiedType: const FullType(String)),
@@ -251,8 +251,8 @@ class _$GcomparisonFieldsReqSerializer
           break;
         case 'document':
           result.document = serializers.deserialize(value,
-                  specifiedType: const FullType(_i8.DocumentNode))
-              as _i8.DocumentNode;
+                  specifiedType: const FullType(_i7.DocumentNode))
+              as _i7.DocumentNode;
           break;
         case 'fragmentName':
           result.fragmentName = serializers.deserialize(value,
@@ -503,7 +503,7 @@ class _$GheroDataReq extends GheroDataReq {
   @override
   final _i3.GheroDataVars vars;
   @override
-  final _i8.DocumentNode document;
+  final _i7.DocumentNode document;
   @override
   final String fragmentName;
   @override
@@ -573,9 +573,9 @@ class GheroDataReqBuilder
       _$this._vars ??= new _i3.GheroDataVarsBuilder();
   set vars(_i3.GheroDataVarsBuilder vars) => _$this._vars = vars;
 
-  _i8.DocumentNode _document;
-  _i8.DocumentNode get document => _$this._document;
-  set document(_i8.DocumentNode document) => _$this._document = document;
+  _i7.DocumentNode _document;
+  _i7.DocumentNode get document => _$this._document;
+  set document(_i7.DocumentNode document) => _$this._document = document;
 
   String _fragmentName;
   String get fragmentName => _$this._fragmentName;
@@ -643,7 +643,7 @@ class _$GcomparisonFieldsReq extends GcomparisonFieldsReq {
   @override
   final _i3.GcomparisonFieldsVars vars;
   @override
-  final _i8.DocumentNode document;
+  final _i7.DocumentNode document;
   @override
   final String fragmentName;
   @override
@@ -718,9 +718,9 @@ class GcomparisonFieldsReqBuilder
       _$this._vars ??= new _i3.GcomparisonFieldsVarsBuilder();
   set vars(_i3.GcomparisonFieldsVarsBuilder vars) => _$this._vars = vars;
 
-  _i8.DocumentNode _document;
-  _i8.DocumentNode get document => _$this._document;
-  set document(_i8.DocumentNode document) => _$this._document = document;
+  _i7.DocumentNode _document;
+  _i7.DocumentNode get document => _$this._document;
+  set document(_i7.DocumentNode document) => _$this._document = document;
 
   String _fragmentName;
   String get fragmentName => _$this._fragmentName;

--- a/ferry_test_graphql/lib/queries/interfaces/hero_for_episode.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/interfaces/hero_for_episode.req.gql.dart
@@ -9,10 +9,9 @@ import 'package:ferry_test_graphql/queries/interfaces/hero_for_episode.data.gql.
     as _i2;
 import 'package:ferry_test_graphql/queries/interfaces/hero_for_episode.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
-import 'package:gql/ast.dart' as _i8;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
+import 'package:gql/ast.dart' as _i7;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'hero_for_episode.req.gql.g.dart';
 
@@ -28,7 +27,6 @@ abstract class GHeroForEpisodeReq
   static void _initializeBuilder(GHeroForEpisodeReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'HeroForEpisode')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GHeroForEpisodeVars get vars;
   _i4.Operation get operation;
@@ -56,9 +54,9 @@ abstract class GHeroForEpisodeReq
   static Serializer<GHeroForEpisodeReq> get serializer =>
       _$gHeroForEpisodeReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GHeroForEpisodeReq.serializer, this);
+      _i6.serializers.serializeWith(GHeroForEpisodeReq.serializer, this);
   static GHeroForEpisodeReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GHeroForEpisodeReq.serializer, json);
+      _i6.serializers.deserializeWith(GHeroForEpisodeReq.serializer, json);
 }
 
 abstract class GDroidFragmentReq
@@ -74,7 +72,7 @@ abstract class GDroidFragmentReq
     ..document = _i5.document
     ..fragmentName = 'DroidFragment';
   _i3.GDroidFragmentVars get vars;
-  _i8.DocumentNode get document;
+  _i7.DocumentNode get document;
   String get fragmentName;
   Map<String, dynamic> get idFields;
   @override
@@ -83,7 +81,7 @@ abstract class GDroidFragmentReq
   static Serializer<GDroidFragmentReq> get serializer =>
       _$gDroidFragmentReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GDroidFragmentReq.serializer, this);
+      _i6.serializers.serializeWith(GDroidFragmentReq.serializer, this);
   static GDroidFragmentReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GDroidFragmentReq.serializer, json);
+      _i6.serializers.deserializeWith(GDroidFragmentReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/interfaces/hero_for_episode.req.gql.g.dart
+++ b/ferry_test_graphql/lib/queries/interfaces/hero_for_episode.req.gql.g.dart
@@ -142,7 +142,7 @@ class _$GDroidFragmentReqSerializer
           specifiedType: const FullType(_i3.GDroidFragmentVars)),
       'document',
       serializers.serialize(object.document,
-          specifiedType: const FullType(_i8.DocumentNode)),
+          specifiedType: const FullType(_i7.DocumentNode)),
       'fragmentName',
       serializers.serialize(object.fragmentName,
           specifiedType: const FullType(String)),
@@ -174,8 +174,8 @@ class _$GDroidFragmentReqSerializer
           break;
         case 'document':
           result.document = serializers.deserialize(value,
-                  specifiedType: const FullType(_i8.DocumentNode))
-              as _i8.DocumentNode;
+                  specifiedType: const FullType(_i7.DocumentNode))
+              as _i7.DocumentNode;
           break;
         case 'fragmentName':
           result.fragmentName = serializers.deserialize(value,
@@ -425,7 +425,7 @@ class _$GDroidFragmentReq extends GDroidFragmentReq {
   @override
   final _i3.GDroidFragmentVars vars;
   @override
-  final _i8.DocumentNode document;
+  final _i7.DocumentNode document;
   @override
   final String fragmentName;
   @override
@@ -498,9 +498,9 @@ class GDroidFragmentReqBuilder
       _$this._vars ??= new _i3.GDroidFragmentVarsBuilder();
   set vars(_i3.GDroidFragmentVarsBuilder vars) => _$this._vars = vars;
 
-  _i8.DocumentNode _document;
-  _i8.DocumentNode get document => _$this._document;
-  set document(_i8.DocumentNode document) => _$this._document = document;
+  _i7.DocumentNode _document;
+  _i7.DocumentNode get document => _$this._document;
+  set document(_i7.DocumentNode document) => _$this._document = document;
 
   String _fragmentName;
   String get fragmentName => _$this._fragmentName;

--- a/ferry_test_graphql/lib/queries/no_vars/hero_no_vars.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/no_vars/hero_no_vars.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/queries/no_vars/hero_no_vars.data.gql.dart'
     as _i2;
 import 'package:ferry_test_graphql/queries/no_vars/hero_no_vars.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'hero_no_vars.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GHeroNoVarsReq
   static void _initializeBuilder(GHeroNoVarsReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'HeroNoVars')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GHeroNoVarsVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GHeroNoVarsReq
   static Serializer<GHeroNoVarsReq> get serializer =>
       _$gHeroNoVarsReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GHeroNoVarsReq.serializer, this);
+      _i6.serializers.serializeWith(GHeroNoVarsReq.serializer, this);
   static GHeroNoVarsReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GHeroNoVarsReq.serializer, json);
+      _i6.serializers.deserializeWith(GHeroNoVarsReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/variables/human_with_args.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/variables/human_with_args.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/queries/variables/human_with_args.data.gql.da
     as _i2;
 import 'package:ferry_test_graphql/queries/variables/human_with_args.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'human_with_args.req.gql.g.dart';
 
@@ -27,7 +26,6 @@ abstract class GHumanWithArgsReq
   static void _initializeBuilder(GHumanWithArgsReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'HumanWithArgs')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GHumanWithArgsVars get vars;
   _i4.Operation get operation;
@@ -55,7 +53,7 @@ abstract class GHumanWithArgsReq
   static Serializer<GHumanWithArgsReq> get serializer =>
       _$gHumanWithArgsReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GHumanWithArgsReq.serializer, this);
+      _i6.serializers.serializeWith(GHumanWithArgsReq.serializer, this);
   static GHumanWithArgsReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GHumanWithArgsReq.serializer, json);
+      _i6.serializers.deserializeWith(GHumanWithArgsReq.serializer, json);
 }

--- a/ferry_test_graphql/lib/queries/variables/reviews.req.gql.dart
+++ b/ferry_test_graphql/lib/queries/variables/reviews.req.gql.dart
@@ -9,9 +9,8 @@ import 'package:ferry_test_graphql/queries/variables/reviews.data.gql.dart'
     as _i2;
 import 'package:ferry_test_graphql/queries/variables/reviews.var.gql.dart'
     as _i3;
-import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i7;
+import 'package:ferry_test_graphql/schema/serializers.gql.dart' as _i6;
 import 'package:gql_exec/gql_exec.dart' as _i4;
-import 'package:uuid/uuid.dart' as _i6;
 
 part 'reviews.req.gql.g.dart';
 
@@ -26,7 +25,6 @@ abstract class GReviewsReq
   static void _initializeBuilder(GReviewsReqBuilder b) => b
     ..operation =
         _i4.Operation(document: _i5.document, operationName: 'Reviews')
-    ..requestId = _i6.Uuid().v1()
     ..executeOnListen = true;
   _i3.GReviewsVars get vars;
   _i4.Operation get operation;
@@ -53,7 +51,7 @@ abstract class GReviewsReq
       _i2.GReviewsData.fromJson(json);
   static Serializer<GReviewsReq> get serializer => _$gReviewsReqSerializer;
   Map<String, dynamic> toJson() =>
-      _i7.serializers.serializeWith(GReviewsReq.serializer, this);
+      _i6.serializers.serializeWith(GReviewsReq.serializer, this);
   static GReviewsReq fromJson(Map<String, dynamic> json) =>
-      _i7.serializers.deserializeWith(GReviewsReq.serializer, json);
+      _i6.serializers.deserializeWith(GReviewsReq.serializer, json);
 }

--- a/ferry_test_graphql/pubspec.yaml
+++ b/ferry_test_graphql/pubspec.yaml
@@ -10,7 +10,6 @@ dependencies:
   gql: ^0.12.3
   gql_exec: ^0.2.4
   gql_code_builder: ^0.1.2
-  uuid: ^2.2.0
 dev_dependencies: 
   build_runner: ^1.10.1
   gql_build: ^0.1.2


### PR DESCRIPTION
This PR removes the default assigned uuids from OperationRequests.

Now rather than filtering results in the `request()` stream by `requestId`, ferry will first check if `requestId` is `null`. If it is, it will return results for identical OperationRequests in the same stream. Otherwise, it will only include results for requests with the same`requestId`.

This approach has a few tradeoffs:

The primary benefit is that OperationRequests can now be instantiated inside the build method of a Flutter Widget without manually providing a `requestId` without causing ferry to re-execute the operation on every widget build.

However, this also means that responses for an OperationRequest will be received by the response stream of any identical OperationRequest.

For example, if I listen to the following request:

```
final req = GTodosQuery((b) => b..vars.first = 5);

client.request(req).listen((data) => print(data));
```
...then later listen to an identical request
```
final req2 = GTodosQuery((b) => b..vars.first = 5);

client.request(req2).listen((data) => print(data));
```
The results from the second request will be received by the original listener. To avoid this behavior, we'd need to manually provide a `requestId` to each request.

Previously, since ferry automatically assigned a default uuid to `requestId`, streams would only receive results from other OperationRequest instances if we manually included the same `requestId`. 