### PR TITLE
Add support for dataIdFromObject to ferry_cache and swap the order of assignment in denormalize_fragment

### DIFF
--- a/ferry_cache/lib/src/cache.dart
+++ b/ferry_cache/lib/src/cache.dart
@@ -25,14 +25,13 @@ class Cache {
 
   Cache({
     Store? store,
-    utils.DataIdResolver? dataIdFromObject,
+    this.dataIdFromObject,
     this.typePolicies = const {},
     this.addTypename = true,
     Map<OperationRequest, Map<String, Map<String, dynamic>?>>
         seedOptimisticPatches = const {},
   })  : store = store ?? MemoryStore(),
-        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches),
-        dataIdFromObject = dataIdFromObject;
+        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches);
 
   /// Reads data for the given [dataId] from the [Store], merging in any data from optimistic patches
   @visibleForTesting
@@ -65,7 +64,7 @@ class Cache {
           store,
           typePolicies,
           addTypename,
-          dataIdFromObject: dataIdFromObject,
+          dataIdFromObject,
         ).doOnDone(() => closed = true);
 
         return NeverStream<TData?>()
@@ -101,7 +100,7 @@ class Cache {
           store,
           typePolicies,
           addTypename,
-          dataIdFromObject: dataIdFromObject,
+          dataIdFromObject,
         ).doOnDone(() => closed = true);
 
         return NeverStream<TData?>()

--- a/ferry_cache/lib/src/cache.dart
+++ b/ferry_cache/lib/src/cache.dart
@@ -13,6 +13,7 @@ class Cache {
   final Map<String, TypePolicy> typePolicies;
   final bool addTypename;
   final Store store;
+  final utils.DataIdResolver? dataIdFromObject;
 
   @visibleForTesting
   final BehaviorSubject<
@@ -24,12 +25,14 @@ class Cache {
 
   Cache({
     Store? store,
+    utils.DataIdResolver? dataIdFromObject,
     this.typePolicies = const {},
     this.addTypename = true,
     Map<OperationRequest, Map<String, Map<String, dynamic>?>>
         seedOptimisticPatches = const {},
   })  : store = store ?? MemoryStore(),
-        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches);
+        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches),
+        dataIdFromObject = dataIdFromObject;
 
   /// Reads data for the given [dataId] from the [Store], merging in any data from optimistic patches
   @visibleForTesting
@@ -62,6 +65,7 @@ class Cache {
           store,
           typePolicies,
           addTypename,
+          dataIdFromObject: dataIdFromObject,
         ).doOnDone(() => closed = true);
 
         return NeverStream<TData?>()
@@ -97,6 +101,7 @@ class Cache {
           store,
           typePolicies,
           addTypename,
+          dataIdFromObject: dataIdFromObject,
         ).doOnDone(() => closed = true);
 
         return NeverStream<TData?>()
@@ -129,6 +134,7 @@ class Cache {
       // TODO: don't cast to dynamic
       variables: (request.vars as dynamic)?.toJson(),
       typePolicies: typePolicies,
+      dataIdFromObject: dataIdFromObject,
     );
     return json == null ? null : request.parseData(json);
   }
@@ -147,6 +153,7 @@ class Cache {
       variables: (request.vars as dynamic)?.toJson(),
       typePolicies: typePolicies,
       addTypename: addTypename,
+      dataIdFromObject: dataIdFromObject,
     );
     return json == null ? null : request.parseData(json);
   }
@@ -177,6 +184,7 @@ class Cache {
         data: (data as dynamic)?.toJson(),
         typePolicies: typePolicies,
         addTypename: addTypename,
+        dataIdFromObject: dataIdFromObject,
       );
 
   /// Normalizes [data] for the given fragment and writes it to the [Store].
@@ -206,6 +214,7 @@ class Cache {
         data: (data as dynamic)?.toJson(),
         typePolicies: typePolicies,
         addTypename: addTypename,
+        dataIdFromObject: dataIdFromObject,
       );
 
   void _writeData(
@@ -237,6 +246,7 @@ class Cache {
         // TODO: don't cast to dynamic
         (data as dynamic)?.toJson(),
         typePolicies: typePolicies,
+        dataIdFromObject: dataIdFromObject,
       );
 
   /// Removes the entity from the [Store] as well as from any optimistic

--- a/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -2,6 +2,7 @@ import 'package:normalize/policies.dart';
 import 'package:normalize/normalize.dart';
 import 'package:collection/collection.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:normalize/utils.dart';
 import 'package:rxdart/rxdart.dart';
 
 import 'package:ferry_exec/ferry_exec.dart';
@@ -9,15 +10,15 @@ import './utils/data_for_id_stream.dart';
 
 /// Emits when the data for this fragment changes, returning a `Set` of changed IDs.
 Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
-  FragmentRequest<TData, TVars> request,
-  bool optimistic,
-  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
-      optimisticPatchesStream,
-  Map<String, dynamic>? Function(String dataId) optimisticReader,
-  Store store,
-  Map<String, TypePolicy> typePolicies,
-  bool addTypename,
-) {
+    FragmentRequest<TData, TVars> request,
+    bool optimistic,
+    Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
+        optimisticPatchesStream,
+    Map<String, dynamic>? Function(String dataId) optimisticReader,
+    Store store,
+    Map<String, TypePolicy> typePolicies,
+    bool addTypename,
+    {DataIdResolver? dataIdFromObject}) {
   final dataIds = <String>{};
 
   denormalizeFragment(
@@ -33,6 +34,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
     typePolicies: typePolicies,
     addTypename: addTypename,
     returnPartialData: true,
+    dataIdFromObject: dataIdFromObject,
   );
 
   /// IDs that have changed

--- a/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -10,15 +10,16 @@ import './utils/data_for_id_stream.dart';
 
 /// Emits when the data for this fragment changes, returning a `Set` of changed IDs.
 Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
-    FragmentRequest<TData, TVars> request,
-    bool optimistic,
-    Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
-        optimisticPatchesStream,
-    Map<String, dynamic>? Function(String dataId) optimisticReader,
-    Store store,
-    Map<String, TypePolicy> typePolicies,
-    bool addTypename,
-    {DataIdResolver? dataIdFromObject}) {
+  FragmentRequest<TData, TVars> request,
+  bool optimistic,
+  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
+      optimisticPatchesStream,
+  Map<String, dynamic>? Function(String dataId) optimisticReader,
+  Store store,
+  Map<String, TypePolicy> typePolicies,
+  bool addTypename,
+  DataIdResolver? dataIdFromObject,
+) {
   final dataIds = <String>{};
 
   denormalizeFragment(

--- a/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -11,15 +11,15 @@ import './utils/operation_root_data.dart';
 
 /// Emits when the data for this request changes, returning a `Set` of changed IDs.
 Stream<Set<String>> operationDataChangeStream<TData, TVars>(
-  OperationRequest<TData, TVars> request,
-  bool optimistic,
-  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
-      optimisticPatchesStream,
-  Map<String, dynamic>? Function(String dataId) optimisticReader,
-  Store store,
-  Map<String, TypePolicy> typePolicies,
-  bool addTypename,
-) {
+    OperationRequest<TData, TVars> request,
+    bool optimistic,
+    Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
+        optimisticPatchesStream,
+    Map<String, dynamic>? Function(String dataId) optimisticReader,
+    Store store,
+    Map<String, TypePolicy> typePolicies,
+    bool addTypename,
+    {DataIdResolver? dataIdFromObject}) {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
     request.operation.operationName,
@@ -43,6 +43,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
     typePolicies: typePolicies,
     addTypename: addTypename,
     returnPartialData: true,
+    dataIdFromObject: dataIdFromObject,
   );
 
   /// IDs that have changed

--- a/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -11,15 +11,16 @@ import './utils/operation_root_data.dart';
 
 /// Emits when the data for this request changes, returning a `Set` of changed IDs.
 Stream<Set<String>> operationDataChangeStream<TData, TVars>(
-    OperationRequest<TData, TVars> request,
-    bool optimistic,
-    Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
-        optimisticPatchesStream,
-    Map<String, dynamic>? Function(String dataId) optimisticReader,
-    Store store,
-    Map<String, TypePolicy> typePolicies,
-    bool addTypename,
-    {DataIdResolver? dataIdFromObject}) {
+  OperationRequest<TData, TVars> request,
+  bool optimistic,
+  Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
+      optimisticPatchesStream,
+  Map<String, dynamic>? Function(String dataId) optimisticReader,
+  Store store,
+  Map<String, TypePolicy> typePolicies,
+  bool addTypename,
+  DataIdResolver? dataIdFromObject,
+) {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
     request.operation.operationName,

--- a/ferry_cache/test/data_change_streams_test.dart
+++ b/ferry_cache/test/data_change_streams_test.dart
@@ -65,6 +65,7 @@ void main() {
         cache.store,
         {},
         true,
+        null,
       );
 
       expect(
@@ -87,6 +88,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -110,6 +112,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -130,6 +133,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -153,6 +157,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -184,6 +189,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -218,6 +224,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -247,6 +254,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -282,6 +290,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -318,6 +327,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -338,6 +348,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -358,6 +369,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(
@@ -388,6 +400,7 @@ void main() {
           cache.store,
           {},
           true,
+          null,
         );
 
         expect(

--- a/ferry_cache/test/sync_operations_test.dart
+++ b/ferry_cache/test/sync_operations_test.dart
@@ -44,6 +44,20 @@ void main() {
       expect(cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
     });
 
+    test('dataIdFromObject overrides cache.identify', () {
+      final cache = Cache(dataIdFromObject: (object) => 'OVERRIDE');
+      expect(cache.identify(reviewFragmentData), equals('OVERRIDE'));
+    });
+
+    test('can read and write with a data id override', () {
+      final cache = Cache(dataIdFromObject: (object) => 'OVERRIDE');
+      cache.writeFragment(reviewFragmentReq, reviewFragmentData);
+
+      reviewFragmentReq.idFields['id'] = 'OVERRIDE';
+
+      expect(cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+    });
+
     test('can clear cache', () {
       final cache = Cache();
 

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -64,8 +64,8 @@ Map<String, dynamic>? denormalizeFragment({
 
   final dataId = resolveDataId(
     data: {
-      ...idFields,
       '__typename': fragmentDefinition.typeCondition.on.name.value,
+      ...idFields,
     },
     typePolicies: typePolicies,
     dataIdFromObject: dataIdFromObject,

--- a/normalize/test/fragments_test.dart
+++ b/normalize/test/fragments_test.dart
@@ -197,5 +197,28 @@ void main() {
         equals(normalizedMap),
       );
     });
+
+    test('Override __typename on denormalize', () {
+      final fragment = parseString('''
+        fragment user on Author {
+          id
+          name
+        }
+      ''');
+      final data = {'id': '1', 'name': 'Paul'};
+
+      final normalizedMap = {
+        'NotAuthor:1': {'id': '1', '__typename': 'Author', 'name': 'Paul'},
+      };
+
+      expect(
+        denormalizeFragment(
+          document: fragment,
+          idFields: {'id': '1', '__typename': 'NotAuthor'},
+          read: (dataId) => normalizedMap[dataId],
+        ),
+        equals(data),
+      );
+    });
   });
 }


### PR DESCRIPTION
This attempts to fix #187 with minimal changes.

I wrote some simple tests, but happy to build out more complex test cases if necessary, normalize seemed to test this functionality pretty well already.