### PR TITLE
fix: Streamline typename handling

### DIFF
--- a/packages/normalize/lib/src/denormalize_fragment.dart
+++ b/packages/normalize/lib/src/denormalize_fragment.dart
@@ -2,6 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:normalize/normalize.dart';
 
 import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/utils/add_typename_visitor.dart';
@@ -33,7 +34,7 @@ Map<String, dynamic>? denormalizeFragment({
   bool addTypename = false,
   bool returnPartialData = false,
   bool handleException = true,
-  String referenceKey = '\$ref',
+  String referenceKey = kDefaultReferenceKey,
   Map<String, Set<String>> possibleTypes = const {},
 }) {
   if (addTypename) {
@@ -42,24 +43,11 @@ Map<String, dynamic>? denormalizeFragment({
       [AddTypenameVisitor()],
     );
   }
-
   final fragmentMap = getFragmentMap(document);
-
-  if (fragmentMap.length > 1 && fragmentName == null) {
-    throw Exception(
-      'Multiple fragments defined, but no fragmentName provided',
-    );
-  }
-
-  if (fragmentName != null && fragmentMap[fragmentName] == null) {
-    throw Exception(
-      'Fragment "$fragmentName" not found',
-    );
-  }
-
-  final fragmentDefinition = fragmentName != null
-      ? fragmentMap[fragmentName]!
-      : fragmentMap.values.first;
+  final fragmentDefinition = findFragmentInFragmentMap(
+    fragmentMap: fragmentMap,
+    fragmentName: fragmentName,
+  );
 
   final dataId = resolveDataId(
     data: {

--- a/packages/normalize/lib/src/normalize_fragment.dart
+++ b/packages/normalize/lib/src/normalize_fragment.dart
@@ -1,4 +1,5 @@
 import 'package:gql/ast.dart';
+import 'package:normalize/src/utils/constants.dart';
 
 import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/policies/type_policy.dart';
@@ -37,7 +38,7 @@ void normalizeFragment({
   Map<String, TypePolicy> typePolicies = const {},
   DataIdResolver? dataIdFromObject,
   bool addTypename = false,
-  String referenceKey = '\$ref',
+  String referenceKey = kDefaultReferenceKey,
   bool acceptPartialData = true,
   Map<String, Set<String>> possibleTypes = const {},
 }) {

--- a/packages/normalize/lib/src/normalize_node.dart
+++ b/packages/normalize/lib/src/normalize_node.dart
@@ -112,6 +112,8 @@ Object? normalizeNode({
       })
     };
 
+    if (dataId != null) existingNormalizedData = config.read(dataId);
+
     final mergedData = deepMerge(
       Map.from(existingNormalizedData as Map<dynamic, dynamic>? ?? {}),
       dataToMerge,

--- a/packages/normalize/lib/src/utils/constants.dart
+++ b/packages/normalize/lib/src/utils/constants.dart
@@ -1,0 +1,1 @@
+const kDefaultReferenceKey = '\$ref';

--- a/packages/normalize/lib/src/utils/get_fragment_map.dart
+++ b/packages/normalize/lib/src/utils/get_fragment_map.dart
@@ -5,3 +5,27 @@ Map<String, FragmentDefinitionNode> getFragmentMap(DocumentNode document) => {
           in document.definitions.whereType<FragmentDefinitionNode>())
         fragmentDefinition.name.value: fragmentDefinition
     };
+
+FragmentDefinitionNode findFragmentInFragmentMap({
+  required Map<String, FragmentDefinitionNode> fragmentMap,
+  String? fragmentName,
+}) {
+  if (fragmentName == null) {
+    if (fragmentMap.isEmpty) {
+      throw Exception('Found no fragment definitions in document.');
+    }
+    if (fragmentMap.length > 1) {
+      throw Exception(
+        'Multiple fragments defined, but no fragmentName provided',
+      );
+    }
+    return fragmentMap.values.first;
+  }
+  final lookupFragment = fragmentMap[fragmentName];
+  if (lookupFragment == null) {
+    throw Exception(
+      'Fragment "$fragmentName" not found',
+    );
+  }
+  return lookupFragment;
+}

--- a/packages/normalize/lib/src/utils/identify.dart
+++ b/packages/normalize/lib/src/utils/identify.dart
@@ -1,10 +1,11 @@
 import 'package:normalize/src/policies/type_policy.dart';
 import './resolve_data_id.dart';
+import 'constants.dart';
 
 /// Returns the canonical ID for a given object or reference.
 String? identify(
   Map data, {
-  String referenceKey = '\$ref',
+  String referenceKey = kDefaultReferenceKey,
   Map<String, TypePolicy> typePolicies = const {},
   DataIdResolver? dataIdFromObject,
 }) =>

--- a/packages/normalize/lib/src/utils/reachable_ids.dart
+++ b/packages/normalize/lib/src/utils/reachable_ids.dart
@@ -1,11 +1,13 @@
 import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/resolve_root_typename.dart';
 
+import 'constants.dart';
+
 /// Returns a set of dataIds that can be reached by any root query.
 Set<String> reachableIds(
   Map<String, dynamic>? Function(String dataId) read, [
   Map<String, TypePolicy> typePolicies = const {},
-  String referenceKey = '\$ref',
+  String referenceKey = kDefaultReferenceKey,
 ]) =>
     defaultRootTypenames.keys
         .map(
@@ -34,7 +36,7 @@ Set<String> reachableIds(
 Set<String> reachableIdsFromDataId(
   String dataId,
   Map<String, dynamic>? Function(String dataId) read, [
-  String referenceKey = '\$ref',
+  String referenceKey = kDefaultReferenceKey,
 ]) =>
     _idsInObject(read(dataId), read, referenceKey, {})..add(dataId);
 

--- a/packages/normalize/lib/src/utils/resolve_data_id.dart
+++ b/packages/normalize/lib/src/utils/resolve_data_id.dart
@@ -1,6 +1,8 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:normalize/utils.dart';
+
 import '../policies/type_policy.dart';
 import './exceptions.dart';
 
@@ -22,12 +24,12 @@ String? resolveDataId({
   if (typename == null) return null;
 
   final typePolicy = typePolicies[typename];
-
-  if (typePolicy?.keyFields != null) {
-    if (typePolicy!.keyFields!.isEmpty) return null;
+  final keyFields = typePolicy?.keyFields;
+  if (keyFields != null) {
+    if (keyFields.isEmpty) return null;
 
     try {
-      final fields = keyFieldsWithArgs(typePolicy.keyFields!, data);
+      final fields = keyFieldsWithArgs(keyFields, data);
       return '$typename:${json.encode(fields)}';
     } on MissingKeyFieldException {
       return null;
@@ -35,6 +37,10 @@ String? resolveDataId({
   }
 
   if (dataIdFromObject != null) return dataIdFromObject(data);
+
+  if (allRootTypenames(typePolicies).contains(typename)) {
+    return typename;
+  }
 
   final id = data['id'] ?? data['_id'];
   return id == null ? null : '$typename:$id';

--- a/packages/normalize/lib/src/utils/resolve_root_typename.dart
+++ b/packages/normalize/lib/src/utils/resolve_root_typename.dart
@@ -37,6 +37,17 @@ String typenameForOperationType(
   }
 }
 
+Set<String> allRootTypenames(Map<String, TypePolicy> typePolicies) {
+  return {
+    ...OperationType.values.map(
+      (operationType) => typenameForOperationType(
+        operationType,
+        typePolicies,
+      ),
+    )
+  };
+}
+
 String resolveRootTypename(
   OperationDefinitionNode operationDefinition,
   Map<String, TypePolicy> typePolicies,

--- a/packages/normalize/test/root_type_test.dart
+++ b/packages/normalize/test/root_type_test.dart
@@ -1,0 +1,123 @@
+import 'package:normalize/utils.dart';
+import 'package:test/test.dart';
+import 'package:gql/language.dart';
+
+import 'package:normalize/normalize.dart';
+
+void main() {
+  group('Root Fragments', () {
+    final query = parseString('''
+      fragment AuthorFragment on Query {
+        __typename
+        person {
+          __typename
+          id
+          name
+          age
+        }
+      }
+    ''');
+    final normalizedData = {
+      'Person:1': {'__typename': 'Person', 'id': 1, 'name': 'Bob', 'age': null},
+      'Query': {
+        '__typename': 'Query',
+        'person': {r'$ref': 'Person:1'}
+      }
+    };
+    final data = {
+      '__typename': 'Query',
+      'person': {
+        'id': 1,
+        '__typename': 'Person',
+        'name': 'Bob',
+        'age': null,
+      }
+    };
+    test('Produces correct normalized object', () {
+      final normalizedResult = {};
+      normalizeFragment(
+        read: (dataId) => normalizedResult[dataId],
+        write: (dataId, value) => normalizedResult[dataId] = value,
+        document: query,
+        data: data,
+        possibleTypes: {
+          'Person': {'Author'}
+        },
+        idFields: {},
+      );
+
+      expect(
+        normalizedResult,
+        equals(normalizedData),
+      );
+    });
+    test('Produces correct denormalized object', () {
+      final result = denormalizeFragment(
+        read: (dataId) => normalizedData[dataId],
+        document: query,
+        possibleTypes: {
+          'Person': {'Author'}
+        },
+        idFields: {},
+      );
+
+      expect(
+        result,
+        equals(data),
+      );
+    });
+    test('Validate Fragment', () {
+      validateFragmentDataStructure(document: query, data: data);
+    });
+  });
+
+  group('Nested root types', () {
+    final document = parseString('''
+          query Q {
+            __typename
+            name
+            q {
+              __typename
+              age
+            }
+          }
+
+        ''');
+    final data = {
+      '__typename': 'Query',
+      'name': 'Bob',
+      'q': {'__typename': 'Query', 'age': 31}
+    };
+    final normalizedData = {
+      'Query': {
+        '__typename': 'Query',
+        'q': {r'$ref': 'Query'},
+        'name': 'Bob',
+        'age': 31
+      }
+    };
+    test('Normalizes nested root types', () {
+      final normalized = {};
+      normalizeOperation(
+        write: (key, data) {
+          normalized[key] = data;
+        },
+        read: (key) => normalized[key],
+        document: document,
+        data: data,
+      );
+      expect(normalized, equals(normalizedData));
+    });
+    test('Denormalizes nested root types', () {
+      expect(
+          denormalizeOperation(
+            read: (key) => normalizedData[key],
+            document: document,
+          ),
+          equals(data));
+    });
+    test('Validate Query', () {
+      validateOperationDataStructure(document: document, data: data);
+    });
+  });
+}


### PR DESCRIPTION
This PR streamlines how `dataId`'s are resolved throughout the normalization. Right now operation types are handled specially for operations, but not for fragments, or nested fields with the same type.

Assume we have the schema

```graphql
type Query {
  query: Query
  name: String
}
```

then normalizing the fragment

```graphql
fragment F on Query {
  __typename
  name
}
```
will throw an error unless a custom `dataIdFromObject` is specified. This while the above can be normalized just as easily as

```graphql
query Q {
  __typename
  name
}
```

Furthermore, this problem is also present with fields having the operation type as their type. Take the query

```graphql
Mutation Q2 {
  __typename
  q { name __typename }
}
```

normalizing this should yield

```json
{"query": {"__typename": "Query", "name": "Bob", "q": {"$ref": "Query"} }}
```

but it will yield

```json
{"query": {"__typename": "Query", "q": {"__typename": "Query", "name": "Bob"} }}
```

I.e., we're missing out on updating the cache correctly. Returning `Query` from e.g. a mutation can be a nifty way to allow advanced cache updates.

Finally, this PR fixes a bug where nested objects within themselves will not be normalized correctly. 

**NOTICE, THIS CHANGE IS BREAKING**: All users providing `dataIdFromObject` will have to handle operation types appropriately.