### PR TITLE
fix: Use Posix separators for output paths

### DIFF
--- a/packages/ferry_generator/lib/src/utils/locations.dart
+++ b/packages/ferry_generator/lib/src/utils/locations.dart
@@ -7,7 +7,7 @@ String outputPath(
 ) {
   final pathSegments = p.url.split(inputPath);
   pathSegments.insert(pathSegments.length - 1, outputDir);
-  return p.joinAll(pathSegments);
+  return p.posix.joinAll(pathSegments);
 }
 
 AssetId outputAssetId(


### PR DESCRIPTION
This solves the problem that on Windows the import paths are created with backslash, which makes the import corrupt.

Solution is from @axrs, see https://github.com/gql-dart/ferry/issues/298#issuecomment-1009613691.

This closes #298 and closes #316.

To use it add the following to `pubspec.yaml`:
```yaml
dependencies:
  ferry_generator:
    git:
      url: https://github.com/friebetill/ferry.git
      path: packages/ferry_generator/

dependency_overrides:
  ferry_generator:
    git:
      url: https://github.com/friebetill/ferry.git
      path: packages/ferry_generator/
```