### PR TITLE
fix cast error

### DIFF
--- a/packages/normalize/lib/src/normalize_node.dart
+++ b/packages/normalize/lib/src/normalize_node.dart
@@ -38,7 +38,7 @@ Object? normalizeNode({
 
   if (dataForNode is Map) {
     final dataId = resolveDataId(
-      data: dataForNode as Map<String, dynamic>,
+      data: Map<String, dynamic>.from(dataForNode),
       typePolicies: config.typePolicies,
       dataIdFromObject: config.dataIdFromObject,
     );


### PR DESCRIPTION
Fixing this error:
```
E/flutter (20393): [ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>' in type cast
E/flutter (20393): #0      normalizeNode (package:normalize/src/normalize_node.dart:41:25)
E/flutter (20393): #1      normalizeNode.<anonymous closure> (package:normalize/src/normalize_node.dart:90:29)
E/flutter (20393): #2      ListMixin.fold (dart:collection/list.dart:237:22)
E/flutter (20393): #3      normalizeNode (package:normalize/src/normalize_node.dart:60:19)
E/flutter (20393): #4      normalizeOperation (package:normalize/src/normalize_operation.dart:68:5)
E/flutter (20393): #5      NormalizingDataProxy.writeQuery (package:graphql/src/cache/_normalizing_data_proxy.dart:128:7)
E/flutter (20393): #6      fetchMoreImplementation.<anonymous closure> (package:graphql/src/core/fetch_more.dart:58:55)
E/flutter (20393): #7      InternalQueryWriteHandling._writeQueryOrSetExceptionOnQueryResult (package:graphql/src/core/_query_write_handling.dart:32:17)
E/flutter (20393): #8      InternalQueryWriteHandling.attemptCacheWriteFromClient (package:graphql/src/core/_query_write_handling.dart:89:7)
E/flutter (20393): #9      fetchMoreImplementation (package:graphql/src/core/fetch_more.dart:54:20)
E/flutter (20393): <asynchronous suspension>
```