### PR TITLE
fix: Preserve backwards compatibility

### DIFF
--- a/packages/normalize/lib/src/denormalize_operation.dart
+++ b/packages/normalize/lib/src/denormalize_operation.dart
@@ -43,16 +43,11 @@ Map<String, dynamic>? denormalizeOperation({
 
   final rootTypeName = resolveRootTypename(operationDefinition, typePolicies);
   final dataId = resolveDataId(
-    data: {'__typename': rootTypeName},
-    typePolicies: typePolicies,
-    dataIdFromObject: dataIdFromObject,
-  );
-
-  if (dataId == null) {
-    throw Exception(
-      'Unable to resolve data ID for type $rootTypeName. Please ensure that you are handling operation types appropriatelya',
-    );
-  }
+        data: {'__typename': rootTypeName},
+        typePolicies: typePolicies,
+        dataIdFromObject: dataIdFromObject,
+      ) ??
+      rootTypeName;
 
   final config = NormalizationConfig(
     read: read,

--- a/packages/normalize/lib/src/normalize_operation.dart
+++ b/packages/normalize/lib/src/normalize_operation.dart
@@ -49,19 +49,15 @@ void normalizeOperation({
   final rootTypeName = resolveRootTypename(operationDefinition, typePolicies);
 
   final dataId = resolveDataId(
-    data: {
-      '__typename': rootTypeName,
-      ...data,
-    },
-    typePolicies: typePolicies,
-    dataIdFromObject: dataIdFromObject,
-  );
+        data: {
+          '__typename': rootTypeName,
+          ...data,
+        },
+        typePolicies: typePolicies,
+        dataIdFromObject: dataIdFromObject,
+      ) ??
+      rootTypeName;
 
-  if (dataId == null) {
-    throw Exception(
-      'Unable to resolve data ID for type $rootTypeName. Please ensure that you are handling operation types appropriatelya',
-    );
-  }
   final config = NormalizationConfig(
     read: read,
     variables: variables,


### PR DESCRIPTION
This change will ensure backward compatibility by defaulting the typename to the `rootTypeName` when we can't resolve the data ID for a root object. 

After some consideration, I believe this is a better implementation. We HAVE to write the root objects otherwise no nested objects will be saved.

This, I believe, also means that we can release this as a minor change.