### PR TITLE
[normalize] migrate to NNBD

### DIFF
--- a/normalize/CHANGELOG.md
+++ b/normalize/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0]
+
+- add null safety
+
 ## [0.4.7]
 
 - add `reachableIdsFromDataId` util

--- a/normalize/lib/src/config/normalization_config.dart
+++ b/normalize/lib/src/config/normalization_config.dart
@@ -1,11 +1,10 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
 
 class NormalizationConfig {
-  final Map<String, dynamic> Function(String dataId) read;
+  final Map<String, dynamic>? Function(String dataId) read;
 
   /// Fragment or operation variables that parameterize the document.
   final Map<String, dynamic> variables;
@@ -19,7 +18,7 @@ class NormalizationConfig {
 
   /// Resolves a data id [String] for a given object [Map],
   /// or returns `null` if the [Map] should not be normalized.
-  final DataIdResolver dataIdFromObject;
+  final DataIdResolver? dataIdFromObject;
 
   /// Whether to add a `__typename` field to every selection set in the document.
   final bool addTypename;
@@ -28,13 +27,13 @@ class NormalizationConfig {
   final bool allowPartialData;
 
   NormalizationConfig({
-    @required this.read,
-    @required this.variables,
-    @required this.typePolicies,
-    @required this.referenceKey,
-    @required this.fragmentMap,
-    @required this.dataIdFromObject,
-    @required this.addTypename,
-    @required this.allowPartialData,
+    required this.read,
+    required this.variables,
+    required this.typePolicies,
+    required this.referenceKey,
+    required this.fragmentMap,
+    required this.dataIdFromObject,
+    required this.addTypename,
+    required this.allowPartialData,
   });
 }

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 import 'package:normalize/normalize.dart';
 
 import 'package:normalize/src/config/normalization_config.dart';
@@ -25,14 +24,14 @@ import 'package:normalize/src/denormalize_node.dart';
 ///
 /// Likewise, if a custom [referenceKey] was used to normalize the data, it
 /// must be provided. Otherwise, the default '$ref' key will be used.
-Map<String, dynamic> denormalizeFragment({
-  @required Map<String, dynamic> Function(String dataId) read,
-  @required DocumentNode document,
-  @required Map<String, dynamic> idFields,
-  String fragmentName,
+Map<String, dynamic>? denormalizeFragment({
+  required Map<String, dynamic>? Function(String dataId) read,
+  required DocumentNode document,
+  required Map<String, dynamic> idFields,
+  String? fragmentName,
   Map<String, dynamic> variables = const {},
   Map<String, TypePolicy> typePolicies = const {},
-  DataIdResolver dataIdFromObject,
+  DataIdResolver? dataIdFromObject,
   bool addTypename = false,
   bool returnPartialData = false,
   bool handleException = true,
@@ -60,7 +59,7 @@ Map<String, dynamic> denormalizeFragment({
   }
 
   final fragmentDefinition = fragmentName != null
-      ? fragmentMap[fragmentName]
+      ? fragmentMap[fragmentName]!
       : fragmentMap.values.first;
 
   final dataId = resolveDataId(
@@ -94,7 +93,7 @@ Map<String, dynamic> denormalizeFragment({
       selectionSet: fragmentDefinition.selectionSet,
       dataForNode: read(dataId),
       config: config,
-    );
+    ) as Map<String, dynamic>?;
   } on PartialDataException {
     if (handleException) {
       return null;

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -72,6 +72,12 @@ Map<String, dynamic> denormalizeFragment({
     dataIdFromObject: dataIdFromObject,
   );
 
+  if (dataId == null) {
+    throw Exception(
+      'Unable to resolve data ID for type ${fragmentDefinition.typeCondition.on.name.value}. Please ensure that you are passing the correct ID fields',
+    );
+  }
+
   final config = NormalizationConfig(
     read: read,
     variables: variables,

--- a/normalize/lib/src/denormalize_node.dart
+++ b/normalize/lib/src/denormalize_node.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/utils/field_key.dart';
 import 'package:normalize/src/utils/expand_fragments.dart';
@@ -11,10 +10,10 @@ import 'package:normalize/src/policies/field_policy.dart';
 /// Returns a denormalized object for a given [SelectionSetNode].
 ///
 /// This is called recursively as the AST is traversed.
-Object denormalizeNode({
-  @required SelectionSetNode selectionSet,
-  @required Object dataForNode,
-  @required NormalizationConfig config,
+Object? denormalizeNode({
+  required SelectionSetNode? selectionSet,
+  required Object? dataForNode,
+  required NormalizationConfig config,
 }) {
   if (dataForNode == null) return null;
 
@@ -78,7 +77,7 @@ Object denormalizeNode({
             // we can denormalize missing fields with policies
             // because they may be purely virtualized
             return result
-              ..[resultKey] = fieldPolicy.read(
+              ..[resultKey] = fieldPolicy!.read!(
                 denormalizedData[fieldName],
                 FieldFunctionOptions(
                   field: fieldNode,

--- a/normalize/lib/src/denormalize_operation.dart
+++ b/normalize/lib/src/denormalize_operation.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 import 'package:normalize/normalize.dart';
 
 import 'package:normalize/src/policies/type_policy.dart';
@@ -21,13 +20,13 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 ///
 /// Likewise, if a custom [referenceKey] was used to normalize the data, it
 /// must be provided. Otherwise, the default '$ref' key will be used.
-Map<String, dynamic> denormalizeOperation({
-  @required Map<String, dynamic> Function(String dataId) read,
-  @required DocumentNode document,
-  String operationName,
+Map<String, dynamic>? denormalizeOperation({
+  required Map<String, dynamic>? Function(String dataId) read,
+  required DocumentNode document,
+  String? operationName,
   Map<String, dynamic> variables = const {},
   Map<String, TypePolicy> typePolicies = const {},
-  DataIdResolver dataIdFromObject,
+  DataIdResolver? dataIdFromObject,
   bool addTypename = false,
   bool returnPartialData = false,
   bool handleException = true,
@@ -63,7 +62,7 @@ Map<String, dynamic> denormalizeOperation({
       selectionSet: operationDefinition.selectionSet,
       dataForNode: read(rootTypename) ?? const {},
       config: config,
-    );
+    ) as Map<String, dynamic>?;
   } on PartialDataException {
     if (handleException) {
       return null;

--- a/normalize/lib/src/normalize_fragment.dart
+++ b/normalize/lib/src/normalize_fragment.dart
@@ -34,8 +34,8 @@ void normalizeFragment({
   @required Map<String, dynamic> idFields,
   @required Map<String, dynamic> data,
   String fragmentName,
-  Map<String, dynamic> variables,
-  Map<String, TypePolicy> typePolicies,
+  Map<String, dynamic> variables = const {},
+  Map<String, TypePolicy> typePolicies = const {},
   DataIdResolver dataIdFromObject,
   bool addTypename = false,
   String referenceKey = '\$ref',
@@ -83,6 +83,12 @@ void normalizeFragment({
     typePolicies: typePolicies,
     dataIdFromObject: dataIdFromObject,
   );
+
+  if (dataId == null) {
+    throw Exception(
+      'Unable to resolve data ID for type ${fragmentDefinition.typeCondition.on.name.value}. Please ensure that you are passing the correct ID fields',
+    );
+  }
 
   write(
     dataId,

--- a/normalize/lib/src/normalize_fragment.dart
+++ b/normalize/lib/src/normalize_fragment.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/policies/type_policy.dart';
@@ -28,15 +27,15 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 /// should begin with '$' since a graphl response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
 void normalizeFragment({
-  @required void Function(String dataId, Map<String, dynamic> value) write,
-  @required Map<String, dynamic> Function(String dataId) read,
-  @required DocumentNode document,
-  @required Map<String, dynamic> idFields,
-  @required Map<String, dynamic> data,
-  String fragmentName,
+  required void Function(String dataId, Map<String, dynamic>? value) write,
+  required Map<String, dynamic>? Function(String dataId) read,
+  required DocumentNode document,
+  required Map<String, dynamic> idFields,
+  required Map<String, dynamic> data,
+  String? fragmentName,
   Map<String, dynamic> variables = const {},
   Map<String, TypePolicy> typePolicies = const {},
-  DataIdResolver dataIdFromObject,
+  DataIdResolver? dataIdFromObject,
   bool addTypename = false,
   String referenceKey = '\$ref',
   bool acceptPartialData = true,
@@ -58,7 +57,7 @@ void normalizeFragment({
   }
 
   final fragmentDefinition = fragmentName != null
-      ? fragmentMap[fragmentName]
+      ? fragmentMap[fragmentName]!
       : fragmentMap.values.first;
 
   final dataForFragment = {
@@ -99,6 +98,6 @@ void normalizeFragment({
       config: config,
       write: write,
       root: true,
-    ),
+    ) as Map<String, dynamic>?,
   );
 }

--- a/normalize/lib/src/normalize_node.dart
+++ b/normalize/lib/src/normalize_node.dart
@@ -47,7 +47,7 @@ Object normalizeNode({
     if (dataId != null) existingNormalizedData = config.read(dataId);
 
     final typename = dataForNode['__typename'];
-    final typePolicy = (config.typePolicies ?? const {})[typename];
+    final typePolicy = config.typePolicies[typename];
 
     final subNodes = expandFragments(
       typename: typename,

--- a/normalize/lib/src/normalize_node.dart
+++ b/normalize/lib/src/normalize_node.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/utils/field_key.dart';
@@ -12,12 +11,12 @@ import 'package:normalize/src/policies/field_policy.dart';
 /// Returns a normalized object for a given [SelectionSetNode].
 ///
 /// This is called recursively as the AST is traversed.
-Object normalizeNode({
-  @required SelectionSetNode selectionSet,
-  @required Object dataForNode,
-  @required Object existingNormalizedData,
-  @required NormalizationConfig config,
-  @required void Function(String dataId, Map<String, dynamic> value) write,
+Object? normalizeNode({
+  required SelectionSetNode? selectionSet,
+  required Object? dataForNode,
+  required Object? existingNormalizedData,
+  required NormalizationConfig config,
+  required void Function(String dataId, Map<String, dynamic> value) write,
   bool root = false,
 }) {
   if (dataForNode == null) return null;
@@ -39,7 +38,7 @@ Object normalizeNode({
 
   if (dataForNode is Map) {
     final dataId = resolveDataId(
-      data: dataForNode,
+      data: dataForNode as Map<String, dynamic>,
       typePolicies: config.typePolicies,
       dataIdFromObject: config.dataIdFromObject,
     );
@@ -96,7 +95,7 @@ Object normalizeNode({
           );
           if (policyCanMerge) {
             return data
-              ..[fieldName] = fieldPolicy.merge(
+              ..[fieldName] = fieldPolicy!.merge!(
                 existingFieldData,
                 fieldData,
                 FieldFunctionOptions(
@@ -113,7 +112,7 @@ Object normalizeNode({
     };
 
     final mergedData = deepMerge(
-      Map.from(existingNormalizedData ?? {}),
+      Map.from(existingNormalizedData as Map<dynamic, dynamic>? ?? {}),
       dataToMerge,
     );
 

--- a/normalize/lib/src/normalize_operation.dart
+++ b/normalize/lib/src/normalize_operation.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/policies/type_policy.dart';
@@ -25,14 +24,14 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 /// should begin with '$' since a graphl response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
 void normalizeOperation({
-  @required void Function(String dataId, Map<String, dynamic> value) write,
-  @required Map<String, dynamic> Function(String dataId) read,
-  @required DocumentNode document,
-  @required Map<String, dynamic> data,
-  String operationName,
+  required void Function(String dataId, Map<String, dynamic>? value) write,
+  required Map<String, dynamic>? Function(String dataId) read,
+  required DocumentNode document,
+  required Map<String, dynamic> data,
+  String? operationName,
   Map<String, dynamic> variables = const {},
   Map<String, TypePolicy> typePolicies = const {},
-  DataIdResolver dataIdFromObject,
+  DataIdResolver? dataIdFromObject,
   bool addTypename = false,
   bool acceptPartialData = true,
   String referenceKey = '\$ref',
@@ -71,6 +70,6 @@ void normalizeOperation({
       config: config,
       write: write,
       root: true,
-    ),
+    ) as Map<String, dynamic>?,
   );
 }

--- a/normalize/lib/src/policies/field_policy.dart
+++ b/normalize/lib/src/policies/field_policy.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/utils/field_key.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
@@ -19,9 +18,9 @@ class FieldFunctionOptions {
   final Map<String, dynamic> args;
 
   FieldFunctionOptions({
-    @required this.field,
-    @required NormalizationConfig config,
-  })  : _config = config,
+    required this.field,
+    required NormalizationConfig config,
+  })   : _config = config,
         variables = config.variables,
         args = argsWithValues(config.variables, field.arguments);
 
@@ -39,7 +38,7 @@ class FieldFunctionOptions {
       };
 
   /// Returns denormalized data for the given [field] and normalized [data], recursively resolving any references.
-  T readField<T>(FieldNode field, Object data) => denormalizeNode(
+  T? readField<T>(FieldNode field, Object? data) => denormalizeNode(
         selectionSet: field.selectionSet,
         dataForNode: data,
         config: NormalizationConfig(
@@ -52,7 +51,7 @@ class FieldFunctionOptions {
           addTypename: _config.addTypename,
           allowPartialData: true,
         ),
-      );
+      ) as T?;
 }
 
 typedef FieldReadFunction<TExisting, TReadResult> = TReadResult Function(
@@ -74,13 +73,13 @@ class FieldPolicy<TExisting, TIncoming, TReadResult> {
   /// By default, it is assumed that all field arguments might be important.
   ///
   /// If an empty [List] is provided, all arguments will be ignored.
-  List<String> keyArgs;
+  List<String>? keyArgs;
 
   /// Custom function to read existing field
-  FieldReadFunction<TExisting, TReadResult> read;
+  FieldReadFunction<TExisting, TReadResult>? read;
 
   /// Custom function to merge into existing field
-  FieldMergeFunction<TExisting, TIncoming> merge;
+  FieldMergeFunction<TExisting, TIncoming>? merge;
 
   FieldPolicy({this.keyArgs, this.read, this.merge});
 }

--- a/normalize/lib/src/policies/type_policy.dart
+++ b/normalize/lib/src/policies/type_policy.dart
@@ -20,7 +20,7 @@ class TypePolicy {
   /// If you don't wish to normalize this type, simply pass an empty `Map`. In
   /// that case, we won't normalize this type and it will be reachable from its
   /// parent.
-  Map<String, dynamic> keyFields;
+  Map<String, dynamic>? keyFields;
 
   /// Set to `true` if this type is the root Query in your schema.
   bool queryType;

--- a/normalize/lib/src/utils/add_typename_visitor.dart
+++ b/normalize/lib/src/utils/add_typename_visitor.dart
@@ -31,11 +31,8 @@ class AddTypenameVisitor extends TransformingVisitor {
 
   @override
   FragmentDefinitionNode visitFragmentDefinitionNode(
-      FragmentDefinitionNode node) {
-    if (node.selectionSet == null) {
-      return node;
-    }
-
+    FragmentDefinitionNode node,
+  ) {
     final hasTypename = node.selectionSet.selections
         .whereType<FieldNode>()
         .any((node) => node.name.value == '__typename');
@@ -59,14 +56,11 @@ class AddTypenameVisitor extends TransformingVisitor {
 
   @override
   OperationDefinitionNode visitOperationDefinitionNode(
-      OperationDefinitionNode node) {
+    OperationDefinitionNode node,
+  ) {
     // Subscriptions can only have a single root type
     // https://spec.graphql.org/June2018/#example-2353b
     if (node.type == OperationType.subscription) {
-      return node;
-    }
-
-    if (node.selectionSet == null) {
       return node;
     }
 

--- a/normalize/lib/src/utils/add_typename_visitor.dart
+++ b/normalize/lib/src/utils/add_typename_visitor.dart
@@ -7,7 +7,7 @@ class AddTypenameVisitor extends TransformingVisitor {
       return node;
     }
 
-    final hasTypename = node.selectionSet.selections
+    final hasTypename = node.selectionSet!.selections
         .whereType<FieldNode>()
         .any((node) => node.name.value == '__typename');
 
@@ -23,7 +23,7 @@ class AddTypenameVisitor extends TransformingVisitor {
           FieldNode(
             name: NameNode(value: '__typename'),
           ),
-          ...node.selectionSet.selections,
+          ...node.selectionSet!.selections,
         ],
       ),
     );

--- a/normalize/lib/src/utils/exceptions.dart
+++ b/normalize/lib/src/utils/exceptions.dart
@@ -1,11 +1,9 @@
-import 'package:meta/meta.dart';
 import 'package:normalize/utils.dart';
 
 /// Exception occurring when structurally valid data cannot be resolved
 /// for an expected field.
-@immutable
 class PartialDataException implements Exception {
-  PartialDataException({@required this.path});
+  PartialDataException({required this.path});
 
   /// Path to the first unfound subfield.
   ///

--- a/normalize/lib/src/utils/expand_fragments.dart
+++ b/normalize/lib/src/utils/expand_fragments.dart
@@ -15,20 +15,29 @@ List<FieldNode> expandFragments({
       fieldNodes.add(selectionNode);
     } else if (selectionNode is InlineFragmentNode) {
       // Only include this fragment if the type name matches
-      if (selectionNode.typeCondition.on.name.value == typename) {
-        fieldNodes.addAll(expandFragments(
-          typename: typename,
-          selectionSet: selectionNode.selectionSet,
-          fragmentMap: fragmentMap,
-        ));
+      if (selectionNode.typeCondition?.on?.name?.value == typename) {
+        fieldNodes.addAll(
+          expandFragments(
+            typename: typename,
+            selectionSet: selectionNode.selectionSet,
+            fragmentMap: fragmentMap,
+          ),
+        );
       }
     } else if (selectionNode is FragmentSpreadNode) {
       final fragment = fragmentMap[selectionNode.name.value];
-      fieldNodes.addAll(expandFragments(
-        typename: typename,
-        selectionSet: fragment.selectionSet,
-        fragmentMap: fragmentMap,
-      ));
+
+      if (fragment == null) {
+        throw Exception('Missing fragment ${selectionNode.name.value}');
+      }
+
+      fieldNodes.addAll(
+        expandFragments(
+          typename: typename,
+          selectionSet: fragment.selectionSet,
+          fragmentMap: fragmentMap,
+        ),
+      );
     } else {
       throw (FormatException('Unknown selection node type'));
     }

--- a/normalize/lib/src/utils/expand_fragments.dart
+++ b/normalize/lib/src/utils/expand_fragments.dart
@@ -1,12 +1,11 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 /// Adds fragment fields to selections if fragment type matches [typename]
 /// and deeply merges nested field nodes.
 List<FieldNode> expandFragments({
-  @required String typename,
-  @required SelectionSetNode selectionSet,
-  @required Map<String, FragmentDefinitionNode> fragmentMap,
+  required String? typename,
+  required SelectionSetNode selectionSet,
+  required Map<String, FragmentDefinitionNode> fragmentMap,
 }) {
   final fieldNodes = <FieldNode>[];
 
@@ -15,7 +14,7 @@ List<FieldNode> expandFragments({
       fieldNodes.add(selectionNode);
     } else if (selectionNode is InlineFragmentNode) {
       // Only include this fragment if the type name matches
-      if (selectionNode.typeCondition?.on?.name?.value == typename) {
+      if (selectionNode.typeCondition?.on.name.value == typename) {
         fieldNodes.addAll(
           expandFragments(
             typename: typename,
@@ -63,7 +62,7 @@ List<SelectionNode> _mergeSelections(
                 final existingNode = selectionMap[key];
                 final existingSelections = existingNode is FieldNode &&
                         existingNode.selectionSet != null
-                    ? existingNode.selectionSet.selections
+                    ? existingNode.selectionSet!.selections
                     : <SelectionNode>[];
                 final mergedField = FieldNode(
                   name: selection.name,
@@ -73,7 +72,7 @@ List<SelectionNode> _mergeSelections(
                     selections: _mergeSelections(
                       [
                         ...existingSelections,
-                        ...selection.selectionSet.selections
+                        ...selection.selectionSet!.selections
                       ],
                     ),
                   ),

--- a/normalize/lib/src/utils/field_key.dart
+++ b/normalize/lib/src/utils/field_key.dart
@@ -25,7 +25,7 @@ class FieldKey {
     Map<String, dynamic> variables,
     FieldPolicy fieldPolicy,
   ) {
-    final pertinentArguments = fieldPolicy == null
+    final pertinentArguments = fieldPolicy?.keyArgs == null
         ? fieldNode.arguments
         : fieldNode.arguments.where(
             (argument) => fieldPolicy.keyArgs.contains(argument.name.value));

--- a/normalize/lib/src/utils/field_key.dart
+++ b/normalize/lib/src/utils/field_key.dart
@@ -16,19 +16,19 @@ class FieldKey {
   FieldKey(
     FieldNode fieldNode,
     Map<String, dynamic> variables,
-    FieldPolicy fieldPolicy,
+    FieldPolicy? fieldPolicy,
   )   : fieldName = fieldNode.name.value,
         args = _initArgs(fieldNode, variables, fieldPolicy);
 
   static SplayTreeMap<String, dynamic> _initArgs(
     FieldNode fieldNode,
     Map<String, dynamic> variables,
-    FieldPolicy fieldPolicy,
+    FieldPolicy? fieldPolicy,
   ) {
     final pertinentArguments = fieldPolicy?.keyArgs == null
         ? fieldNode.arguments
         : fieldNode.arguments.where(
-            (argument) => fieldPolicy.keyArgs.contains(argument.name.value));
+            (argument) => fieldPolicy!.keyArgs!.contains(argument.name.value));
     return argsWithValues(variables, pertinentArguments);
   }
 
@@ -72,7 +72,7 @@ SplayTreeMap<String, dynamic> argsWithValues(
         ),
     );
 
-Object _resolveValueNode(
+Object? _resolveValueNode(
   ValueNode valueNode,
   Map<String, dynamic> variables,
 ) {

--- a/normalize/lib/src/utils/get_operation_definition.dart
+++ b/normalize/lib/src/utils/get_operation_definition.dart
@@ -4,11 +4,12 @@ import 'package:gql/ast.dart';
 OperationDefinitionNode getOperationDefinition(
   DocumentNode document,
   String operationName,
-) =>
-    operationName != null
-        ? document.definitions.whereType<OperationDefinitionNode>().firstWhere(
-              (definition) => definition.name.value == operationName,
-              orElse: () => throw (Exception(
-                  'Could not find operationName "$operationName"')),
-            )
-        : document.definitions.whereType<OperationDefinitionNode>().first;
+) {
+  if (operationName != null) {
+    return document.definitions
+        .whereType<OperationDefinitionNode>()
+        .firstWhere((definition) => definition.name?.value == operationName);
+  } else {
+    return document.definitions.whereType<OperationDefinitionNode>().first;
+  }
+}

--- a/normalize/lib/src/utils/get_operation_definition.dart
+++ b/normalize/lib/src/utils/get_operation_definition.dart
@@ -3,7 +3,7 @@ import 'package:gql/ast.dart';
 /// Returns the AST Node for the GraphQL Operation.
 OperationDefinitionNode getOperationDefinition(
   DocumentNode document,
-  String operationName,
+  String? operationName,
 ) {
   if (operationName != null) {
     return document.definitions

--- a/normalize/lib/src/utils/identify.dart
+++ b/normalize/lib/src/utils/identify.dart
@@ -5,7 +5,7 @@ import './resolve_data_id.dart';
 String identify(
   Map data, {
   String referenceKey = '\$ref',
-  Map<String, TypePolicy> typePolicies,
+  Map<String, TypePolicy> typePolicies = const {},
   DataIdResolver dataIdFromObject,
 }) =>
     data.containsKey(referenceKey)

--- a/normalize/lib/src/utils/identify.dart
+++ b/normalize/lib/src/utils/identify.dart
@@ -2,11 +2,11 @@ import 'package:normalize/src/policies/type_policy.dart';
 import './resolve_data_id.dart';
 
 /// Returns the canonical ID for a given object or reference.
-String identify(
+String? identify(
   Map data, {
   String referenceKey = '\$ref',
   Map<String, TypePolicy> typePolicies = const {},
-  DataIdResolver dataIdFromObject,
+  DataIdResolver? dataIdFromObject,
 }) =>
     data.containsKey(referenceKey)
         ? data[referenceKey]

--- a/normalize/lib/src/utils/is_dangling_reference.dart
+++ b/normalize/lib/src/utils/is_dangling_reference.dart
@@ -2,12 +2,11 @@ import 'package:normalize/src/config/normalization_config.dart';
 
 /// Determines whether the given [data] is a reference that points to a non-existent object.
 bool isDanglingReference(
-  Object data,
+  Object? data,
   NormalizationConfig config,
 ) {
   if (data is Map && data.containsKey(config.referenceKey)) {
-    final referencedData =
-        config.read(data[config.referenceKey] ?? ''); // TODO: Remove
+    final referencedData = config.read(data[config.referenceKey]);
     if (referencedData == null) return true;
   }
   return false;

--- a/normalize/lib/src/utils/is_dangling_reference.dart
+++ b/normalize/lib/src/utils/is_dangling_reference.dart
@@ -6,7 +6,8 @@ bool isDanglingReference(
   NormalizationConfig config,
 ) {
   if (data is Map && data.containsKey(config.referenceKey)) {
-    final referencedData = config.read(data[config.referenceKey]);
+    final referencedData =
+        config.read(data[config.referenceKey] ?? ''); // TODO: Remove
     if (referencedData == null) return true;
   }
   return false;

--- a/normalize/lib/src/utils/reachable_ids.dart
+++ b/normalize/lib/src/utils/reachable_ids.dart
@@ -3,7 +3,7 @@ import 'package:normalize/src/utils/resolve_root_typename.dart';
 
 /// Returns a set of dataIds that can be reached by any root query.
 Set<String> reachableIds(
-  Map<String, dynamic> Function(String dataId) read, [
+  Map<String, dynamic>? Function(String dataId) read, [
   Map<String, TypePolicy> typePolicies = const {},
   String referenceKey = '\$ref',
 ]) =>
@@ -40,21 +40,20 @@ Set<String> reachableIdsFromDataId(
 
 /// Recursively finds reachable IDs in [object]
 Set<String> _idsInObject(
-  Object object,
-  Map<String, dynamic> Function(String dataId) read,
+  Object? object,
+  Map<String, dynamic>? Function(String dataId) read,
   String referenceKey,
   Set<String> visited,
 ) {
   if (object is Map) {
     if (object.containsKey(referenceKey)) {
       if (visited.contains(object[referenceKey])) return {};
-      return {object[referenceKey] ?? ''}..addAll(
-          // TODO: remove
+      return {object[referenceKey]}..addAll(
           _idsInObject(
-            read(object[referenceKey] ?? ''), // TODO: remove
+            read(object[referenceKey]),
             read,
             referenceKey,
-            visited..add(object[referenceKey] ?? ''), // TODO: remove
+            visited..add(object[referenceKey]),
           ),
         );
     }

--- a/normalize/lib/src/utils/reachable_ids.dart
+++ b/normalize/lib/src/utils/reachable_ids.dart
@@ -48,12 +48,13 @@ Set<String> _idsInObject(
   if (object is Map) {
     if (object.containsKey(referenceKey)) {
       if (visited.contains(object[referenceKey])) return {};
-      return {object[referenceKey]}..addAll(
+      return {object[referenceKey] ?? ''}..addAll(
+          // TODO: remove
           _idsInObject(
-            read(object[referenceKey]),
+            read(object[referenceKey] ?? ''), // TODO: remove
             read,
             referenceKey,
-            visited..add(object[referenceKey]),
+            visited..add(object[referenceKey] ?? ''), // TODO: remove
           ),
         );
     }

--- a/normalize/lib/src/utils/resolve_data_id.dart
+++ b/normalize/lib/src/utils/resolve_data_id.dart
@@ -17,13 +17,13 @@ typedef DataIdResolver = String Function(Map<String, dynamic> object);
 /// Returns [null] if this type should not be normalized.
 String resolveDataId({
   @required Map<String, dynamic> data,
-  Map<String, TypePolicy> typePolicies,
+  @required Map<String, TypePolicy> typePolicies,
   DataIdResolver dataIdFromObject,
 }) {
   final typename = data['__typename'];
   if (typename == null) return null;
 
-  final typePolicy = (typePolicies ?? const {})[typename];
+  final typePolicy = typePolicies[typename];
 
   if (typePolicy?.keyFields != null) {
     if (typePolicy.keyFields.isEmpty) return null;

--- a/normalize/lib/src/utils/resolve_data_id.dart
+++ b/normalize/lib/src/utils/resolve_data_id.dart
@@ -1,12 +1,10 @@
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:meta/meta.dart';
-
 import '../policies/type_policy.dart';
 import './exceptions.dart';
 
-typedef DataIdResolver = String Function(Map<String, dynamic> object);
+typedef DataIdResolver = String? Function(Map<String, dynamic> object);
 
 /// Returns a unique ID to use to reference this normalized object.
 ///
@@ -15,10 +13,10 @@ typedef DataIdResolver = String Function(Map<String, dynamic> object);
 /// If none is provided, falls back to the 'id' or '_id' field, respectively.
 ///
 /// Returns [null] if this type should not be normalized.
-String resolveDataId({
-  @required Map<String, dynamic> data,
-  @required Map<String, TypePolicy> typePolicies,
-  DataIdResolver dataIdFromObject,
+String? resolveDataId({
+  required Map<String, dynamic> data,
+  required Map<String, TypePolicy> typePolicies,
+  DataIdResolver? dataIdFromObject,
 }) {
   final typename = data['__typename'];
   if (typename == null) return null;
@@ -26,10 +24,10 @@ String resolveDataId({
   final typePolicy = typePolicies[typename];
 
   if (typePolicy?.keyFields != null) {
-    if (typePolicy.keyFields.isEmpty) return null;
+    if (typePolicy!.keyFields!.isEmpty) return null;
 
     try {
-      final fields = keyFieldsWithArgs(typePolicy.keyFields, data);
+      final fields = keyFieldsWithArgs(typePolicy.keyFields!, data);
       return '$typename:${json.encode(fields)}';
     } on MissingKeyFieldException {
       return null;

--- a/normalize/lib/src/utils/resolve_root_typename.dart
+++ b/normalize/lib/src/utils/resolve_root_typename.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:gql/ast.dart';
 import '../policies/type_policy.dart';
 
@@ -13,32 +14,26 @@ String typenameForOperationType(
 ) {
   switch (operationType) {
     case OperationType.query:
-      return typePolicies?.entries
-              ?.firstWhere(
+      return typePolicies.entries
+              .firstWhereOrNull(
                 (entry) => entry.value.queryType,
-                orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.query] ??
-          'Query'; // TODO: Remove
+          defaultRootTypenames[OperationType.query]!;
     case OperationType.mutation:
-      return typePolicies?.entries
-              ?.firstWhere(
+      return typePolicies.entries
+              .firstWhereOrNull(
                 (entry) => entry.value.mutationType,
-                orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.mutation] ??
-          'Query'; // TODO: Remove
+          defaultRootTypenames[OperationType.mutation]!;
     case OperationType.subscription:
-      return typePolicies?.entries
-              ?.firstWhere(
+      return typePolicies.entries
+              .firstWhereOrNull(
                 (entry) => entry.value.subscriptionType,
-                orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.subscription] ??
-          'Query'; // TODO: Remove
+          defaultRootTypenames[OperationType.subscription]!;
   }
 }
 

--- a/normalize/lib/src/utils/resolve_root_typename.dart
+++ b/normalize/lib/src/utils/resolve_root_typename.dart
@@ -19,7 +19,8 @@ String typenameForOperationType(
                 orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.query];
+          defaultRootTypenames[OperationType.query] ??
+          'Query'; // TODO: Remove
     case OperationType.mutation:
       return typePolicies?.entries
               ?.firstWhere(
@@ -27,7 +28,8 @@ String typenameForOperationType(
                 orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.mutation];
+          defaultRootTypenames[OperationType.mutation] ??
+          'Query'; // TODO: Remove
     case OperationType.subscription:
       return typePolicies?.entries
               ?.firstWhere(
@@ -35,9 +37,9 @@ String typenameForOperationType(
                 orElse: () => null,
               )
               ?.key ??
-          defaultRootTypenames[OperationType.subscription];
+          defaultRootTypenames[OperationType.subscription] ??
+          'Query'; // TODO: Remove
   }
-  return null;
 }
 
 String resolveRootTypename(

--- a/normalize/lib/src/utils/validate_structure.dart
+++ b/normalize/lib/src/utils/validate_structure.dart
@@ -71,7 +71,7 @@ bool validateFragmentDataStructure({
         // get data at top level
         read: (_) => data,
         // "disable" normalization
-        dataIdFromObject: (_) => null,
+        dataIdFromObject: (_) => '',
         // idFields unnecessary without normalization
         idFields: <String, dynamic>{},
         document: document,

--- a/normalize/lib/src/utils/validate_structure.dart
+++ b/normalize/lib/src/utils/validate_structure.dart
@@ -1,5 +1,4 @@
 import 'package:gql/ast.dart';
-import 'package:meta/meta.dart';
 
 import 'package:normalize/src/denormalize_operation.dart';
 import 'package:normalize/src/denormalize_fragment.dart';
@@ -17,9 +16,9 @@ import 'package:normalize/src/utils/exceptions.dart';
 ///
 /// [spec]: https://spec.graphql.org/June2018/#sec-Data
 bool validateOperationDataStructure({
-  @required DocumentNode document,
-  @required Map<String, dynamic> data,
-  String operationName,
+  required DocumentNode document,
+  required Map<String, dynamic>? data,
+  String? operationName,
   Map<String, dynamic> variables = const {},
   bool addTypename = false,
   bool handleException = false,
@@ -54,9 +53,9 @@ bool validateOperationDataStructure({
 ///
 /// Calls [denormalizeFragment] internally.
 bool validateFragmentDataStructure({
-  @required DocumentNode document,
-  @required Map<String, dynamic> data,
-  String fragmentName,
+  required DocumentNode document,
+  required Map<String, dynamic>? data,
+  String? fragmentName,
   Map<String, dynamic> variables = const {},
   bool addTypename = false,
   bool handleException = false,

--- a/normalize/pubspec.yaml
+++ b/normalize/pubspec.yaml
@@ -1,12 +1,13 @@
 name: normalize
-version: 0.4.7
+version: 0.5.0-nullsafety.0
 homepage: https://github.com/gql-dart/ferry/tree/master/normalize
 description: Normalization and denormalization of GraphQL responses in Dart
 repository: https://github.com/gql-dart/ferry
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.12.0-259.16.beta <3.0.0'
 dependencies:
   gql: ^0.13.0-nullsafety.1
+  collection: ^1.15.0-nullsafety.4
 dev_dependencies:
   test: ^1.16.4
   pedantic: ^1.10.0

--- a/normalize/pubspec.yaml
+++ b/normalize/pubspec.yaml
@@ -3,11 +3,10 @@ version: 0.4.7
 homepage: https://github.com/gql-dart/ferry/tree/master/normalize
 description: Normalization and denormalization of GraphQL responses in Dart
 repository: https://github.com/gql-dart/ferry
-environment: 
+environment:
   sdk: '>=2.2.2 <3.0.0'
-dependencies: 
-  gql: ^0.12.4
-  meta: ^1.1.8
-dev_dependencies: 
-  test: ^1.14.3
-  pedantic: ^1.9.0
+dependencies:
+  gql: ^0.13.0-nullsafety.1
+dev_dependencies:
+  test: ^1.16.4
+  pedantic: ^1.10.0

--- a/normalize/test/field_policy/merge_test.dart
+++ b/normalize/test/field_policy/merge_test.dart
@@ -24,7 +24,7 @@ void main() {
         ]
       };
 
-      final existing = {
+      final existing = <String, dynamic>{
         'Query': {
           '__typename': 'Query',
           'posts': [
@@ -106,7 +106,7 @@ void main() {
         ]
       };
 
-      final existing = {
+      final existing = <String, dynamic>{
         'Query': {
           '__typename': 'Query',
           'posts': [
@@ -274,7 +274,7 @@ void main() {
         ]
       };
 
-      final existing = {
+      final existing = <String, dynamic>{
         'Query': {
           '__typename': 'Query',
           'posts': [

--- a/normalize/test/field_policy/read_test.dart
+++ b/normalize/test/field_policy/read_test.dart
@@ -54,7 +54,7 @@ void main() {
                 fields: {
                   'posts': FieldPolicy(
                     read: (existing, options) => options
-                        .readField<List>(options.field, existing ?? [])
+                        .readField<List>(options.field, existing ?? [])!
                         .where((post) => post['id'] == '123')
                         .toList(),
                   )


### PR DESCRIPTION
@micimize I've migrated `normalize` and have all tests passing, except for [a couple](https://github.com/gql-dart/ferry/blob/7b73b634f722be81c287f92aa7e40fbfc2c1f4a4/normalize/test/partial_input_test.dart#L148) related to `validateFragmentDateStructure()`.

The issue is that `denormalizeFragment()`'s `read(String dataId)` callback now expects a non-null `dataId`.

closes #154