### PR TITLE
Updated RequestController duplciate request logic

### DIFF
--- a/packages/ferry/lib/src/request_controller_typed_link.dart
+++ b/packages/ferry/lib/src/request_controller_typed_link.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
-import 'package:rxdart/rxdart.dart';
+
 import 'package:ferry_exec/ferry_exec.dart';
+import 'package:rxdart/rxdart.dart';
 
 /// Allows multiple requests to be made by adding requests to the
 /// [requestController].
@@ -37,7 +38,7 @@ class RequestControllerTypedLink extends TypedLink {
         .whereType<OperationRequest<TData, TVars>>()
         .where(
           (req) => req.requestId == null
-              ? req == request
+              ? identical(req, request)
               : req.requestId == request.requestId,
         )
         .doOnData(


### PR DESCRIPTION
Updated logic in RequestControllerTypedLink to check the stream for the same instance, rather than equivalent, requests.  This was creating duplicate network requests if the a new request was created with the same parameters that had been issued previously.  This affects both queries and mutations.

This addresses the issue in #341 