### PR TITLE
feat: Add support for better fragment type resolution

### DIFF
--- a/ferry_cache/lib/src/cache.dart
+++ b/ferry_cache/lib/src/cache.dart
@@ -11,6 +11,7 @@ import './fragment_data_change_stream.dart';
 
 class Cache {
   final Map<String, TypePolicy> typePolicies;
+  final Map<String, Set<String>> possibleTypes;
   final bool addTypename;
   final Store store;
   final utils.DataIdResolver? dataIdFromObject;
@@ -27,6 +28,7 @@ class Cache {
     Store? store,
     this.dataIdFromObject,
     this.typePolicies = const {},
+    this.possibleTypes = const {},
     this.addTypename = true,
     Map<OperationRequest, Map<String, Map<String, dynamic>?>>
         seedOptimisticPatches = const {},
@@ -65,6 +67,7 @@ class Cache {
           typePolicies,
           addTypename,
           dataIdFromObject,
+          possibleTypes,
         ).doOnDone(() => closed = true);
 
         return NeverStream<TData?>()

--- a/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -20,6 +20,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
   Map<String, TypePolicy> typePolicies,
   bool addTypename,
   DataIdResolver? dataIdFromObject,
+  Map<String, Set<String>> possibleTypes,
 ) {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
@@ -67,6 +68,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
           data,
           request,
           typePolicies,
+          possibleTypes,
         ),
       );
     }

--- a/ferry_cache/lib/src/utils/operation_root_data.dart
+++ b/ferry_cache/lib/src/utils/operation_root_data.dart
@@ -9,13 +9,14 @@ Map<String, dynamic> operationRootData<TData, TVars>(
   Map<String, dynamic>? data,
   OperationRequest<TData, TVars> request,
   Map<String, TypePolicy> typePolicies,
+  Map<String, Set<String>> possibleTypes,
 ) {
   final fieldNames = operationFieldNames(
     request.operation.document,
     request.operation.operationName!,
     (request.vars as dynamic).toJson(),
     typePolicies,
-    {},
+    possibleTypes,
   );
   return {
     for (var fieldName in fieldNames)

--- a/ferry_cache/lib/src/utils/operation_root_data.dart
+++ b/ferry_cache/lib/src/utils/operation_root_data.dart
@@ -15,6 +15,7 @@ Map<String, dynamic> operationRootData<TData, TVars>(
     request.operation.operationName!,
     (request.vars as dynamic).toJson(),
     typePolicies,
+    {},
   );
   return {
     for (var fieldName in fieldNames)

--- a/ferry_cache/test/data_change_streams_test.dart
+++ b/ferry_cache/test/data_change_streams_test.dart
@@ -66,6 +66,7 @@ void main() {
         {},
         true,
         null,
+        {},
       );
 
       expect(
@@ -89,6 +90,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -113,6 +115,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -134,6 +137,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -158,6 +162,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(
@@ -190,6 +195,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(
@@ -225,6 +231,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -255,6 +262,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(
@@ -291,6 +299,7 @@ void main() {
           {},
           true,
           null,
+          {},
         );
 
         expect(

--- a/normalize/lib/src/config/normalization_config.dart
+++ b/normalize/lib/src/config/normalization_config.dart
@@ -26,7 +26,8 @@ class NormalizationConfig {
   /// Whether to accept or return partial data.
   final bool allowPartialData;
 
-  final Map<String, Set<String>> possibleTypeOf;
+  /// A map from an interface/union to possible types.
+  final Map<String, Set<String>> possibleTypes;
 
   NormalizationConfig({
     required this.read,
@@ -37,6 +38,6 @@ class NormalizationConfig {
     required this.dataIdFromObject,
     required this.addTypename,
     required this.allowPartialData,
-    required this.possibleTypeOf,
+    required this.possibleTypes,
   });
 }

--- a/normalize/lib/src/config/normalization_config.dart
+++ b/normalize/lib/src/config/normalization_config.dart
@@ -26,6 +26,8 @@ class NormalizationConfig {
   /// Whether to accept or return partial data.
   final bool allowPartialData;
 
+  final Map<String, Set<String>> possibleTypeOf;
+
   NormalizationConfig({
     required this.read,
     required this.variables,
@@ -35,5 +37,6 @@ class NormalizationConfig {
     required this.dataIdFromObject,
     required this.addTypename,
     required this.allowPartialData,
+    required this.possibleTypeOf,
   });
 }

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -34,7 +34,7 @@ Map<String, dynamic>? denormalizeFragment({
   bool returnPartialData = false,
   bool handleException = true,
   String referenceKey = '\$ref',
-  Map<String, Set<String>> possibleTypeOf = const {},
+  Map<String, Set<String>> possibleTypes = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -85,7 +85,7 @@ Map<String, dynamic>? denormalizeFragment({
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
     allowPartialData: returnPartialData,
-    possibleTypeOf: possibleTypeOf,
+    possibleTypes: possibleTypes,
   );
 
   try {

--- a/normalize/lib/src/denormalize_fragment.dart
+++ b/normalize/lib/src/denormalize_fragment.dart
@@ -2,11 +2,9 @@ import 'package:gql/ast.dart';
 import 'package:normalize/normalize.dart';
 
 import 'package:normalize/src/config/normalization_config.dart';
-import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/utils/add_typename_visitor.dart';
-import 'package:normalize/src/utils/exceptions.dart';
 import 'package:normalize/src/denormalize_node.dart';
 
 /// Denormalizes data for a given fragment.
@@ -36,6 +34,7 @@ Map<String, dynamic>? denormalizeFragment({
   bool returnPartialData = false,
   bool handleException = true,
   String referenceKey = '\$ref',
+  Map<String, Set<String>> possibleTypeOf = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -86,6 +85,7 @@ Map<String, dynamic>? denormalizeFragment({
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
     allowPartialData: returnPartialData,
+    possibleTypeOf: possibleTypeOf,
   );
 
   try {

--- a/normalize/lib/src/denormalize_node.dart
+++ b/normalize/lib/src/denormalize_node.dart
@@ -45,7 +45,7 @@ Object? denormalizeNode({
       typename: typename,
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
-      possibleTypeOf: config.possibleTypeOf,
+      possibleTypes: config.possibleTypes,
     );
 
     final result = subNodes.fold<Map<String, dynamic>>(

--- a/normalize/lib/src/denormalize_node.dart
+++ b/normalize/lib/src/denormalize_node.dart
@@ -45,6 +45,7 @@ Object? denormalizeNode({
       typename: typename,
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
+      possibleTypeOf: config.possibleTypeOf,
     );
 
     final result = subNodes.fold<Map<String, dynamic>>(

--- a/normalize/lib/src/denormalize_operation.dart
+++ b/normalize/lib/src/denormalize_operation.dart
@@ -1,10 +1,8 @@
 import 'package:gql/ast.dart';
 import 'package:normalize/normalize.dart';
 
-import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/resolve_root_typename.dart';
 import 'package:normalize/src/utils/add_typename_visitor.dart';
-import 'package:normalize/src/utils/exceptions.dart';
 import 'package:normalize/src/utils/get_operation_definition.dart';
 import 'package:normalize/src/denormalize_node.dart';
 import 'package:normalize/src/config/normalization_config.dart';
@@ -31,6 +29,7 @@ Map<String, dynamic>? denormalizeOperation({
   bool returnPartialData = false,
   bool handleException = true,
   String referenceKey = '\$ref',
+  Map<String, Set<String>> possibleTypeOf = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -55,6 +54,7 @@ Map<String, dynamic>? denormalizeOperation({
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
     allowPartialData: returnPartialData,
+    possibleTypeOf: possibleTypeOf,
   );
 
   try {

--- a/normalize/lib/src/denormalize_operation.dart
+++ b/normalize/lib/src/denormalize_operation.dart
@@ -29,7 +29,7 @@ Map<String, dynamic>? denormalizeOperation({
   bool returnPartialData = false,
   bool handleException = true,
   String referenceKey = '\$ref',
-  Map<String, Set<String>> possibleTypeOf = const {},
+  Map<String, Set<String>> possibleTypes = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -54,7 +54,7 @@ Map<String, dynamic>? denormalizeOperation({
     dataIdFromObject: dataIdFromObject,
     addTypename: addTypename,
     allowPartialData: returnPartialData,
-    possibleTypeOf: possibleTypeOf,
+    possibleTypes: possibleTypes,
   );
 
   try {

--- a/normalize/lib/src/normalize_fragment.dart
+++ b/normalize/lib/src/normalize_fragment.dart
@@ -39,6 +39,7 @@ void normalizeFragment({
   bool addTypename = false,
   String referenceKey = '\$ref',
   bool acceptPartialData = true,
+  Map<String, Set<String>> possibleTypeOf = const {},
 }) {
   // Always add typenames to ensure data is stored with typename
   document = transform(
@@ -75,6 +76,7 @@ void normalizeFragment({
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
     allowPartialData: acceptPartialData,
+    possibleTypeOf: possibleTypeOf,
   );
 
   final dataId = resolveDataId(

--- a/normalize/lib/src/normalize_fragment.dart
+++ b/normalize/lib/src/normalize_fragment.dart
@@ -39,7 +39,7 @@ void normalizeFragment({
   bool addTypename = false,
   String referenceKey = '\$ref',
   bool acceptPartialData = true,
-  Map<String, Set<String>> possibleTypeOf = const {},
+  Map<String, Set<String>> possibleTypes = const {},
 }) {
   // Always add typenames to ensure data is stored with typename
   document = transform(
@@ -76,7 +76,7 @@ void normalizeFragment({
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
     allowPartialData: acceptPartialData,
-    possibleTypeOf: possibleTypeOf,
+    possibleTypes: possibleTypes,
   );
 
   final dataId = resolveDataId(

--- a/normalize/lib/src/normalize_node.dart
+++ b/normalize/lib/src/normalize_node.dart
@@ -52,6 +52,7 @@ Object? normalizeNode({
       typename: typename,
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
+      possibleTypeOf: config.possibleTypeOf,
     );
 
     final dataToMerge = <String, dynamic>{

--- a/normalize/lib/src/normalize_node.dart
+++ b/normalize/lib/src/normalize_node.dart
@@ -52,7 +52,7 @@ Object? normalizeNode({
       typename: typename,
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
-      possibleTypeOf: config.possibleTypeOf,
+      possibleTypes: config.possibleTypes,
     );
 
     final dataToMerge = <String, dynamic>{

--- a/normalize/lib/src/normalize_operation.dart
+++ b/normalize/lib/src/normalize_operation.dart
@@ -35,6 +35,7 @@ void normalizeOperation({
   bool addTypename = false,
   bool acceptPartialData = true,
   String referenceKey = '\$ref',
+  Map<String, Set<String>> possibleTypeOf = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -59,6 +60,7 @@ void normalizeOperation({
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
     allowPartialData: acceptPartialData,
+    possibleTypeOf: possibleTypeOf,
   );
 
   write(

--- a/normalize/lib/src/normalize_operation.dart
+++ b/normalize/lib/src/normalize_operation.dart
@@ -35,7 +35,7 @@ void normalizeOperation({
   bool addTypename = false,
   bool acceptPartialData = true,
   String referenceKey = '\$ref',
-  Map<String, Set<String>> possibleTypeOf = const {},
+  Map<String, Set<String>> possibleTypes = const {},
 }) {
   if (addTypename) {
     document = transform(
@@ -60,7 +60,7 @@ void normalizeOperation({
     addTypename: addTypename,
     dataIdFromObject: dataIdFromObject,
     allowPartialData: acceptPartialData,
-    possibleTypeOf: possibleTypeOf,
+    possibleTypes: possibleTypes,
   );
 
   write(

--- a/normalize/lib/src/policies/field_policy.dart
+++ b/normalize/lib/src/policies/field_policy.dart
@@ -20,7 +20,7 @@ class FieldFunctionOptions {
   FieldFunctionOptions({
     required this.field,
     required NormalizationConfig config,
-  })   : _config = config,
+  })  : _config = config,
         variables = config.variables,
         args = argsWithValues(config.variables, field.arguments);
 
@@ -50,6 +50,7 @@ class FieldFunctionOptions {
           dataIdFromObject: _config.dataIdFromObject,
           addTypename: _config.addTypename,
           allowPartialData: true,
+          possibleTypeOf: _config.possibleTypeOf,
         ),
       ) as T?;
 }

--- a/normalize/lib/src/policies/field_policy.dart
+++ b/normalize/lib/src/policies/field_policy.dart
@@ -50,7 +50,7 @@ class FieldFunctionOptions {
           dataIdFromObject: _config.dataIdFromObject,
           addTypename: _config.addTypename,
           allowPartialData: true,
-          possibleTypeOf: _config.possibleTypeOf,
+          possibleTypes: _config.possibleTypes,
         ),
       ) as T?;
 }

--- a/normalize/lib/src/utils/expand_fragments.dart
+++ b/normalize/lib/src/utils/expand_fragments.dart
@@ -6,7 +6,7 @@ List<FieldNode> expandFragments({
   required String? typename,
   required SelectionSetNode selectionSet,
   required Map<String, FragmentDefinitionNode> fragmentMap,
-  required Map<String, Set<String>> possibleTypeOf,
+  required Map<String, Set<String>> possibleTypes,
 }) {
   final fieldNodes = <FieldNode>[];
 
@@ -40,13 +40,13 @@ List<FieldNode> expandFragments({
     //  - If the fragment and current type are the same (fragmentOnName == typename)
     //  - Or the current type is a type of the fragment target
     if (fragmentOnName == typename ||
-        possibleTypeOf[typename]?.contains(fragmentOnName) == true) {
+        possibleTypes[fragmentOnName]?.contains(typename) == true) {
       fieldNodes.addAll(
         expandFragments(
           typename: typename,
           selectionSet: fragmentSelectionSet,
           fragmentMap: fragmentMap,
-          possibleTypeOf: possibleTypeOf,
+          possibleTypes: possibleTypes,
         ),
       );
     }

--- a/normalize/lib/src/utils/operation_field_names.dart
+++ b/normalize/lib/src/utils/operation_field_names.dart
@@ -13,7 +13,7 @@ List<String> operationFieldNames<TData, TVars>(
   String operationName,
   Map<String, dynamic> vars,
   Map<String, TypePolicy> typePolicies,
-  Map<String, Set<String>> possibleTypeOf,
+  Map<String, Set<String>> possibleTypes,
 ) {
   final operationDefinition = getOperationDefinition(
     document,
@@ -28,7 +28,7 @@ List<String> operationFieldNames<TData, TVars>(
     typename: rootTypename,
     selectionSet: operationDefinition.selectionSet,
     fragmentMap: fragmentMap,
-    possibleTypeOf: possibleTypeOf,
+    possibleTypes: possibleTypes,
   );
   final typePolicy = typePolicies[rootTypename];
   return fields.map((fieldNode) {

--- a/normalize/lib/src/utils/operation_field_names.dart
+++ b/normalize/lib/src/utils/operation_field_names.dart
@@ -13,6 +13,7 @@ List<String> operationFieldNames<TData, TVars>(
   String operationName,
   Map<String, dynamic> vars,
   Map<String, TypePolicy> typePolicies,
+  Map<String, Set<String>> possibleTypeOf,
 ) {
   final operationDefinition = getOperationDefinition(
     document,
@@ -27,6 +28,7 @@ List<String> operationFieldNames<TData, TVars>(
     typename: rootTypename,
     selectionSet: operationDefinition.selectionSet,
     fragmentMap: fragmentMap,
+    possibleTypeOf: possibleTypeOf,
   );
   final typePolicy = typePolicies[rootTypename];
   return fields.map((fieldNode) {

--- a/normalize/test/possible_type_of.dart
+++ b/normalize/test/possible_type_of.dart
@@ -6,9 +6,8 @@ import 'package:normalize/normalize.dart';
 void main() {
   group('Normalizing and denormalizing with possible type of', () {
     test('Mutiple fragments', () {
-      final possibleTypeOf = {
-        'Author': {'User'},
-        'Audience': {'User'},
+      final possibleTypes = {
+        'User': {'Author', 'Audience'},
       };
       final document = parseString('''
         fragment FAudience on Audience {
@@ -80,7 +79,7 @@ void main() {
         document: document,
         data: data,
         acceptPartialData: false,
-        possibleTypeOf: possibleTypeOf,
+        possibleTypes: possibleTypes,
       );
       expect(
         normalizedResult,
@@ -92,7 +91,7 @@ void main() {
           document: document,
           handleException: false,
           read: (dataId) => normalizedMap[dataId],
-          possibleTypeOf: possibleTypeOf,
+          possibleTypes: possibleTypes,
         ),
         equals(data),
       );

--- a/normalize/test/possible_type_of.dart
+++ b/normalize/test/possible_type_of.dart
@@ -1,0 +1,101 @@
+import 'package:test/test.dart';
+import 'package:gql/language.dart';
+
+import 'package:normalize/normalize.dart';
+
+void main() {
+  group('Normalizing and denormalizing with possible type of', () {
+    test('Mutiple fragments', () {
+      final possibleTypeOf = {
+        'Author': {'User'},
+        'Audience': {'User'},
+      };
+      final document = parseString('''
+        fragment FAudience on Audience {
+          __typename
+          id
+          numHands
+          isClapping
+        }
+        fragment FUser on User {
+          id
+          __typename
+          name
+        }
+        query {
+          users {
+            ... on Author {
+              __typename
+              id
+              isGoodAuthor
+            }
+            ...FAudience
+            ...FUser
+          }
+        }
+      ''');
+      final data = {
+        'users': [
+          {
+            '__typename': 'Author',
+            'id': '1',
+            'name': 'Knud',
+            'isGoodAuthor': true,
+          },
+          {
+            '__typename': 'Audience',
+            'id': 'a',
+            'name': 'Lars',
+            'numHands': 2,
+            'isClapping': false
+          },
+        ],
+      };
+
+      final normalizedMap = {
+        'Author:1': {
+          '__typename': 'Author',
+          'id': '1',
+          'name': 'Knud',
+          'isGoodAuthor': true
+        },
+        'Audience:a': {
+          '__typename': 'Audience',
+          'id': 'a',
+          'numHands': 2,
+          'isClapping': false,
+          'name': 'Lars'
+        },
+        'Query': {
+          'users': [
+            {r'$ref': 'Author:1'},
+            {r'$ref': 'Audience:a'}
+          ]
+        },
+      };
+      final normalizedResult = {};
+      normalizeOperation(
+        read: (dataId) => normalizedResult[dataId],
+        write: (dataId, value) => normalizedResult[dataId] = value,
+        document: document,
+        data: data,
+        acceptPartialData: false,
+        possibleTypeOf: possibleTypeOf,
+      );
+      expect(
+        normalizedResult,
+        equals(normalizedMap),
+      );
+
+      expect(
+        denormalizeOperation(
+          document: document,
+          handleException: false,
+          read: (dataId) => normalizedMap[dataId],
+          possibleTypeOf: possibleTypeOf,
+        ),
+        equals(data),
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR adds improved support for fragment resolution by introducing a new map to lookup type relationship

Take the document: 

```graphql
fragment FAuthor on Author {
  __typename
  id
}
fragment FAudience on Audience {
  __typename
  id
  numHands
  isClapping
}
fragment FUser on User {
  id
  __typename
  name
}
query {
  users {
    ...FAuthor
    ...FAudience
    ...FUser
  }
}
```

and the schema 


```graphql

type Query {
  users: [User]
}

interface User { 
  id: ID!
  name: String
}

type Author implements User {
  id: ID!
  name: String
  numBooks: Int
}

type Audience implements User {
  id: ID!
  name: String
  numHands: Int
  isClapping: Boolean
}

```

the current implementation will fail to realize which fragment spreads apply to a given type. E.g. that `FUser` and `FAuthor` should apply to the `Author` type. This leads to partial results on fragments and wrong results on inline fragments.  By adding some introspection in the shape of the `possibleTypeOf` lookup map, which maps object types to possible interfaces and unions, we can resolve this.

If the map is omitted, or if the `__typename` is omitted, this solution will not expand any fragments. This is sound. The current approach expands all fragment spreads and only expands on exact matches for inline fragments, both of which are wrong.

