### PR TITLE
Revert possible types changes for inline fragments

### DIFF
--- a/examples/pokemon_explorer/CHANGELOG.md
+++ b/examples/pokemon_explorer/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.0.3
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.0.2
 
  - **FEAT**: update dependences.

--- a/examples/pokemon_explorer/pubspec.yaml
+++ b/examples/pokemon_explorer/pubspec.yaml
@@ -1,13 +1,13 @@
 name: pokemon_explorer
-version: 0.0.2
+version: 0.0.3
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   gql_link: ^0.4.0-nullsafety.3
   gql_http_link: ^0.4.0-nullsafety.1
   ferry: ^0.10.1-0.1.nullsafety.0
-  ferry_hive_store: ^0.4.3
-  ferry_flutter: ^0.5.3
+  ferry_hive_store: ^0.4.4
+  ferry_flutter: ^0.5.4
   hive: ^2.0.0
   hive_flutter: ^1.0.0
   get_it: ^7.1.3
@@ -17,7 +17,7 @@ dev_dependencies:
   build_runner: ^2.0.2
   gql_build: ^0.2.0-nullsafety.1
   gql_code_builder: ^0.2.0-nullsafety.1
-  ferry_generator: ^0.4.3
+  ferry_generator: ^0.4.4
   flutter_test:
     sdk: flutter
 flutter:

--- a/ferry/CHANGELOG.md
+++ b/ferry/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.10.3
 
  - **FEAT**: update dependences.

--- a/ferry/pubspec.yaml
+++ b/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.10.3
+version: 0.10.4
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry
@@ -14,15 +14,15 @@ dependencies:
   collection: ^1.15.0
   hive: ^2.0.0
   built_value: ^8.0.4
-  ferry_exec: ^0.1.3
-  normalize: ^0.5.4
-  ferry_cache: ^0.5.4
+  ferry_exec: ^0.1.4
+  normalize: ^0.5.5
+  ferry_cache: ^0.5.5
 dev_dependencies:
   test: ^1.16.8
   mockito: ^5.0.2
   build_test: ^2.0.0
   built_value_generator: ^8.0.4
-  ferry_test_graphql: ^0.1.3
+  ferry_test_graphql: ^0.1.4
   pedantic: ^1.11.0
   async: ^2.5.0
   build_runner: ^2.0.2

--- a/ferry_cache/CHANGELOG.md
+++ b/ferry_cache/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.5
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.5.4
 
  - **FEAT**: update dependences.

--- a/ferry_cache/pubspec.yaml
+++ b/ferry_cache/pubspec.yaml
@@ -1,18 +1,18 @@
 name: ferry_cache
-version: 0.5.4
+version: 0.5.5
 homepage: https://ferrygraphql.com/
 description: A normalized, strongly typed, optimistic cache for GraphQL Operations and Fragments
 repository: https://github.com/gql-dart/ferry
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  ferry_exec: ^0.1.3
+  ferry_exec: ^0.1.4
   meta: ^1.3.0
   rxdart: ^0.27.1
-  normalize: ^0.5.4
-  ferry_store: ^0.4.3
+  normalize: ^0.5.5
+  ferry_store: ^0.4.4
   collection: ^1.15.0
 dev_dependencies:
   test: ^1.16.8
   pedantic: ^1.11.0
-  ferry_test_graphql: ^0.1.3
+  ferry_test_graphql: ^0.1.4

--- a/ferry_exec/CHANGELOG.md
+++ b/ferry_exec/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.1.3
 
  - **FEAT**: update dependences.

--- a/ferry_exec/pubspec.yaml
+++ b/ferry_exec/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_exec
-version: 0.1.3
+version: 0.1.4
 homepage: https://ferrygraphql.com/
 description: A strongly typed execution interface for GraphQL operations
 repository: https://github.com/gql-dart/ferry
@@ -15,4 +15,4 @@ dependencies:
 dev_dependencies:
   test: ^1.16.8
   pedantic: ^1.11.0
-  ferry_test_graphql: ^0.1.3
+  ferry_test_graphql: ^0.1.4

--- a/ferry_flutter/CHANGELOG.md
+++ b/ferry_flutter/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.5.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.5.3
 
  - **FEAT**: update dependences.

--- a/ferry_flutter/pubspec.yaml
+++ b/ferry_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_flutter
-version: 0.5.3
+version: 0.5.4
 homepage: https://ferrygraphql.com/
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
@@ -8,7 +8,7 @@ environment:
 dependencies:
   ferry: ^0.10.2
   gql_exec: ^0.3.0
-  ferry_exec: ^0.1.3
+  ferry_exec: ^0.1.4
   flutter:
     sdk: flutter
   flutter_test:

--- a/ferry_generator/CHANGELOG.md
+++ b/ferry_generator/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.4.3
 
  - **FEAT**: update dependences.

--- a/ferry_generator/pubspec.yaml
+++ b/ferry_generator/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_generator
-version: 0.4.3
+version: 0.4.4
 homepage: https://ferrygraphql.com/
 description: Generated types for Ferry GraphQL Client
 repository: https://github.com/gql-dart/ferry
@@ -13,7 +13,7 @@ dependencies:
   code_builder: ^4.0.0
   build: ^2.0.0
   path: ^1.8.0
-  ferry_exec: ^0.1.3
+  ferry_exec: ^0.1.4
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2

--- a/ferry_hive_store/CHANGELOG.md
+++ b/ferry_hive_store/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.4.3
 
  - **FEAT**: update dependences.

--- a/ferry_hive_store/pubspec.yaml
+++ b/ferry_hive_store/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_hive_store
-version: 0.4.3
+version: 0.4.4
 homepage: https://ferrygraphql.com/
 description: Hive-based Store implementation for Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   hive: ^2.0.0
-  ferry_store: ^0.4.3
+  ferry_store: ^0.4.4
   rxdart: ^0.27.1
   collection: ^1.15.0
 dev_dependencies:

--- a/ferry_store/CHANGELOG.md
+++ b/ferry_store/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.4.3
 
  - **FEAT**: update dependences.

--- a/ferry_store/pubspec.yaml
+++ b/ferry_store/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_store
-version: 0.4.3
+version: 0.4.4
 homepage: https://ferrygraphql.com/
 description: Default Store for Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry

--- a/ferry_test_graphql/CHANGELOG.md
+++ b/ferry_test_graphql/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.1.4
+
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.1.3
 
  - **FEAT**: update dependences.

--- a/ferry_test_graphql/pubspec.yaml
+++ b/ferry_test_graphql/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_test_graphql
-version: 0.1.3
+version: 0.1.4
 description: Example GraphQL Operations, used in Ferry tests
 repository: https://github.com/gql-dart/ferry
 environment:
@@ -7,7 +7,7 @@ environment:
 dependencies:
   gql: ^0.13.0
   gql_exec: ^0.3.0
-  ferry_exec: ^0.1.3
+  ferry_exec: ^0.1.4
   built_value: ^8.0.4
   built_collection: ^5.0.0
   gql_code_builder: ^0.2.0
@@ -15,4 +15,4 @@ dev_dependencies:
   build_runner: ^2.0.2
   gql_build: ^0.2.0
   pedantic: ^1.11.0
-  ferry_generator: ^0.4.3
+  ferry_generator: ^0.4.4

--- a/normalize/CHANGELOG.md
+++ b/normalize/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.5
+
+ - **FIX**: allow inline fragments for subtypes without passing possibleTypes.
+ - **FEAT**: update dependences.
+ - **FEAT**: update dependences.
+ - **CHORE**: publish packages.
+ - **CHORE**: publish packages.
+
 ## 0.5.4
 
  - **FEAT**: update dependences.

--- a/normalize/pubspec.yaml
+++ b/normalize/pubspec.yaml
@@ -1,5 +1,5 @@
 name: normalize
-version: 0.5.4
+version: 0.5.5
 homepage: https://github.com/gql-dart/ferry/tree/master/normalize
 description: Normalization and denormalization of GraphQL responses in Dart
 repository: https://github.com/gql-dart/ferry

--- a/normalize/test/query_fragments/named_fragments_test.dart
+++ b/normalize/test/query_fragments/named_fragments_test.dart
@@ -13,7 +13,7 @@ void main() {
           id
           __typename
           author {
-            ...olle
+            ...authorFragment
           }
           title
           comments {
@@ -28,9 +28,13 @@ void main() {
         }
       }
 
-      fragment olle on Author {
+      fragment authorFragment on Author {
         id
         __typename
+        ...personFragment
+      }
+
+      fragment personFragment on Person {
         name
       }
     ''');


### PR DESCRIPTION
The recent changes to allow `possibleTypes` broke the ability to use inline fragments on interfaces and unions without providing a `possibleTypes` map. This PR reverts those changes for inline fragments.