### PR TITLE
Improve default error handling

### DIFF
--- a/ferry/CHANGELOG.md
+++ b/ferry/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4]
+
+- catch Stream error events in `ErrorTypedLink`
+- include `ErrorTypedLink` in the default client `TypedLink` chain
+- update dependencies
+
 ## [0.9.3]
 
 - fix bug causing `FetchPolicy.CacheFirst` & `FetchPolicy.CacheAndNetwork` to only receive the first response from Link

--- a/ferry/lib/ferry.dart
+++ b/ferry/lib/ferry.dart
@@ -7,6 +7,7 @@ import 'package:ferry/src/add_typename_typed_link.dart';
 import 'package:ferry/src/fetch_policy_typed_link.dart';
 import 'package:ferry/src/request_controller_typed_link.dart';
 import 'package:ferry/src/update_cache_typed_link.dart';
+import 'package:ferry/src/error_typed_link.dart';
 
 export 'package:ferry_cache/ferry_cache.dart';
 export 'package:gql_link/gql_link.dart';
@@ -37,6 +38,7 @@ class Client extends TypedLink {
   })  : cache = cache ?? Cache(),
         requestController = requestController ?? StreamController.broadcast() {
     _typedLink = TypedLink.from([
+      ErrorTypedLink(),
       RequestControllerTypedLink(this.requestController),
       if (addTypename) AddTypenameTypedLink(),
       if (updateCacheHandlers.isNotEmpty)

--- a/ferry/lib/src/error_typed_link.dart
+++ b/ferry/lib/src/error_typed_link.dart
@@ -1,22 +1,34 @@
 import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:ferry_exec/ferry_exec.dart';
-
-export 'package:gql_link/gql_link.dart';
+import 'package:gql_link/gql_link.dart';
 
 /// A base class for exceptions thrown by [TypedLink]s
 @immutable
-class TypedLinkException implements Exception {
-  /// The original exception causing this exception
-  final dynamic originalException;
-
+class TypedLinkException extends LinkException {
   const TypedLinkException(
-    this.originalException,
-  );
+    dynamic originalException,
+  ) : super(originalException);
+
+  @override
+  bool operator ==(Object o) =>
+      o is TypedLinkException && o.originalException == originalException;
+
+  @override
+  int get hashCode => originalException.hashCode;
 }
 
-/// Catches any errors in the [TypedLink.request] chain, and returns a
-/// [Stream.errror] with the error.
+/// Catches [Exception]s in the link chain and converts them into data.
+///
+/// Emits the exception as the [OperationResponse.linkException] property.
+///
+/// [ErrorTypedLink] catches the following types of exceptions:
+///
+/// 1. Exceptions thrown when forwarding the TypedLink
+/// 2. Stream.error events emitted by any downstream TypedLink
+///
+/// In order to ensure that [Exception]s are caught, [ErrorTypedLink] should be
+/// placed at the very beginning of the [TypedLink] chain.
 class ErrorTypedLink extends TypedLink {
   const ErrorTypedLink();
 
@@ -26,10 +38,26 @@ class ErrorTypedLink extends TypedLink {
     forward,
   ]) {
     try {
-      return forward(operationRequest);
-    } catch (e) {
-      return Stream.error(
-        TypedLinkException(e),
+      return forward(operationRequest).transform(
+        StreamTransformer.fromHandlers(
+          handleError: (error, stackTrace, sink) => sink.add(
+            OperationResponse(
+              operationRequest: operationRequest,
+              linkException:
+                  error is LinkException ? error : TypedLinkException(error),
+              dataSource: DataSource.None,
+            ),
+          ),
+        ),
+      );
+    } catch (error) {
+      return Stream.value(
+        OperationResponse(
+          operationRequest: operationRequest,
+          linkException:
+              error is LinkException ? error : TypedLinkException(error),
+          dataSource: DataSource.None,
+        ),
       );
     }
   }

--- a/ferry/lib/src/error_typed_link.dart
+++ b/ferry/lib/src/error_typed_link.dart
@@ -1,22 +1,6 @@
 import 'dart:async';
-import 'package:meta/meta.dart';
 import 'package:ferry_exec/ferry_exec.dart';
 import 'package:gql_link/gql_link.dart';
-
-/// A base class for exceptions thrown by [TypedLink]s
-@immutable
-class TypedLinkException extends LinkException {
-  const TypedLinkException(
-    dynamic originalException,
-  ) : super(originalException);
-
-  @override
-  bool operator ==(Object o) =>
-      o is TypedLinkException && o.originalException == originalException;
-
-  @override
-  int get hashCode => originalException.hashCode;
-}
 
 /// Catches [Exception]s in the link chain and converts them into data.
 ///

--- a/ferry/pubspec.yaml
+++ b/ferry/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   collection: ^1.14.12
   hive: ^1.4.4
   built_value: ^7.1.0
-  ferry_exec: ^0.0.2
+  ferry_exec: ^0.0.3
   normalize: ^0.4.7
   ferry_cache: ^0.4.3
 dev_dependencies: 

--- a/ferry/pubspec.yaml
+++ b/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.9.3
+version: 0.9.4
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry
@@ -15,14 +15,14 @@ dependencies:
   hive: ^1.4.4
   built_value: ^7.1.0
   ferry_exec: ^0.0.2
-  normalize: ^0.4.5
-  ferry_cache: ^0.4.2
+  normalize: ^0.4.7
+  ferry_cache: ^0.4.3
 dev_dependencies: 
   test: ^1.9.4
   mockito: ^4.1.1
   build_runner: ^1.10.1
   build_test: ^0.10.12+1
   built_value_generator: ^7.1.0
-  ferry_test_graphql: ^0.0.2
+  ferry_test_graphql: ^0.0.3
   pedantic: ^1.9.0
   async: ^2.4.2

--- a/ferry/test/typed_links/error_typed_link_test.dart
+++ b/ferry/test/typed_links/error_typed_link_test.dart
@@ -1,28 +1,106 @@
 import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:rxdart/rxdart.dart';
 
 import 'package:ferry/ferry.dart';
 import 'package:ferry/src/error_typed_link.dart';
 import 'package:ferry_test_graphql/queries/variables/human_with_args.req.gql.dart';
+import 'package:ferry_test_graphql/queries/variables/human_with_args.data.gql.dart';
 
 class MockTypedLink extends Mock implements TypedLink {}
 
 void main() {
   final req = GHumanWithArgsReq((b) => b..vars.id = '123');
+  final mockTypedLink = MockTypedLink();
 
-  test(
-      'Returns a stream that emits an error if any typed link in chain throws an exception',
+  TypedLink client;
+
+  group('Error Catching', () {
+    setUpAll(() {
+      client = TypedLink.from([
+        ErrorTypedLink(),
+        mockTypedLink,
+      ]);
+    });
+
+    test(
+      'can catch errors thrown when forwarding the request',
       () async {
-    final mockTypedLink = MockTypedLink();
-    final exception = Exception('something went wrong');
-    when(mockTypedLink.request(req, any)).thenThrow(exception);
+        final exception = Exception('something went wrong');
+        when(mockTypedLink.request(req, any)).thenThrow(exception);
 
-    final typedLink = TypedLink.from([
-      ErrorTypedLink(),
-      mockTypedLink,
-    ]);
+        expect(
+          client.request(req),
+          emitsInOrder([
+            OperationResponse(
+              operationRequest: req,
+              linkException: TypedLinkException(exception),
+              dataSource: DataSource.None,
+            ),
+            emitsDone,
+          ]),
+        );
+      },
+    );
 
-    expect(
-        typedLink.request(req), emitsError(TypeMatcher<TypedLinkException>()));
+    test(
+      'can catch errors events in downstream TypedLinks',
+      () async {
+        final exception = Exception('something went wrong');
+        when(mockTypedLink.request(req, any))
+            .thenAnswer((_) => Stream.error(exception));
+
+        expect(
+          client.request(req),
+          emitsInOrder([
+            OperationResponse(
+              operationRequest: req,
+              linkException: TypedLinkException(exception),
+              dataSource: DataSource.None,
+            ),
+            emitsDone,
+          ]),
+        );
+      },
+    );
+
+    test(
+      'can emit data after emitting errors',
+      () async {
+        final exception = Exception('something went wrong');
+
+        final exceptionResponse = OperationResponse(
+          operationRequest: req,
+          linkException: TypedLinkException(exception),
+          dataSource: DataSource.None,
+        );
+
+        final dataResponse = OperationResponse(
+          operationRequest: req,
+          dataSource: DataSource.Link,
+          data: GHumanWithArgsData(
+            (b) => b
+              ..human.id = 'luke'
+              ..human.name = 'Luke',
+          ),
+        );
+
+        when(mockTypedLink.request(req, any)).thenAnswer(
+          (_) => MergeStream([
+            Stream.error(exception),
+            Stream.value(dataResponse),
+          ]),
+        );
+
+        expect(
+          client.request(req),
+          emitsInOrder([
+            exceptionResponse,
+            dataResponse,
+            emitsDone,
+          ]),
+        );
+      },
+    );
   });
 }

--- a/ferry_exec/CHANGELOG.md
+++ b/ferry_exec/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3]
+
+- add `TypedLinkException`
+
 ## [0.0.2]
 
 - update dependencies

--- a/ferry_exec/lib/ferry_exec.dart
+++ b/ferry_exec/lib/ferry_exec.dart
@@ -3,3 +3,4 @@ export 'package:ferry_exec/src/fragment_request.dart';
 export 'package:ferry_exec/src/operation_request.dart';
 export 'package:ferry_exec/src/operation_response.dart';
 export 'package:ferry_exec/src/typed_link.dart';
+export 'package:ferry_exec/src/exceptions.dart';

--- a/ferry_exec/lib/src/exceptions.dart
+++ b/ferry_exec/lib/src/exceptions.dart
@@ -1,0 +1,16 @@
+import 'package:ferry_exec/ferry_exec.dart';
+import 'package:gql_link/gql_link.dart';
+
+/// A base class for exceptions thrown by [TypedLink]s
+class TypedLinkException extends LinkException {
+  const TypedLinkException(
+    dynamic originalException,
+  ) : super(originalException);
+
+  @override
+  bool operator ==(Object o) =>
+      o is TypedLinkException && o.originalException == originalException;
+
+  @override
+  int get hashCode => originalException.hashCode;
+}

--- a/ferry_exec/pubspec.yaml
+++ b/ferry_exec/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_exec
-version: 0.0.2
+version: 0.0.3
 homepage: https://ferrygraphql.com/
 description: A strongly typed execution interface for GraphQL operations
 repository: https://github.com/gql-dart/ferry

--- a/ferry_flutter/CHANGELOG.md
+++ b/ferry_flutter/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0]
+
+- include error property in `OperationResponseBuilder`
+
 ## [0.3.2]
 
 - update dependencies

--- a/ferry_flutter/lib/src/operation.dart
+++ b/ferry_flutter/lib/src/operation.dart
@@ -4,6 +4,7 @@ import 'package:ferry_exec/ferry_exec.dart';
 typedef OperationResponseBuilder<TData, TVars> = Widget Function(
   BuildContext context,
   OperationResponse<TData, TVars> response,
+  Object error,
 );
 
 class Operation<TData, TVars> extends StatefulWidget {
@@ -52,6 +53,7 @@ class _OperationState<TData, TVars> extends State<Operation<TData, TVars>> {
       builder: (context, snapshot) => widget.builder(
         context,
         snapshot.data,
+        snapshot.error,
       ),
     );
   }

--- a/ferry_flutter/pubspec.yaml
+++ b/ferry_flutter/pubspec.yaml
@@ -1,14 +1,14 @@
 name: ferry_flutter
-version: 0.3.2
+version: 0.4.0
 homepage: https://ferrygraphql.com/
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
 environment: 
   sdk: '>=2.7.0 <3.0.0'
 dependencies: 
-  ferry: ^0.9.2
+  ferry: ^0.9.4
   gql_exec: ^0.2.4
-  ferry_exec: ^0.0.2
+  ferry_exec: ^0.0.3
   flutter: 
     sdk: flutter
   flutter_test: 


### PR DESCRIPTION
This PR improves the default error handling behavior in the following ways:

1. `ErrorTypedLink` now catches `Stream.error` events and converts them into `OperationResponse`s with a `linkException` property.
2. `ErrorTypedLink` now catches sync errors when forwarding the request in the TypedLink chain and converts them into `OperationResponse`s with a `linkException` property.
3. `ferry_flutter`'s `OperationResponseBuilder` now includes any errors from the underlying `StreamBuilder`