### PR TITLE
fix: add possibleTypes to every function that can use it of normalize

### DIFF
--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -86,6 +86,7 @@ class Cache {
           typePolicies,
           addTypename,
           dataIdFromObject,
+          possibleTypes,
         ),
         getData: () => readFragment(request, optimistic: optimistic),
       );
@@ -137,6 +138,7 @@ class Cache {
       variables: (request.vars as dynamic)?.toJson(),
       typePolicies: typePolicies,
       dataIdFromObject: dataIdFromObject,
+      possibleTypes: possibleTypes,
     );
     return json == null ? null : request.parseData(json);
   }
@@ -156,6 +158,7 @@ class Cache {
       typePolicies: typePolicies,
       addTypename: addTypename,
       dataIdFromObject: dataIdFromObject,
+      possibleTypes: possibleTypes,
     );
     return json == null ? null : request.parseData(json);
   }
@@ -187,6 +190,7 @@ class Cache {
         typePolicies: typePolicies,
         addTypename: addTypename,
         dataIdFromObject: dataIdFromObject,
+        possibleTypes: possibleTypes,
       );
 
   /// Normalizes [data] for the given fragment and writes it to the [Store].
@@ -217,6 +221,7 @@ class Cache {
         typePolicies: typePolicies,
         addTypename: addTypename,
         dataIdFromObject: dataIdFromObject,
+        possibleTypes: possibleTypes,
       );
 
   void _writeData(

--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -19,6 +19,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
   Map<String, TypePolicy> typePolicies,
   bool addTypename,
   DataIdResolver? dataIdFromObject,
+    Map<String, Set<String>> possibleTypes,
 ) {
   final dataIds = <String>{};
 
@@ -36,6 +37,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
     addTypename: addTypename,
     returnPartialData: true,
     dataIdFromObject: dataIdFromObject,
+    possibleTypes: possibleTypes,
   );
 
   /// IDs that have changed

--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -19,7 +19,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
   Map<String, TypePolicy> typePolicies,
   bool addTypename,
   DataIdResolver? dataIdFromObject,
-    Map<String, Set<String>> possibleTypes,
+  Map<String, Set<String>> possibleTypes,
 ) {
   final dataIds = <String>{};
 

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -34,20 +34,19 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
   final dataIds = <String>{};
 
   denormalizeOperation(
-    read: (dataId) {
-      dataIds.add(dataId);
-      return optimistic ? optimisticReader(dataId) : store.get(dataId);
-    },
-    document: request.operation.document,
-    operationName: request.operation.operationName,
-    // TODO: don't cast to dynamic
-    variables: (request.vars as dynamic)?.toJson(),
-    typePolicies: typePolicies,
-    addTypename: addTypename,
-    returnPartialData: true,
-    dataIdFromObject: dataIdFromObject,
-    possibleTypes: possibleTypes
-  );
+      read: (dataId) {
+        dataIds.add(dataId);
+        return optimistic ? optimisticReader(dataId) : store.get(dataId);
+      },
+      document: request.operation.document,
+      operationName: request.operation.operationName,
+      // TODO: don't cast to dynamic
+      variables: (request.vars as dynamic)?.toJson(),
+      typePolicies: typePolicies,
+      addTypename: addTypename,
+      returnPartialData: true,
+      dataIdFromObject: dataIdFromObject,
+      possibleTypes: possibleTypes);
 
   /// IDs that have changed
   final changed = <String>{};

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -46,6 +46,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
     addTypename: addTypename,
     returnPartialData: true,
     dataIdFromObject: dataIdFromObject,
+    possibleTypes: possibleTypes
   );
 
   /// IDs that have changed

--- a/packages/ferry_cache/test/test/data_change_streams_test.dart
+++ b/packages/ferry_cache/test/test/data_change_streams_test.dart
@@ -329,15 +329,15 @@ void main() {
     group('fragmentDataChangeStream', () {
       test("doesn't trigger before a change", () async {
         final stream = fragmentDataChangeStream(
-          lukeFragment,
-          true,
-          cache.optimisticPatchesStream,
-          cache.optimisticReader,
-          cache.store,
-          {},
-          true,
-          null,
-        );
+            lukeFragment,
+            true,
+            cache.optimisticPatchesStream,
+            cache.optimisticReader,
+            cache.store,
+            {},
+            true,
+            null,
+            {});
 
         expect(
           stream,
@@ -350,15 +350,15 @@ void main() {
 
       test("doesn't trigger with the same data", () async {
         final stream = fragmentDataChangeStream(
-          lukeFragment,
-          true,
-          cache.optimisticPatchesStream,
-          cache.optimisticReader,
-          cache.store,
-          {},
-          true,
-          null,
-        );
+            lukeFragment,
+            true,
+            cache.optimisticPatchesStream,
+            cache.optimisticReader,
+            cache.store,
+            {},
+            true,
+            null,
+            {});
 
         expect(stream, emitsInOrder([emitsDone]));
 
@@ -371,15 +371,15 @@ void main() {
 
       test('triggers with different data', () async {
         final stream = fragmentDataChangeStream(
-          lukeFragment,
-          true,
-          cache.optimisticPatchesStream,
-          cache.optimisticReader,
-          cache.store,
-          {},
-          true,
-          null,
-        );
+            lukeFragment,
+            true,
+            cache.optimisticPatchesStream,
+            cache.optimisticReader,
+            cache.store,
+            {},
+            true,
+            null,
+            {});
 
         expect(
           stream,
@@ -402,15 +402,15 @@ void main() {
       test('triggers with change to dependent reference', () async {
         final hanFrag = GheroDataReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
-          hanFrag,
-          true,
-          cache.optimisticPatchesStream,
-          cache.optimisticReader,
-          cache.store,
-          {},
-          true,
-          null,
-        );
+            hanFrag,
+            true,
+            cache.optimisticPatchesStream,
+            cache.optimisticReader,
+            cache.store,
+            {},
+            true,
+            null,
+            {});
 
         expect(
           stream,


### PR DESCRIPTION
normalize now requires possibleTypes in order to deal with fragments, unions, and interfaces. 

these possibleTypes were not correctly passed from the cache to normalize in some scenarios.