### PR TITLE
Fixed issue with update cache typed link

### DIFF
--- a/ferry/lib/src/update_cache_typed_link.dart
+++ b/ferry/lib/src/update_cache_typed_link.dart
@@ -124,7 +124,7 @@ class UpdateCacheTypedLink extends TypedLink {
       _updateCacheHandlersStream<TData, TVars>(
     Stream<OperationResponse<TData, TVars>> stream,
   ) {
-    var runNonOptimistically = false;
+    var runNonOptimistically = true;
 
     return stream.doOnData((res) {
       final key = res.operationRequest.updateCacheHandlerKey;
@@ -146,6 +146,10 @@ class UpdateCacheTypedLink extends TypedLink {
             return;
           }
         case DataSource.Link:
+          {
+            handler(proxy, res);
+            return;
+          }
         case DataSource.Cache:
           {
             if (runNonOptimistically == false) {


### PR DESCRIPTION
When using a link that emits sequential responses for a single request (like graphql subscription) it only invoke the cache handler for the first response only. So this is a fix for the issue.

`runNonOptimistically` should be true default for the common requests. For a request with `DataSource.Link` it should be marked as `false` then again it should be `true` after update the cache.