### PR TITLE
remove workaround for rxdart memory leak

### DIFF
--- a/ferry/lib/src/fetch_policy_typed_link.dart
+++ b/ferry/lib/src/fetch_policy_typed_link.dart
@@ -81,32 +81,21 @@ class FetchPolicyTypedLink extends TypedLink {
                           [_cacheTypedLink.request(operationRequest).skip(1)]),
             );
       case FetchPolicy.CacheAndNetwork:
-        {
-          final responseStreamFromNetwork =
-              _optimisticLinkTypedLink.request(operationRequest);
+        final sharedNetworkStream =
+            _optimisticLinkTypedLink.request(operationRequest).shareValue();
 
-          final controller =
-              StreamController<OperationResponse<TData, TVars>>();
-          final networkStreamSubscription = responseStreamFromNetwork
-              .listen(controller.add, onError: controller.addError);
-
-          final sharedNetworkStream = controller.stream.shareValue();
-
-          return _cacheTypedLink
-              .request(operationRequest)
-              .where((response) => response.data != null)
-              .takeUntil(sharedNetworkStream)
-              .concatWith([
-            sharedNetworkStream
-                .doOnData(_writeToCache)
-                .switchMap((networkResponse) => ConcatStream([
-                      Stream.value(networkResponse),
-                      _cacheTypedLink.request(operationRequest).skip(1),
-                    ]))
-          ]).doOnCancel(() {
-            networkStreamSubscription.cancel();
-          });
-        }
+        return _cacheTypedLink
+            .request(operationRequest)
+            .where((response) => response.data != null)
+            .takeUntil(sharedNetworkStream)
+            .concatWith([
+          sharedNetworkStream
+              .doOnData(_writeToCache)
+              .switchMap((networkResponse) => ConcatStream([
+                    Stream.value(networkResponse),
+                    _cacheTypedLink.request(operationRequest).skip(1),
+                  ]))
+        ]);
     }
     return null;
   }

--- a/ferry/test/typed_links/fetch_policy_typed_link_test.dart
+++ b/ferry/test/typed_links/fetch_policy_typed_link_test.dart
@@ -32,7 +32,8 @@ void main() {
     );
 
     when(mockLink.request(any, any)).thenAnswer(
-      (_) => Stream.value(Response(data: data.toJson())),
+      (_) => Stream.value(Response(data: data.toJson())).delay(
+          Duration(milliseconds: 0)), //add delay to reliably test caching
     );
 
     StreamController<OperationRequest> requestController;


### PR DESCRIPTION
On my last PR I included an ugly hack that created a new `StreamController` for each new request `FetchPolicy.CachAndNetwork.`
I did not know why it was required, but the stream did not properly cancel otherwise.

I just read about a fixed memory leak in rxdart 0.25, and immediately thought of this issue.
Turns out, that really was the problem.
With rxdart 0.25.0, this workaround is no longer required (I verified it by downgrading back to 0.24 - link_subscription_cancel_test fails on 0.24, but not on 0.25 when the workaround is removed).

However, now another test failed:
CacheAndNetwork returns correct data now got a network response when it expected a cached response. But this was fixed the adding a delay of 0 milliseconds to the mocked network response (could this be solved in a more elegant way?)

