### PR TITLE
chore: enforce conventional commits

### DIFF
--- a/.github/workflows/commits.yml
+++ b/.github/workflows/commits.yml
@@ -1,0 +1,13 @@
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review] # Currently, this action only support these events
+
+jobs:
+  hqprs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Conventional PRs
+        uses: Namchee/conventional-pr@v0.4.1
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+          link_issue: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing to Ferry
+
+## Create a new issue
+
+The easiest way to get involved is to create a [new issue](https://github.com/gql-dart/ferry/issues/new) when you spot a bug, if the documentation is incomplete or out of date, or if you identify an implementation problem.
+
+## General coding guidlines
+
+If you'd like to add a feature or fix a bug, we're more than happy to accept pull requests! We only ask a few things:
+
+- Use [conventional commits](https://www.conventionalcommits.org/). This allows us to automatically build changelogs and publish `alpha` releases.
+- Ensure your code contains no analyzer errors.
+- Format your code with `dartfmt`.
+- Write tests for all new code paths, consider using the [Stream Matchers](https://pub.dartlang.org/packages/test#stream-matchers) available from the test package.
+- Write helpful documentation
+- If you would like to make a bigger / fundamental change to the codebase, please file a lightweight example PR / issue first.


### PR DESCRIPTION
Enforces [Conventional PRs](https://github.com/marketplace/actions/conventional-prs) via github action.