### PR TITLE
fix: remove analyzer from ferry_generator

### DIFF
--- a/packages/ferry/benchmark/operations.dart
+++ b/packages/ferry/benchmark/operations.dart
@@ -31,6 +31,7 @@ class AutoResponderLink extends Link {
   ]) =>
       Stream.value(
         Response(
+          response: {},
           data: GHumanWithArgsData(
             (b) => b
               ..human.id = req.variables['id']

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   gql: ^0.13.0
   rxdart: ^0.27.1
   gql_link: ^0.4.0
-  gql_exec: ^0.3.0
+  gql_exec: ^0.4.0
   meta: ^1.3.0
   collection: ^1.15.0
   hive: ^2.0.0

--- a/packages/ferry/test/link_subscription_cancel_test.dart
+++ b/packages/ferry/test/link_subscription_cancel_test.dart
@@ -17,9 +17,8 @@ class _StreamCancelTestLink extends Link {
     StreamSubscription? sub;
     try {
       //simulate events coming in, e.g. from a websocket
-      sub =
-          Stream.periodic(Duration(microseconds: 1), (_) => Response(data: {}))
-              .listen(controller.add);
+      sub = Stream.periodic(Duration(microseconds: 1),
+          (_) => Response(data: {}, response: {})).listen(controller.add);
       //yield* should finish when the client stops listening
       yield* controller.stream;
     } finally {

--- a/packages/ferry/test/typed_links/fetch_policy_typed_link_test.dart
+++ b/packages/ferry/test/typed_links/fetch_policy_typed_link_test.dart
@@ -41,8 +41,8 @@ void main() {
 
     when(mockLink.request(any, any)).thenAnswer(
       (_) => Stream.fromIterable([
-        Response(data: data.toJson()),
-        Response(data: newData.toJson()),
+        Response(data: data.toJson(), response: {}),
+        Response(data: newData.toJson(), response: {}),
       ]).interval(Duration(milliseconds: 10)),
     );
 

--- a/packages/ferry/test/typed_links/gql_typed_link_test.dart
+++ b/packages/ferry/test/typed_links/gql_typed_link_test.dart
@@ -24,7 +24,7 @@ void main() {
       ];
 
       when(mockLink.request(req.execRequest, any)).thenAnswer(
-        (_) => Stream.value(Response(errors: graphQLErrors)),
+        (_) => Stream.value(Response(errors: graphQLErrors, response: {})),
       );
 
       final typedLink = GqlTypedLink(mockLink);
@@ -50,6 +50,7 @@ void main() {
       when(mockLink.request(req.execRequest, any)).thenAnswer(
         (_) => Stream.value(
           Response(
+            response: {},
             context: Context().withEntry<ResponseExtensions>(
               ResponseExtensions(extensionData),
             ),
@@ -79,7 +80,7 @@ void main() {
           ..fetchPolicy = FetchPolicy.NetworkOnly,
       );
 
-      final exception = ServerException(parsedResponse: Response());
+      final exception = ServerException(parsedResponse: Response(response: {}));
 
       when(mockLink.request(req.execRequest, any))
           .thenAnswer((_) => Stream.error(exception));
@@ -106,7 +107,7 @@ void main() {
         final controller = StreamController<Response>();
 
         controller.addError('error');
-        controller.add(Response(data: {}));
+        controller.add(Response(data: {}, response: {}));
         controller.close();
 
         yield* controller.stream;

--- a/packages/ferry/test/typed_links/update_cache_typed_link_test.dart
+++ b/packages/ferry/test/typed_links/update_cache_typed_link_test.dart
@@ -124,12 +124,14 @@ void main() {
       expect(cache.readQuery(reviewsReq), equals(null));
 
       requestController.add(createReviewReq);
-      linkController.add(Response(data: createReviewData.toJson()));
+      linkController
+          .add(Response(data: createReviewData.toJson(), response: {}));
       await queue.next;
 
       expect(cache.readQuery(reviewsReq)!.reviews!.length, equals(1));
 
-      linkController.add(Response(data: createReviewData.toJson()));
+      linkController
+          .add(Response(data: createReviewData.toJson(), response: {}));
       await queue.next;
 
       expect(cache.readQuery(reviewsReq)!.reviews!.length, equals(2));
@@ -160,7 +162,8 @@ void main() {
           equals('456'),
         );
 
-        linkController.add(Response(data: createReviewData.toJson()));
+        linkController
+            .add(Response(data: createReviewData.toJson(), response: {}));
         final res2 = await queue.next;
 
         expect(res2.dataSource, equals(DataSource.Link));

--- a/packages/ferry_exec/pubspec.yaml
+++ b/packages/ferry_exec/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   gql: ^0.13.0
-  gql_exec: ^0.3.0
+  gql_exec: ^0.4.0
   gql_link: ^0.4.0
   meta: ^1.3.0
   async: ^2.5.0

--- a/packages/ferry_flutter/pubspec.yaml
+++ b/packages/ferry_flutter/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   ferry: ^0.10.2
-  gql_exec: ^0.3.0
+  gql_exec: ^0.4.0
   ferry_exec: ^0.1.5-dev.1
   flutter:
     sdk: flutter

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   gql: ^0.13.0
-  gql_code_builder: ^0.3.0-alpha.0
+  gql_code_builder: ^0.5.0
   built_collection: ^5.0.0
   code_builder: ^4.0.0
   build: ^2.0.0
@@ -15,7 +15,6 @@ dependencies:
   ferry_exec: ^0.1.5-dev.1
   yaml: ^3.1.0
   dart_style: ^2.0.3
-  analyzer: ^1.7.2
   glob: ^2.0.1
   built_value_generator: ^8.1.1
   built_value: ^8.1.2

--- a/packages/ferry_test_graphql/lib/fragments/__generated__/review_fragment.data.gql.dart
+++ b/packages/ferry_test_graphql/lib/fragments/__generated__/review_fragment.data.gql.dart
@@ -25,16 +25,12 @@ abstract class GReviewFragmentData
 
   static void _initializeBuilder(GReviewFragmentDataBuilder b) =>
       b..G__typename = 'Review';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   int get stars;
-  @override
   String? get commentary;
   static Serializer<GReviewFragmentData> get serializer =>
       _$gReviewFragmentDataSerializer;
-  @override
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GReviewFragmentData.serializer, this)
           as Map<String, dynamic>);

--- a/packages/ferry_test_graphql/lib/queries/__generated__/hero_with_fragments.data.gql.dart
+++ b/packages/ferry_test_graphql/lib/queries/__generated__/hero_with_fragments.data.gql.dart
@@ -42,18 +42,13 @@ abstract class GHeroWithFragmentsData_hero
 
   static void _initializeBuilder(GHeroWithFragmentsData_heroBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
-  @override
   GHeroWithFragmentsData_hero_friendsConnection get friendsConnection;
   static Serializer<GHeroWithFragmentsData_hero> get serializer =>
       _$gHeroWithFragmentsDataHeroSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
       GHeroWithFragmentsData_hero.serializer, this) as Map<String, dynamic>);
   static GHeroWithFragmentsData_hero? fromJson(Map<String, dynamic> json) =>
@@ -75,16 +70,12 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection
   static void _initializeBuilder(
           GHeroWithFragmentsData_hero_friendsConnectionBuilder b) =>
       b..G__typename = 'FriendsConnection';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   int? get totalCount;
-  @override
   BuiltList<GHeroWithFragmentsData_hero_friendsConnection_edges>? get edges;
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection>
       get serializer => _$gHeroWithFragmentsDataHeroFriendsConnectionSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GHeroWithFragmentsData_hero_friendsConnection.serializer, this)
       as Map<String, dynamic>);
@@ -108,15 +99,12 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection_edges
   static void _initializeBuilder(
           GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder b) =>
       b..G__typename = 'FriendsEdge';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   GHeroWithFragmentsData_hero_friendsConnection_edges_node? get node;
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection_edges>
       get serializer =>
           _$gHeroWithFragmentsDataHeroFriendsConnectionEdgesSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GHeroWithFragmentsData_hero_friendsConnection_edges.serializer, this)
       as Map<String, dynamic>);
@@ -142,17 +130,13 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection_edges_node
   static void _initializeBuilder(
           GHeroWithFragmentsData_hero_friendsConnection_edges_nodeBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
   static Serializer<GHeroWithFragmentsData_hero_friendsConnection_edges_node>
       get serializer =>
           _$gHeroWithFragmentsDataHeroFriendsConnectionEdgesNodeSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
       GHeroWithFragmentsData_hero_friendsConnection_edges_node.serializer,
       this) as Map<String, dynamic>);
@@ -179,15 +163,11 @@ abstract class GheroDataData
 
   static void _initializeBuilder(GheroDataDataBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
   static Serializer<GheroDataData> get serializer => _$gheroDataDataSerializer;
-  @override
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GheroDataData.serializer, this)
           as Map<String, dynamic>);
@@ -196,14 +176,10 @@ abstract class GheroDataData
 }
 
 abstract class GcomparisonFields implements GheroData {
-  @override
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
   GcomparisonFields_friendsConnection get friendsConnection;
-  @override
   Map<String, dynamic> toJson();
 }
 
@@ -222,13 +198,9 @@ abstract class GcomparisonFields_friendsConnection_edges {
 
 abstract class GcomparisonFields_friendsConnection_edges_node
     implements GheroData {
-  @override
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
-  @override
   Map<String, dynamic> toJson();
 }
 
@@ -245,18 +217,13 @@ abstract class GcomparisonFieldsData
 
   static void _initializeBuilder(GcomparisonFieldsDataBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
-  @override
   GcomparisonFieldsData_friendsConnection get friendsConnection;
   static Serializer<GcomparisonFieldsData> get serializer =>
       _$gcomparisonFieldsDataSerializer;
-  @override
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GcomparisonFieldsData.serializer, this)
           as Map<String, dynamic>);
@@ -278,16 +245,12 @@ abstract class GcomparisonFieldsData_friendsConnection
   static void _initializeBuilder(
           GcomparisonFieldsData_friendsConnectionBuilder b) =>
       b..G__typename = 'FriendsConnection';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   int? get totalCount;
-  @override
   BuiltList<GcomparisonFieldsData_friendsConnection_edges>? get edges;
   static Serializer<GcomparisonFieldsData_friendsConnection> get serializer =>
       _$gcomparisonFieldsDataFriendsConnectionSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GcomparisonFieldsData_friendsConnection.serializer, this)
       as Map<String, dynamic>);
@@ -311,14 +274,11 @@ abstract class GcomparisonFieldsData_friendsConnection_edges
   static void _initializeBuilder(
           GcomparisonFieldsData_friendsConnection_edgesBuilder b) =>
       b..G__typename = 'FriendsEdge';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   GcomparisonFieldsData_friendsConnection_edges_node? get node;
   static Serializer<GcomparisonFieldsData_friendsConnection_edges>
       get serializer => _$gcomparisonFieldsDataFriendsConnectionEdgesSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GcomparisonFieldsData_friendsConnection_edges.serializer, this)
       as Map<String, dynamic>);
@@ -343,17 +303,13 @@ abstract class GcomparisonFieldsData_friendsConnection_edges_node
   static void _initializeBuilder(
           GcomparisonFieldsData_friendsConnection_edges_nodeBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get id;
-  @override
   String get name;
   static Serializer<GcomparisonFieldsData_friendsConnection_edges_node>
       get serializer =>
           _$gcomparisonFieldsDataFriendsConnectionEdgesNodeSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
           GcomparisonFieldsData_friendsConnection_edges_node.serializer, this)
       as Map<String, dynamic>);

--- a/packages/ferry_test_graphql/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
+++ b/packages/ferry_test_graphql/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
@@ -60,14 +60,11 @@ abstract class GHeroForEpisodeData_hero__base
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__baseBuilder b) =>
       b..G__typename = 'Character';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get name;
   static Serializer<GHeroForEpisodeData_hero__base> get serializer =>
       _$gHeroForEpisodeDataHeroBaseSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
       GHeroForEpisodeData_hero__base.serializer, this) as Map<String, dynamic>);
   static GHeroForEpisodeData_hero__base? fromJson(Map<String, dynamic> json) =>
@@ -89,16 +86,12 @@ abstract class GHeroForEpisodeData_hero__asDroid
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__asDroidBuilder b) =>
       b..G__typename = 'Droid';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String get name;
-  @override
   String? get primaryFunction;
   static Serializer<GHeroForEpisodeData_hero__asDroid> get serializer =>
       _$gHeroForEpisodeDataHeroAsDroidSerializer;
-  @override
   Map<String, dynamic> toJson() => (_i1.serializers
           .serializeWith(GHeroForEpisodeData_hero__asDroid.serializer, this)
       as Map<String, dynamic>);
@@ -125,14 +118,11 @@ abstract class GDroidFragmentData
 
   static void _initializeBuilder(GDroidFragmentDataBuilder b) =>
       b..G__typename = 'Droid';
-  @override
   @BuiltValueField(wireName: '__typename')
   String get G__typename;
-  @override
   String? get primaryFunction;
   static Serializer<GDroidFragmentData> get serializer =>
       _$gDroidFragmentDataSerializer;
-  @override
   Map<String, dynamic> toJson() =>
       (_i1.serializers.serializeWith(GDroidFragmentData.serializer, this)
           as Map<String, dynamic>);

--- a/packages/ferry_test_graphql/pubspec.yaml
+++ b/packages/ferry_test_graphql/pubspec.yaml
@@ -6,11 +6,11 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
   gql: ^0.13.0
-  gql_exec: ^0.3.0
+  gql_exec: ^0.4.0
   ferry_exec: ^0.1.5-dev.1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.3.0-alpha.0
+  gql_code_builder: ^0.5.0
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2


### PR DESCRIPTION
Current Problem:
Ferry generator isn't compatible with a lot of updated generator packages because of this old analyzer entry.

Example output: 
```
Because auto_route_generator 3.2.3 depends on analyzer >=2.7.0 <4.0.0 and ferry_generator >=0.5.0-dev.5 depends on analyzer ^1.7.2, auto_route_generator 3.2.3 is incompatible with ferry_generator >=0.5.0-dev.5.
So, because app depends on both ferry_generator ^0.5.0-dev.9 and auto_route_generator 3.2.3, version solving failed.
pub get failed (1; So, because app depends on both ferry_generator ^0.5.0-dev.9 and auto_route_generator 3.2.3, version solving failed.)

```

It looks like the analyzer entry is vestigial since `dart analyze` does not require to be added as a library.

Solution:
* Delete the entry
* Update existing deps gql_code_builder and gql_exec

Tested: 
* re-ran `flutter pub get` in ferry_generator

Inside ferry_test_graphql
* Made ferry_generator pull from current repo
* Ran `flutter pub run build_runner build --delete-conflicting-outputs`
* Ran `flutter test`




