### PR TITLE
refactor(store): Make the Store async.

### DIFF
--- a/packages/ferry/lib/src/fetch_policy_typed_link.dart
+++ b/packages/ferry/lib/src/fetch_policy_typed_link.dart
@@ -1,18 +1,16 @@
 import 'dart:async';
-import 'package:gql_link/gql_link.dart';
-import 'package:rxdart/rxdart.dart';
-import 'package:normalize/utils.dart';
-import 'package:gql/ast.dart';
-import 'package:ferry_cache/ferry_cache.dart';
-import 'package:ferry_exec/ferry_exec.dart';
 
-import 'package:ferry/src/optimistic_typed_link.dart';
-import 'package:ferry/src/gql_typed_link.dart';
 import 'package:ferry/src/cache_typed_link.dart';
+import 'package:ferry/src/gql_typed_link.dart';
+import 'package:ferry/src/optimistic_typed_link.dart';
+import 'package:ferry_exec/ferry_exec.dart';
+import 'package:gql/ast.dart';
+import 'package:normalize/utils.dart';
+import 'package:rxdart/rxdart.dart';
 
 export 'package:ferry_cache/ferry_cache.dart';
-export 'package:gql_link/gql_link.dart';
 export 'package:ferry_exec/ferry_exec.dart';
+export 'package:gql_link/gql_link.dart';
 
 const _defaultFetchPolicies = {
   OperationType.query: FetchPolicy.CacheFirst,
@@ -134,11 +132,11 @@ class FetchPolicyTypedLink extends TypedLink {
   }
 
   /// Writes data from [OperationResponse] to the cache.
-  void _writeToCache<TData, TVars>(
+  Future<void> _writeToCache<TData, TVars>(
     OperationResponse<TData, TVars> response,
-  ) {
+  ) async {
     if (response.data != null) {
-      cache.writeQuery(
+      await cache.writeQuery(
         response.operationRequest,
         response.data,
         optimisticRequest: response.dataSource == DataSource.Optimistic

--- a/packages/ferry/lib/src/update_cache_typed_link.dart
+++ b/packages/ferry/lib/src/update_cache_typed_link.dart
@@ -116,7 +116,8 @@ class UpdateCacheTypedLink extends TypedLink {
   ]) =>
       forward!(req).doOnData(_updateCache);
 
-  Future<void> _updateCache<TData, TVars>(OperationResponse<TData, TVars> res) async {
+  Future<void> _updateCache<TData, TVars>(
+      OperationResponse<TData, TVars> res) async {
     final key = res.operationRequest.updateCacheHandlerKey;
     if (key == null) return;
 

--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -40,18 +40,19 @@ class Cache {
   /// Reads data for the given [dataId] from the [Store], merging in any data from optimistic patches
   @visibleForTesting
   Future<Map<String, dynamic>?> optimisticReader(String dataId) async =>
-      (await optimisticPatchesStream.value!.values.fold<Future<Map<String, dynamic>>>(
+      (await optimisticPatchesStream.value!.values
+          .fold<Future<Map<String, dynamic>>>(
         Future.value({dataId: await store.get(dataId)}),
         (merged, patch) async {
           final toMerge = await merged;
           return patch.containsKey(dataId)
-            ? Map.from(
-                utils.deepMerge(
-                  toMerge,
-                  {dataId: patch[dataId]},
-                ),
-              )
-            : toMerge;
+              ? Map.from(
+                  utils.deepMerge(
+                    toMerge,
+                    {dataId: patch[dataId]},
+                  ),
+                )
+              : toMerge;
         },
       ))[dataId];
 

--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -1,29 +1,28 @@
-import 'package:normalize/policies.dart';
-import 'package:normalize/normalize.dart';
 import 'package:collection/collection.dart';
+import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:normalize/normalize.dart';
 import 'package:normalize/utils.dart';
 import 'package:rxdart/rxdart.dart';
 
-import 'package:ferry_exec/ferry_exec.dart';
 import './utils/data_for_id_stream.dart';
 
 /// Emits when the data for this fragment changes, returning a `Set` of changed IDs.
-Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
+Future<Stream<Set<String>>> fragmentDataChangeStream<TData, TVars>(
   FragmentRequest<TData, TVars> request,
   bool optimistic,
   Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
       optimisticPatchesStream,
-  Map<String, dynamic>? Function(String dataId) optimisticReader,
+  Future<Map<String, dynamic>?> Function(String dataId) optimisticReader,
   Store store,
   Map<String, TypePolicy> typePolicies,
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
-) {
+) async {
   final dataIds = <String>{};
 
-  denormalizeFragment(
+  await denormalizeFragment(
     read: (dataId) {
       dataIds.add(dataId);
       return optimistic ? optimisticReader(dataId) : store.get(dataId);
@@ -72,6 +71,6 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
     },
   )
 
-      /// Skip the first result since this returns the existsing data
+      /// Skip the first result since this returns the existing data
       .skip(1);
 }

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -1,27 +1,26 @@
-import 'package:normalize/policies.dart';
-import 'package:normalize/utils.dart';
-import 'package:normalize/normalize.dart';
 import 'package:collection/collection.dart';
+import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:normalize/normalize.dart';
+import 'package:normalize/utils.dart';
 import 'package:rxdart/rxdart.dart';
 
-import 'package:ferry_exec/ferry_exec.dart';
 import './utils/data_for_id_stream.dart';
 import './utils/operation_root_data.dart';
 
 /// Emits when the data for this request changes, returning a `Set` of changed IDs.
-Stream<Set<String>> operationDataChangeStream<TData, TVars>(
+Future<Stream<Set<String>>> operationDataChangeStream<TData, TVars>(
   OperationRequest<TData, TVars> request,
   bool optimistic,
   Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
       optimisticPatchesStream,
-  Map<String, dynamic>? Function(String dataId) optimisticReader,
+  Future<Map<String, dynamic>?> Function(String dataId) optimisticReader,
   Store store,
   Map<String, TypePolicy> typePolicies,
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
-) {
+) async {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
     request.operation.operationName,
@@ -33,7 +32,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
 
   final dataIds = <String>{};
 
-  denormalizeOperation(
+  await denormalizeOperation(
       read: (dataId) {
         dataIds.add(dataId);
         return optimistic ? optimisticReader(dataId) : store.get(dataId);
@@ -92,6 +91,6 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
     },
   )
 
-      /// Skip the first result since this returns the existsing data
+      /// Skip the first result since this returns the existing data
       .skip(1);
 }

--- a/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
+++ b/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
@@ -1,7 +1,6 @@
+import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
 import 'package:rxdart/rxdart.dart';
-
-import 'package:ferry_exec/ferry_exec.dart';
 
 /// Returns the normalized data for the given [dataId], optionally merging optimistic data.
 Stream<Map<String, dynamic>?> dataForIdStream(
@@ -10,16 +9,16 @@ Stream<Map<String, dynamic>?> dataForIdStream(
   bool optimistic,
   Stream<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
       optimisticPatchesStream,
-  Map<String, dynamic>? Function(String dataId) optimisticReader,
+  Future<Map<String, dynamic>?> Function(String dataId) optimisticReader,
 ) =>
     optimistic
         ? CombineLatestStream.combine2<
             Map<String, dynamic>?,
             Map<OperationRequest<dynamic, dynamic>,
                 Map<String, Map<String, dynamic>?>>?,
-            Map<String, dynamic>?>(
+            Future<Map<String, dynamic>?>>(
             store.watch(dataId),
             optimisticPatchesStream,
             (_, __) => optimisticReader(dataId),
-          )
+          ).asyncMap((event) => event)
         : store.watch(dataId);

--- a/packages/ferry_cache/test/eviction_test.dart
+++ b/packages/ferry_cache/test/eviction_test.dart
@@ -68,12 +68,20 @@ void main() {
       final cache = Cache();
       await cache.writeQuery(hanReq, hanData);
       expect(
-        (await cache.readQuery(hanReq))!.human.friendsConnection.friends!.length,
+        (await cache.readQuery(hanReq))!
+            .human
+            .friendsConnection
+            .friends!
+            .length,
         equals(2),
       );
       await cache.evict(cache.identify(chewieData.human)!);
       expect(
-        (await cache.readQuery(hanReq))!.human.friendsConnection.friends!.length,
+        (await cache.readQuery(hanReq))!
+            .human
+            .friendsConnection
+            .friends!
+            .length,
         equals(1),
       );
     });
@@ -103,7 +111,8 @@ void main() {
         optimisticResult,
         equals(hanData.rebuild((b) => b..human.height = null)),
       );
-      final nonOptimisticResult = await cache.readQuery(hanReq, optimistic: false);
+      final nonOptimisticResult =
+          await cache.readQuery(hanReq, optimistic: false);
       expect(
         nonOptimisticResult,
         equals(hanData),

--- a/packages/ferry_cache/test/eviction_test.dart
+++ b/packages/ferry_cache/test/eviction_test.dart
@@ -1,10 +1,8 @@
-import 'package:test/test.dart';
-import 'package:normalize/src/utils/field_key.dart';
-
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_test_graphql/queries/__generated__/human_with_args.data.gql.dart';
 import 'package:ferry_test_graphql/queries/__generated__/human_with_args.req.gql.dart';
-
-import 'package:ferry_cache/ferry_cache.dart';
+import 'package:normalize/src/utils/field_key.dart';
+import 'package:test/test.dart';
 
 void main() {
   final chewieReq = GHumanWithArgsReq((b) => b..vars.id = 'chewie');
@@ -40,85 +38,85 @@ void main() {
       ]),
   );
   group('Evicting entities', () {
-    test('can evict entities', () {
+    test('can evict entities', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
-      cache.writeQuery(chewieReq, chewieData);
-      expect(cache.readQuery(hanReq), equals(hanData));
+      await cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(chewieReq, chewieData);
+      expect(await cache.readQuery(hanReq), equals(hanData));
       final entityId = cache.identify(hanData.human)!;
-      cache.evict(entityId);
-      expect(cache.readQuery(hanReq), equals(null));
-      expect(cache.store.get(entityId), equals(null));
-      expect(cache.readQuery(chewieReq), equals(chewieData));
+      await cache.evict(entityId);
+      expect(await cache.readQuery(hanReq), equals(null));
+      expect(await cache.store.get(entityId), equals(null));
+      expect(await cache.readQuery(chewieReq), equals(chewieData));
     });
 
-    test('can evict entities optimistically', () {
+    test('can evict entities optimistically', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
-      expect(cache.readQuery(hanReq), equals(hanData));
+      await cache.writeQuery(hanReq, hanData);
+      expect(await cache.readQuery(hanReq), equals(hanData));
       final entityId = cache.identify(hanData.human)!;
-      cache.evict(
+      await cache.evict(
         entityId,
         optimisticRequest: hanReq,
       );
-      expect(cache.readQuery(hanReq, optimistic: true), equals(null));
-      expect(cache.readQuery(hanReq, optimistic: false), equals(hanData));
-      expect(cache.store.get(entityId), isNotNull);
+      expect(await cache.readQuery(hanReq, optimistic: true), equals(null));
+      expect(await cache.readQuery(hanReq, optimistic: false), equals(hanData));
+      expect(await cache.store.get(entityId), isNotNull);
     });
 
-    test('can filter out dangling references', () {
+    test('can filter out dangling references', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(hanReq, hanData);
       expect(
-        cache.readQuery(hanReq)!.human.friendsConnection.friends!.length,
+        (await cache.readQuery(hanReq))!.human.friendsConnection.friends!.length,
         equals(2),
       );
-      cache.evict(cache.identify(chewieData.human)!);
+      await cache.evict(cache.identify(chewieData.human)!);
       expect(
-        cache.readQuery(hanReq)!.human.friendsConnection.friends!.length,
+        (await cache.readQuery(hanReq))!.human.friendsConnection.friends!.length,
         equals(1),
       );
     });
   });
 
   group('Evicting fields', () {
-    test('can evict fields', () {
+    test('can evict fields', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(hanReq, hanData);
       final entityId = cache.identify(hanData.human)!;
-      cache.evict(entityId, fieldName: 'height');
-      final result = cache.readQuery(hanReq);
+      await cache.evict(entityId, fieldName: 'height');
+      final result = await cache.readQuery(hanReq);
       expect(result, equals(hanData.rebuild((b) => b..human.height = null)));
     });
 
-    test('can evict fields optimistically', () {
+    test('can evict fields optimistically', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(hanReq, hanData);
       final entityId = cache.identify(hanData.human)!;
-      cache.evict(
+      await cache.evict(
         entityId,
         fieldName: 'height',
         optimisticRequest: hanReq,
       );
-      final optimisticResult = cache.readQuery(hanReq, optimistic: true);
+      final optimisticResult = await cache.readQuery(hanReq, optimistic: true);
       expect(
         optimisticResult,
         equals(hanData.rebuild((b) => b..human.height = null)),
       );
-      final nonOptimisticResult = cache.readQuery(hanReq, optimistic: false);
+      final nonOptimisticResult = await cache.readQuery(hanReq, optimistic: false);
       expect(
         nonOptimisticResult,
         equals(hanData),
       );
     });
 
-    test('can evict only fields that include specific args', () {
+    test('can evict only fields that include specific args', () async {
       final cache = Cache();
-      cache.writeQuery(
+      await cache.writeQuery(
         hanReq.rebuild((b) => b..vars.friendsAfter = 'luke'),
         hanData,
       );
-      cache.writeQuery(
+      await cache.writeQuery(
         hanReq.rebuild((b) => b..vars.friendsAfter = 'chewie'),
         hanData,
       );
@@ -127,47 +125,49 @@ void main() {
           FieldKey.from('friendsConnection', {'first': 10, 'after': 'luke'});
       final keyChewie =
           FieldKey.from('friendsConnection', {'first': 10, 'after': 'chewie'});
-      expect(cache.store.get(entityId)![keyLuke.toString()], isNotNull);
-      expect(cache.store.get(entityId)![keyChewie.toString()], isNotNull);
-      cache.evict(entityId,
+      var entity = (await cache.store.get(entityId))!;
+      expect(entity[keyLuke.toString()], isNotNull);
+      expect(entity[keyChewie.toString()], isNotNull);
+      await cache.evict(entityId,
           fieldName: 'friendsConnection', args: {'after': 'luke'});
-      expect(cache.store.get(entityId)![keyLuke.toString()], isNull);
-      expect(cache.store.get(entityId)![keyChewie.toString()], isNotNull);
+      entity = (await cache.store.get(entityId))!;
+      expect(entity[keyLuke.toString()], isNull);
+      expect(entity[keyChewie.toString()], isNotNull);
     });
   });
 
   group('Garbage collection', () {
-    test('can remove orphaned entities', () {
+    test('can remove orphaned entities', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
-      cache.writeQuery(
+      await cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(
         hanReq,
         hanData.rebuild((b) => b..human.friendsConnection.friends.removeLast()),
       );
-      expect(cache.store.get('Human:luke'), isNotNull);
-      expect(cache.store.get('Human:chewie'), isNotNull);
-      cache.gc();
-      expect(cache.store.get('Human:luke'), isNotNull);
-      expect(cache.store.get('Human:chewie'), isNull);
+      expect(await cache.store.get('Human:luke'), isNotNull);
+      expect(await cache.store.get('Human:chewie'), isNotNull);
+      await cache.gc();
+      expect(await cache.store.get('Human:luke'), isNotNull);
+      expect(await cache.store.get('Human:chewie'), isNull);
     });
 
-    test('can retain and release entities', () {
+    test('can retain and release entities', () async {
       final cache = Cache();
-      cache.writeQuery(hanReq, hanData);
-      cache.writeQuery(
+      await cache.writeQuery(hanReq, hanData);
+      await cache.writeQuery(
         hanReq,
         hanData.rebuild((b) => b..human.friendsConnection.friends.removeLast()),
       );
-      expect(cache.store.get('Human:luke'), isNotNull);
-      expect(cache.store.get('Human:chewie'), isNotNull);
+      expect(await cache.store.get('Human:luke'), isNotNull);
+      expect(await cache.store.get('Human:chewie'), isNotNull);
       cache.retain('Human:chewie');
-      cache.gc();
-      expect(cache.store.get('Human:luke'), isNotNull);
-      expect(cache.store.get('Human:chewie'), isNotNull);
+      await cache.gc();
+      expect(await cache.store.get('Human:luke'), isNotNull);
+      expect(await cache.store.get('Human:chewie'), isNotNull);
       cache.release('Human:chewie');
-      cache.gc();
-      expect(cache.store.get('Human:luke'), isNotNull);
-      expect(cache.store.get('Human:chewie'), isNull);
+      await cache.gc();
+      expect(await cache.store.get('Human:luke'), isNotNull);
+      expect(await cache.store.get('Human:chewie'), isNull);
     });
   });
 }

--- a/packages/ferry_cache/test/optimism_test.dart
+++ b/packages/ferry_cache/test/optimism_test.dart
@@ -1,9 +1,8 @@
 import 'package:ferry_cache/ferry_cache.dart';
-import 'package:test/test.dart';
-
-import 'package:ferry_test_graphql/mutations/__generated__/create_review.req.gql.dart';
 import 'package:ferry_test_graphql/mutations/__generated__/create_review.data.gql.dart';
+import 'package:ferry_test_graphql/mutations/__generated__/create_review.req.gql.dart';
 import 'package:ferry_test_graphql/schema/__generated__/schema.schema.gql.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Optimism', () {
@@ -40,22 +39,24 @@ void main() {
     group('single optimistic write', () {
       final store = MemoryStore();
       final cache = Cache(store: store);
-      cache.writeQuery(
-        mutation1,
-        mutation1data,
-        optimisticRequest: mutation1,
-      );
+      setUpAll(() async {
+        await cache.writeQuery(
+          mutation1,
+          mutation1data,
+          optimisticRequest: mutation1,
+        );
+      });
 
-      test('data exists optimistically', () {
+      test('data exists optimistically', () async {
         expect(
-          cache.readQuery(mutation1, optimistic: true),
+          await cache.readQuery(mutation1, optimistic: true),
           equals(mutation1data),
         );
       });
 
-      test("data doesn't exist non-optimistically", () {
+      test("data doesn't exist non-optimistically", () async {
         expect(
-          cache.readQuery(mutation1, optimistic: false),
+          await cache.readQuery(mutation1, optimistic: false),
           equals(null),
         );
       });
@@ -68,35 +69,37 @@ void main() {
     group('multiple optimistic writes', () {
       final store = MemoryStore();
       final cache = Cache(store: store);
-      cache.writeQuery(
-        mutation1,
-        mutation1data,
-        optimisticRequest: mutation1,
-      );
+      setUpAll(() async {
+        await cache.writeQuery(
+          mutation1,
+          mutation1data,
+          optimisticRequest: mutation1,
+        );
 
-      cache.writeQuery(
-        mutation2,
-        mutation2data,
-        optimisticRequest: mutation2,
-      );
-      test('data exists optimistically', () {
+        await cache.writeQuery(
+          mutation2,
+          mutation2data,
+          optimisticRequest: mutation2,
+        );
+      });
+      test('data exists optimistically', () async {
         expect(
-          cache.readQuery(mutation1, optimistic: true),
+          await cache.readQuery(mutation1, optimistic: true),
           equals(mutation1data),
         );
         expect(
-          cache.readQuery(mutation2, optimistic: true),
+          await cache.readQuery(mutation2, optimistic: true),
           equals(mutation2data),
         );
       });
 
-      test("data doesn't exist non-optimistically", () {
+      test("data doesn't exist non-optimistically", () async {
         expect(
-          cache.readQuery(mutation1, optimistic: false),
+          await cache.readQuery(mutation1, optimistic: false),
           equals(null),
         );
         expect(
-          cache.readQuery(mutation2, optimistic: false),
+          await cache.readQuery(mutation2, optimistic: false),
           equals(null),
         );
       });
@@ -105,15 +108,15 @@ void main() {
         expect(store.keys.length, equals(0));
       });
 
-      test('can remove a single optimistic patch', () {
+      test('can remove a single optimistic patch', () async {
         cache.removeOptimisticPatch(mutation1);
 
         expect(
-          cache.readQuery(mutation1, optimistic: true),
+          await cache.readQuery(mutation1, optimistic: true),
           equals(null),
         );
         expect(
-          cache.readQuery(mutation2, optimistic: true),
+          await cache.readQuery(mutation2, optimistic: true),
           equals(mutation2data),
         );
       });

--- a/packages/ferry_cache/test/sync_operations_test.dart
+++ b/packages/ferry_cache/test/sync_operations_test.dart
@@ -1,10 +1,9 @@
-import 'package:test/test.dart';
 import 'package:ferry_cache/ferry_cache.dart';
-
-import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
-import 'package:ferry_test_graphql/queries/__generated__/reviews.data.gql.dart';
-import 'package:ferry_test_graphql/fragments/__generated__/review_fragment.req.gql.dart';
 import 'package:ferry_test_graphql/fragments/__generated__/review_fragment.data.gql.dart';
+import 'package:ferry_test_graphql/fragments/__generated__/review_fragment.req.gql.dart';
+import 'package:ferry_test_graphql/queries/__generated__/reviews.data.gql.dart';
+import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
+import 'package:test/test.dart';
 
 final reviewsReq = GReviewsReq();
 
@@ -26,50 +25,50 @@ final reviewFragmentData = GReviewFragmentData.fromJson(review.toJson());
 
 void main() {
   group('sync operations', () {
-    test('can read and write queries', () {
+    test('can read and write queries', () async {
       final cache = Cache();
-      cache.writeQuery(reviewsReq, reviewsData);
-      expect(cache.readQuery(reviewsReq), equals(reviewsData));
+      await cache.writeQuery(reviewsReq, reviewsData);
+      expect(await cache.readQuery(reviewsReq), equals(reviewsData));
     });
 
-    test('can read fragments written by queries', () {
+    test('can read fragments written by queries', () async {
       final cache = Cache();
-      cache.writeQuery(reviewsReq, reviewsData);
-      expect(cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      await cache.writeQuery(reviewsReq, reviewsData);
+      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
     });
 
-    test('can read and write fragments', () {
+    test('can read and write fragments', () async {
       final cache = Cache();
-      cache.writeFragment(reviewFragmentReq, reviewFragmentData);
-      expect(cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      await cache.writeFragment(reviewFragmentReq, reviewFragmentData);
+      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
     });
 
-    test('dataIdFromObject overrides cache.identify', () {
+    test('dataIdFromObject overrides cache.identify', () async {
       final cache = Cache(dataIdFromObject: (object) => 'OVERRIDE');
       expect(cache.identify(reviewFragmentData), equals('OVERRIDE'));
     });
 
-    test('can read and write with a data id override', () {
+    test('can read and write with a data id override', () async {
       final cache = Cache(dataIdFromObject: (object) => 'OVERRIDE');
-      cache.writeFragment(reviewFragmentReq, reviewFragmentData);
+      await cache.writeFragment(reviewFragmentReq, reviewFragmentData);
 
       reviewFragmentReq.idFields['id'] = 'OVERRIDE';
 
-      expect(cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
     });
 
-    test('can clear cache', () {
+    test('can clear cache', () async {
       final cache = Cache();
 
-      cache.writeQuery(reviewsReq, reviewsData);
+      await cache.writeQuery(reviewsReq, reviewsData);
       expect(
-        cache.readQuery(reviewsReq),
+        await cache.readQuery(reviewsReq),
         equals(reviewsData),
       );
 
       cache.clear();
       expect(
-        cache.readQuery(reviewsReq),
+        await cache.readQuery(reviewsReq),
         equals(null),
       );
     });

--- a/packages/ferry_cache/test/sync_operations_test.dart
+++ b/packages/ferry_cache/test/sync_operations_test.dart
@@ -34,13 +34,15 @@ void main() {
     test('can read fragments written by queries', () async {
       final cache = Cache();
       await cache.writeQuery(reviewsReq, reviewsData);
-      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      expect(await cache.readFragment(reviewFragmentReq),
+          equals(reviewFragmentData));
     });
 
     test('can read and write fragments', () async {
       final cache = Cache();
       await cache.writeFragment(reviewFragmentReq, reviewFragmentData);
-      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      expect(await cache.readFragment(reviewFragmentReq),
+          equals(reviewFragmentData));
     });
 
     test('dataIdFromObject overrides cache.identify', () async {
@@ -54,7 +56,8 @@ void main() {
 
       reviewFragmentReq.idFields['id'] = 'OVERRIDE';
 
-      expect(await cache.readFragment(reviewFragmentReq), equals(reviewFragmentData));
+      expect(await cache.readFragment(reviewFragmentReq),
+          equals(reviewFragmentData));
     });
 
     test('can clear cache', () async {

--- a/packages/ferry_cache/test/watch_test.dart
+++ b/packages/ferry_cache/test/watch_test.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:test/test.dart';
 import 'package:ferry_cache/ferry_cache.dart';
-
-import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
 import 'package:ferry_test_graphql/queries/__generated__/reviews.data.gql.dart';
+import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
+import 'package:test/test.dart';
 
 final reviewsReq = GReviewsReq();
 
@@ -21,16 +20,16 @@ final reviewsData = GReviewsData(
 
 void main() {
   group('Watch', () {
-    test('can emit null when no data exists', () {
+    test('can emit null when no data exists', () async {
       final cache = Cache();
       expect(cache.watchQuery(reviewsReq), emitsInOrder([null, emitsDone]));
-      cache.dispose();
+      await cache.dispose();
     });
 
-    test('can return data', () {
+    test('can return data', () async {
       final cache = Cache();
 
-      cache.writeQuery(reviewsReq, reviewsData);
+      await cache.writeQuery(reviewsReq, reviewsData);
 
       expect(
         cache.watchQuery(reviewsReq),
@@ -40,12 +39,12 @@ void main() {
         ]),
       );
 
-      cache.dispose();
+      await cache.dispose();
     });
 
     test('can receive updates to data', () async {
       final cache = Cache();
-      cache.writeQuery(reviewsReq, reviewsData);
+      await cache.writeQuery(reviewsReq, reviewsData);
 
       final nextData = reviewsData
           .rebuild((b) => b.reviews.add(review.rebuild((b) => b..id = '456')));
@@ -60,7 +59,7 @@ void main() {
       );
       await Future.delayed(Duration.zero);
 
-      cache.writeQuery(reviewsReq, nextData);
+      await cache.writeQuery(reviewsReq, nextData);
 
       await Future.delayed(Duration.zero);
 

--- a/packages/ferry_hive_store/lib/src/hive_store.dart
+++ b/packages/ferry_hive_store/lib/src/hive_store.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
-import 'package:rxdart/rxdart.dart';
+
 import 'package:collection/collection.dart';
-import 'package:hive/hive.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:hive/hive.dart';
+import 'package:rxdart/rxdart.dart';
 
 class HiveStore extends Store {
   final Box box;
@@ -17,35 +18,38 @@ class HiveStore extends Store {
       .watch(key: dataId)
       .map<Map<String, dynamic>?>(
           (event) => event.value == null ? null : Map.from(event.value))
-      .startWith(get(dataId))
+      .startWith(_getSync(dataId))
       .distinct(
         (prev, next) => const DeepCollectionEquality().equals(
           prev,
           next,
         ),
       );
-
-  @override
-  Map<String, dynamic>? get(String dataId) =>
+  
+  Map<String, dynamic>? _getSync(String dataId) =>
       box.get(dataId) == null ? null : Map.from(box.get(dataId));
 
   @override
-  void put(String dataId, Map<String, dynamic>? value) =>
+  Future<Map<String, dynamic>?> get(String dataId) async =>
+      box.get(dataId) == null ? null : Map.from(box.get(dataId));
+
+  @override
+  Future<void> put(String dataId, Map<String, dynamic>? value) =>
       box.put(dataId, value);
 
   @override
-  void putAll(Map<String, Map<String, dynamic>?> data) => box.putAll(data);
+  Future<void> putAll(Map<String, Map<String, dynamic>?> data) => box.putAll(data);
 
   @override
-  void delete(String dataId) => box.delete(dataId);
+  Future<void> delete(String dataId) => box.delete(dataId);
 
   @override
-  void deleteAll(Iterable<String> dataIds) => box.deleteAll(dataIds);
+  Future<void> deleteAll(Iterable<String> dataIds) => box.deleteAll(dataIds);
 
   // NOTE: we can't currently use box.clear since it isn't synchronous
   // https://github.com/hivedb/hive/issues/219
   @override
-  void clear() => box.deleteAll(keys);
+  Future<void> clear() => box.deleteAll(keys);
 
   @override
   Future<void> dispose() => box.close();

--- a/packages/ferry_hive_store/lib/src/hive_store.dart
+++ b/packages/ferry_hive_store/lib/src/hive_store.dart
@@ -25,7 +25,7 @@ class HiveStore extends Store {
           next,
         ),
       );
-  
+
   Map<String, dynamic>? _getSync(String dataId) =>
       box.get(dataId) == null ? null : Map.from(box.get(dataId));
 
@@ -38,7 +38,8 @@ class HiveStore extends Store {
       box.put(dataId, value);
 
   @override
-  Future<void> putAll(Map<String, Map<String, dynamic>?> data) => box.putAll(data);
+  Future<void> putAll(Map<String, Map<String, dynamic>?> data) =>
+      box.putAll(data);
 
   @override
   Future<void> delete(String dataId) => box.delete(dataId);

--- a/packages/ferry_hive_store/test/operations_test.dart
+++ b/packages/ferry_hive_store/test/operations_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
-import 'package:hive/hive.dart';
-
 import 'package:ferry_hive_store/ferry_hive_store.dart';
+import 'package:hive/hive.dart';
+import 'package:test/test.dart';
 
 void main() {
   Hive.init('./test/__hive_data__');
@@ -33,7 +32,7 @@ void main() {
       final store = HiveStore(box);
 
       for (var entry in data.entries) {
-        expect(store.get(entry.key), equals(entry.value));
+        expect(await store.get(entry.key), equals(entry.value));
       }
     });
 
@@ -56,7 +55,7 @@ void main() {
       final store = HiveStore(box);
 
       for (var entry in data.entries) {
-        expect(store.get(entry.key), equals(entry.value));
+        expect(await store.get(entry.key), equals(entry.value));
       }
     });
 
@@ -78,11 +77,11 @@ void main() {
       final store = HiveStore(box);
 
       for (var entry in data.entries) {
-        store.put(entry.key, entry.value);
+        await store.put(entry.key, entry.value);
       }
 
       for (var entry in data.entries) {
-        expect(store.get(entry.key), equals(entry.value));
+        expect(await store.get(entry.key), equals(entry.value));
       }
     });
 
@@ -103,10 +102,10 @@ void main() {
       await box.clear();
       final store = HiveStore(box);
 
-      store.putAll(data);
+      await store.putAll(data);
 
       for (var entry in data.entries) {
-        expect(store.get(entry.key), equals(entry.value));
+        expect(await store.get(entry.key), equals(entry.value));
       }
     });
 
@@ -130,9 +129,9 @@ void main() {
 
       final key = store.keys.first;
 
-      store.delete(key);
+      await store.delete(key);
       expect(
-        store.get(key),
+        await store.get(key),
         equals(null),
       );
     });
@@ -155,7 +154,7 @@ void main() {
       await box.putAll(data);
       final store = HiveStore(box);
 
-      store.clear();
+      await store.clear();
       expect(store.keys.length, equals(0));
     });
   });
@@ -215,7 +214,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(data.keys.first, newData);
+      await store.put(data.keys.first, newData);
     });
 
     test('changes to underlying box triggers new data', () async {
@@ -281,7 +280,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(data.keys.first, data.values.first);
+      await store.put(data.keys.first, data.values.first);
       await store.dispose();
     });
 
@@ -318,7 +317,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(newPostKey, newPostValue);
+      await store.put(newPostKey, newPostValue);
       await store.dispose();
     });
   });

--- a/packages/ferry_store/lib/src/memory_store.dart
+++ b/packages/ferry_store/lib/src/memory_store.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
-import 'package:rxdart/rxdart.dart';
+
 import 'package:collection/collection.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:rxdart/rxdart.dart';
 
 class MemoryStore extends Store {
   final BehaviorSubject<Map<String, Map<String, dynamic>?>> _valueStream;
@@ -22,31 +23,31 @@ class MemoryStore extends Store {
           );
 
   @override
-  Map<String, dynamic>? get(String dataId) => _valueStream.value[dataId];
+  Future<Map<String, dynamic>?> get(String dataId) async => _valueStream.value[dataId];
 
   @override
-  void put(String dataId, Map<String, dynamic>? value) => _valueStream.add(
+  Future<void> put(String dataId, Map<String, dynamic>? value) async => _valueStream.add(
         Map.from(_valueStream.value)..addAll({dataId: value}),
       );
 
   @override
-  void putAll(Map<String, Map<String, dynamic>?> data) => _valueStream.add(
+  Future<void> putAll(Map<String, Map<String, dynamic>?> data) async => _valueStream.add(
         Map.from(_valueStream.value)..addAll(data),
       );
 
   @override
-  void delete(String dataId) => _valueStream.add(
+  Future<void> delete(String dataId) async => _valueStream.add(
         Map.from(_valueStream.value)..remove(dataId),
       );
 
   @override
-  void deleteAll(Iterable<String> dataIds) => _valueStream.add(
+  Future<void> deleteAll(Iterable<String> dataIds) async => _valueStream.add(
         Map.from(_valueStream.value)
           ..removeWhere((key, _) => dataIds.contains(key)),
       );
 
   @override
-  void clear() => _valueStream.add({});
+  Future<void> clear() async => _valueStream.add({});
 
   @override
   Future<void> dispose() => _valueStream.close();

--- a/packages/ferry_store/lib/src/memory_store.dart
+++ b/packages/ferry_store/lib/src/memory_store.dart
@@ -23,15 +23,18 @@ class MemoryStore extends Store {
           );
 
   @override
-  Future<Map<String, dynamic>?> get(String dataId) async => _valueStream.value[dataId];
+  Future<Map<String, dynamic>?> get(String dataId) async =>
+      _valueStream.value[dataId];
 
   @override
-  Future<void> put(String dataId, Map<String, dynamic>? value) async => _valueStream.add(
+  Future<void> put(String dataId, Map<String, dynamic>? value) async =>
+      _valueStream.add(
         Map.from(_valueStream.value)..addAll({dataId: value}),
       );
 
   @override
-  Future<void> putAll(Map<String, Map<String, dynamic>?> data) async => _valueStream.add(
+  Future<void> putAll(Map<String, Map<String, dynamic>?> data) async =>
+      _valueStream.add(
         Map.from(_valueStream.value)..addAll(data),
       );
 

--- a/packages/ferry_store/lib/src/store.dart
+++ b/packages/ferry_store/lib/src/store.dart
@@ -3,17 +3,17 @@ abstract class Store {
 
   Stream<Map<String, dynamic>?> watch(String dataId);
 
-  Map<String, dynamic>? get(String dataId);
+  Future<Map<String, dynamic>?> get(String dataId);
 
-  void put(String dataId, Map<String, dynamic>? value);
+  Future<void> put(String dataId, Map<String, dynamic>? value);
 
-  void putAll(Map<String, Map<String, dynamic>?> data);
+  Future<void> putAll(Map<String, Map<String, dynamic>?> data);
 
-  void delete(String dataId);
+  Future<void> delete(String dataId);
 
-  void deleteAll(Iterable<String> dataIds);
+  Future<void> deleteAll(Iterable<String> dataIds);
 
-  void clear();
+  Future<void> clear();
 
   Future<void> dispose() async => null;
 }

--- a/packages/ferry_store/test/operations_test.dart
+++ b/packages/ferry_store/test/operations_test.dart
@@ -1,6 +1,5 @@
-import 'package:test/test.dart';
-
 import 'package:ferry_store/ferry_store.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('CRUD operations', () {
@@ -8,7 +7,7 @@ void main() {
       final store = MemoryStore();
       expect(store.keys.length, equals(0));
     });
-    test('can include seeded data', () {
+    test('can include seeded data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -24,11 +23,11 @@ void main() {
       final store = MemoryStore(data);
 
       for (var key in store.keys) {
-        expect(store.get(key), equals(data[key]));
+        expect(await store.get(key), equals(data[key]));
       }
     });
 
-    test('can get data', () {
+    test('can get data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -44,11 +43,11 @@ void main() {
       final store = MemoryStore(data);
 
       for (var entry in data.entries) {
-        expect(store.get(entry.key), equals(entry.value));
+        expect(await store.get(entry.key), equals(entry.value));
       }
     });
 
-    test('can put data', () {
+    test('can put data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -64,14 +63,14 @@ void main() {
       final store = MemoryStore();
 
       for (var entry in data.entries) {
-        store.put(entry.key, entry.value);
+        await store.put(entry.key, entry.value);
       }
       for (var key in store.keys) {
-        expect(store.get(key), equals(data[key]));
+        expect(await store.get(key), equals(data[key]));
       }
     });
 
-    test('can put all data', () {
+    test('can put all data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -86,14 +85,14 @@ void main() {
 
       final store = MemoryStore();
 
-      store.putAll(data);
+      await store.putAll(data);
 
       for (var key in store.keys) {
-        expect(store.get(key), equals(data[key]));
+        expect(await store.get(key), equals(data[key]));
       }
     });
 
-    test('can delete data', () {
+    test('can delete data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -108,14 +107,14 @@ void main() {
 
       final store = MemoryStore(data);
 
-      store.delete(data.keys.first);
+      await store.delete(data.keys.first);
       expect(
         store.keys,
         equals([data.keys.last]),
       );
     });
 
-    test('can clear data', () {
+    test('can clear data', () async {
       final data = {
         'Query': {
           'posts': [
@@ -130,7 +129,7 @@ void main() {
 
       final store = MemoryStore(data);
 
-      store.clear();
+      await store.clear();
       expect(store.keys.length, equals(0));
     });
   });
@@ -205,7 +204,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(data.keys.first, newData);
+      await store.put(data.keys.first, newData);
     });
 
     test("put method doesn't trigger with correct key and same data", () async {
@@ -232,7 +231,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(data.keys.first, data.values.first);
+      await store.put(data.keys.first, data.values.first);
       await store.dispose();
     });
 
@@ -266,7 +265,7 @@ void main() {
       );
 
       await Future.delayed(Duration.zero);
-      store.put(newPostKey, newPostValue);
+      await store.put(newPostKey, newPostValue);
       await store.dispose();
     });
   });

--- a/packages/normalize/README.md
+++ b/packages/normalize/README.md
@@ -165,9 +165,9 @@ Which will produce the following normalized result:
 If we later want to denormalize this data (for example, when reading from a cache), we can call `denormalize` on the normalizedMap from above. This will give us back the original data response object.
 
 ```dart
-denormalizeOperation(
+await denormalizeOperation(
   document: query,
-  read: (dataId) => normalizedMap[dataId],
+  read: (dataId) async => normalizedMap[dataId],
 )
 ```
 

--- a/packages/normalize/lib/src/config/normalization_config.dart
+++ b/packages/normalize/lib/src/config/normalization_config.dart
@@ -1,10 +1,9 @@
 import 'package:gql/ast.dart';
-
 import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
 
 class NormalizationConfig {
-  final Map<String, dynamic>? Function(String dataId) read;
+  final Future<Map<String, dynamic>?> Function(String dataId) read;
 
   /// Fragment or operation variables that parameterize the document.
   final Map<String, dynamic> variables;

--- a/packages/normalize/lib/src/denormalize_fragment.dart
+++ b/packages/normalize/lib/src/denormalize_fragment.dart
@@ -1,19 +1,18 @@
 import 'package:gql/ast.dart';
 import 'package:normalize/normalize.dart';
-
 import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/denormalize_node.dart';
+import 'package:normalize/src/utils/add_typename_visitor.dart';
 import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
 import 'package:normalize/src/utils/resolve_data_id.dart';
-import 'package:normalize/src/utils/add_typename_visitor.dart';
-import 'package:normalize/src/denormalize_node.dart';
 
 /// Denormalizes data for a given fragment.
 ///
 /// Pass in a [read] function to read the normalized map.
 ///
 /// An [idFields] Map must be provided that includes all identifying data, per
-/// any pertinent [TypePolicy] or [dataIdFromObject] funciton. If entities of
+/// any pertinent [TypePolicy] or [dataIdFromObject] function. If entities of
 /// this type are simply identified by their [__typename] & [id] fields, you
 /// can simply provide a map with just the [id] field (i.e. `{ "id": "1234" }`).
 ///
@@ -23,8 +22,8 @@ import 'package:normalize/src/denormalize_node.dart';
 ///
 /// Likewise, if a custom [referenceKey] was used to normalize the data, it
 /// must be provided. Otherwise, the default '$ref' key will be used.
-Map<String, dynamic>? denormalizeFragment({
-  required Map<String, dynamic>? Function(String dataId) read,
+Future<Map<String, dynamic>?> denormalizeFragment({
+  required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   required Map<String, dynamic> idFields,
   String? fragmentName,
@@ -36,7 +35,7 @@ Map<String, dynamic>? denormalizeFragment({
   bool handleException = true,
   String referenceKey = kDefaultReferenceKey,
   Map<String, Set<String>> possibleTypes = const {},
-}) {
+}) async {
   if (addTypename) {
     document = transform(
       document,
@@ -77,11 +76,11 @@ Map<String, dynamic>? denormalizeFragment({
   );
 
   try {
-    return denormalizeNode(
+    return (await denormalizeNode(
       selectionSet: fragmentDefinition.selectionSet,
-      dataForNode: read(dataId),
+      dataForNode: await read(dataId),
       config: config,
-    ) as Map<String, dynamic>?;
+    )) as Map<String, dynamic>?;
   } on PartialDataException {
     if (handleException) {
       return null;

--- a/packages/normalize/lib/src/denormalize_node.dart
+++ b/packages/normalize/lib/src/denormalize_node.dart
@@ -87,7 +87,7 @@ Future<Object?> denormalizeNode({
                 ),
               );
           }
-          
+
           return result
             ..[resultKey] = await denormalizeNode(
               selectionSet: fieldNode.selectionSet,

--- a/packages/normalize/lib/src/denormalize_operation.dart
+++ b/packages/normalize/lib/src/denormalize_operation.dart
@@ -1,14 +1,13 @@
 import 'package:gql/ast.dart';
 import 'package:normalize/normalize.dart';
-import 'package:normalize/src/utils/constants.dart';
-
-import 'package:normalize/src/utils/resolve_root_typename.dart';
-import 'package:normalize/src/utils/add_typename_visitor.dart';
-import 'package:normalize/src/utils/get_operation_definition.dart';
-import 'package:normalize/src/denormalize_node.dart';
 import 'package:normalize/src/config/normalization_config.dart';
-import 'package:normalize/src/utils/resolve_data_id.dart';
+import 'package:normalize/src/denormalize_node.dart';
+import 'package:normalize/src/utils/add_typename_visitor.dart';
+import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
+import 'package:normalize/src/utils/get_operation_definition.dart';
+import 'package:normalize/src/utils/resolve_data_id.dart';
+import 'package:normalize/src/utils/resolve_root_typename.dart';
 
 /// Denormalizes data for a given query
 ///
@@ -19,8 +18,8 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 ///
 /// Likewise, if a custom [referenceKey] was used to normalize the data, it
 /// must be provided. Otherwise, the default '$ref' key will be used.
-Map<String, dynamic>? denormalizeOperation({
-  required Map<String, dynamic>? Function(String dataId) read,
+Future<Map<String, dynamic>?> denormalizeOperation({
+  required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   String? operationName,
   Map<String, dynamic> variables = const {},
@@ -31,7 +30,7 @@ Map<String, dynamic>? denormalizeOperation({
   bool handleException = true,
   String referenceKey = kDefaultReferenceKey,
   Map<String, Set<String>> possibleTypes = const {},
-}) {
+}) async {
   if (addTypename) {
     document = transform(
       document,
@@ -62,11 +61,12 @@ Map<String, dynamic>? denormalizeOperation({
   );
 
   try {
-    return denormalizeNode(
+    final object = await denormalizeNode(
       selectionSet: operationDefinition.selectionSet,
-      dataForNode: read(dataId),
+      dataForNode: await read(dataId),
       config: config,
-    ) as Map<String, dynamic>?;
+    );
+    return object as Map<String, dynamic>?;
   } on PartialDataException {
     if (handleException) {
       return null;

--- a/packages/normalize/lib/src/normalize_fragment.dart
+++ b/packages/normalize/lib/src/normalize_fragment.dart
@@ -27,7 +27,8 @@ import 'package:normalize/src/utils/resolve_data_id.dart';
 /// should begin with '$' since a graphql response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
 Future<void> normalizeFragment({
-  required Future<void> Function(String dataId, Map<String, dynamic>? value) write,
+  required Future<void> Function(String dataId, Map<String, dynamic>? value)
+      write,
   required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   required Map<String, dynamic> idFields,

--- a/packages/normalize/lib/src/normalize_fragment.dart
+++ b/packages/normalize/lib/src/normalize_fragment.dart
@@ -1,12 +1,11 @@
 import 'package:gql/ast.dart';
-import 'package:normalize/src/utils/constants.dart';
-
-import 'package:normalize/src/utils/resolve_data_id.dart';
+import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/normalize_node.dart';
 import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/add_typename_visitor.dart';
-import 'package:normalize/src/normalize_node.dart';
-import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
+import 'package:normalize/src/utils/resolve_data_id.dart';
 
 /// Normalizes data for a given fragment
 ///
@@ -21,15 +20,15 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 /// IDs are generated for each entity based on the following:
 /// 1. If no __typename field exists, the entity will not be normalized.
 /// 2. If a [TypePolicy] is provided for the given type, it's [TypePolicy.keyFields] are used.
-/// 3. If a [dataIdFromObject] funciton is provided, the result is used.
+/// 3. If a [dataIdFromObject] function is provided, the result is used.
 /// 4. The 'id' or '_id' field (respectively) are used.
 ///
 /// The [referenceKey] is used to reference the ID of a normalized object. It
-/// should begin with '$' since a graphl response object key cannot begin with
+/// should begin with '$' since a graphql response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
-void normalizeFragment({
-  required void Function(String dataId, Map<String, dynamic>? value) write,
-  required Map<String, dynamic>? Function(String dataId) read,
+Future<void> normalizeFragment({
+  required Future<void> Function(String dataId, Map<String, dynamic>? value) write,
+  required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   required Map<String, dynamic> idFields,
   required Map<String, dynamic> data,
@@ -41,7 +40,7 @@ void normalizeFragment({
   String referenceKey = kDefaultReferenceKey,
   bool acceptPartialData = true,
   Map<String, Set<String>> possibleTypes = const {},
-}) {
+}) async {
   // Always add typenames to ensure data is stored with typename
   document = transform(
     document,
@@ -92,15 +91,15 @@ void normalizeFragment({
     );
   }
 
-  write(
+  await write(
     dataId,
-    normalizeNode(
+    (await normalizeNode(
       selectionSet: fragmentDefinition.selectionSet,
       dataForNode: dataForFragment,
-      existingNormalizedData: config.read(dataId),
+      existingNormalizedData: await config.read(dataId),
       config: config,
       write: write,
       root: true,
-    ) as Map<String, dynamic>?,
+    )) as Map<String, dynamic>?,
   );
 }

--- a/packages/normalize/lib/src/normalize_node.dart
+++ b/packages/normalize/lib/src/normalize_node.dart
@@ -15,7 +15,8 @@ Future<Object?> normalizeNode({
   required Object? dataForNode,
   required Object? existingNormalizedData,
   required NormalizationConfig config,
-  required Future<void> Function(String dataId, Map<String, dynamic> value) write,
+  required Future<void> Function(String dataId, Map<String, dynamic> value)
+      write,
   bool root = false,
 }) async {
   if (dataForNode == null) return null;

--- a/packages/normalize/lib/src/normalize_operation.dart
+++ b/packages/normalize/lib/src/normalize_operation.dart
@@ -24,7 +24,8 @@ import 'package:normalize/src/utils/resolve_root_typename.dart';
 /// should begin with '$' since a graphql response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
 Future<void> normalizeOperation({
-  required Future<void> Function(String dataId, Map<String, dynamic>? value) write,
+  required Future<void> Function(String dataId, Map<String, dynamic>? value)
+      write,
   required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   required Map<String, dynamic> data,

--- a/packages/normalize/lib/src/normalize_operation.dart
+++ b/packages/normalize/lib/src/normalize_operation.dart
@@ -1,14 +1,13 @@
 import 'package:gql/ast.dart';
-import 'package:normalize/src/utils/constants.dart';
-
-import 'package:normalize/src/utils/resolve_data_id.dart';
-import 'package:normalize/src/policies/type_policy.dart';
-import 'package:normalize/src/utils/resolve_root_typename.dart';
-import 'package:normalize/src/utils/get_operation_definition.dart';
-import 'package:normalize/src/normalize_node.dart';
 import 'package:normalize/src/config/normalization_config.dart';
+import 'package:normalize/src/normalize_node.dart';
+import 'package:normalize/src/policies/type_policy.dart';
 import 'package:normalize/src/utils/add_typename_visitor.dart';
+import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/get_fragment_map.dart';
+import 'package:normalize/src/utils/get_operation_definition.dart';
+import 'package:normalize/src/utils/resolve_data_id.dart';
+import 'package:normalize/src/utils/resolve_root_typename.dart';
 
 /// Normalizes data for a given query
 ///
@@ -18,15 +17,15 @@ import 'package:normalize/src/utils/get_fragment_map.dart';
 /// IDs are generated for each entity based on the following:
 /// 1. If no __typename field exists, the entity will not be normalized.
 /// 2. If a [TypePolicy] is provided for the given type, it's [TypePolicy.keyFields] are used.
-/// 3. If a [dataIdFromObject] funciton is provided, the result is used.
+/// 3. If a [dataIdFromObject] function is provided, the result is used.
 /// 4. The 'id' or '_id' field (respectively) are used.
 ///
 /// The [referenceKey] is used to reference the ID of a normalized object. It
-/// should begin with '$' since a graphl response object key cannot begin with
+/// should begin with '$' since a graphql response object key cannot begin with
 /// that symbol. If none is provided, we will use '$ref' by default.
-void normalizeOperation({
-  required void Function(String dataId, Map<String, dynamic>? value) write,
-  required Map<String, dynamic>? Function(String dataId) read,
+Future<void> normalizeOperation({
+  required Future<void> Function(String dataId, Map<String, dynamic>? value) write,
+  required Future<Map<String, dynamic>?> Function(String dataId) read,
   required DocumentNode document,
   required Map<String, dynamic> data,
   String? operationName,
@@ -37,7 +36,7 @@ void normalizeOperation({
   bool acceptPartialData = true,
   String referenceKey = kDefaultReferenceKey,
   Map<String, Set<String>> possibleTypes = const {},
-}) {
+}) async {
   if (addTypename) {
     document = transform(
       document,
@@ -70,15 +69,15 @@ void normalizeOperation({
     possibleTypes: possibleTypes,
   );
 
-  write(
+  await write(
     dataId,
-    normalizeNode(
+    (await normalizeNode(
       selectionSet: operationDefinition.selectionSet,
       dataForNode: data,
-      existingNormalizedData: config.read(dataId),
+      existingNormalizedData: await config.read(dataId),
       config: config,
       write: write,
       root: true,
-    ) as Map<String, dynamic>?,
+    )) as Map<String, dynamic>?,
   );
 }

--- a/packages/normalize/lib/src/policies/field_policy.dart
+++ b/packages/normalize/lib/src/policies/field_policy.dart
@@ -1,9 +1,8 @@
 import 'package:gql/ast.dart';
-
-import 'package:normalize/src/utils/field_key.dart';
-import 'package:normalize/src/utils/resolve_data_id.dart';
 import 'package:normalize/src/config/normalization_config.dart';
 import 'package:normalize/src/denormalize_node.dart';
+import 'package:normalize/src/utils/field_key.dart';
+import 'package:normalize/src/utils/resolve_data_id.dart';
 
 class FieldFunctionOptions {
   final NormalizationConfig _config;
@@ -38,7 +37,7 @@ class FieldFunctionOptions {
       };
 
   /// Returns denormalized data for the given [field] and normalized [data], recursively resolving any references.
-  T? readField<T>(FieldNode field, Object? data) => denormalizeNode(
+  Future<T?> readField<T>(FieldNode field, Object? data) => denormalizeNode(
         selectionSet: field.selectionSet,
         dataForNode: data,
         config: NormalizationConfig(
@@ -52,15 +51,15 @@ class FieldFunctionOptions {
           allowPartialData: true,
           possibleTypes: _config.possibleTypes,
         ),
-      ) as T?;
+      ) as Future<T?>;
 }
 
-typedef FieldReadFunction<TExisting, TReadResult> = TReadResult Function(
+typedef FieldReadFunction<TExisting, TReadResult> = Future<TReadResult> Function(
   TExisting existing,
   FieldFunctionOptions options,
 );
 
-typedef FieldMergeFunction<TExisting, TIncoming> = TExisting Function(
+typedef FieldMergeFunction<TExisting, TIncoming> = Future<TExisting> Function(
   TExisting existing,
   TIncoming incoming,
   FieldFunctionOptions options,

--- a/packages/normalize/lib/src/policies/field_policy.dart
+++ b/packages/normalize/lib/src/policies/field_policy.dart
@@ -54,7 +54,8 @@ class FieldFunctionOptions {
       ) as Future<T?>;
 }
 
-typedef FieldReadFunction<TExisting, TReadResult> = Future<TReadResult> Function(
+typedef FieldReadFunction<TExisting, TReadResult> = Future<TReadResult>
+    Function(
   TExisting existing,
   FieldFunctionOptions options,
 );

--- a/packages/normalize/lib/src/utils/is_dangling_reference.dart
+++ b/packages/normalize/lib/src/utils/is_dangling_reference.dart
@@ -1,12 +1,13 @@
 import 'package:normalize/src/config/normalization_config.dart';
 
 /// Determines whether the given [data] is a reference that points to a non-existent object.
-bool isDanglingReference(
+Future<bool> isDanglingReference(
   Object? data,
   NormalizationConfig config,
-) {
+) async {
+  if (data == null) return false;
   if (data is Map && data.containsKey(config.referenceKey)) {
-    final referencedData = config.read(data[config.referenceKey]);
+    final referencedData = await config.read(data[config.referenceKey]);
     if (referencedData == null) return true;
   }
   return false;

--- a/packages/normalize/lib/src/utils/reachable_ids.dart
+++ b/packages/normalize/lib/src/utils/reachable_ids.dart
@@ -11,24 +11,24 @@ Future<Set<String>> reachableIds(
 ]) =>
     defaultRootTypenames.keys
         .map(
-      (type) => typenameForOperationType(
-        type,
-        typePolicies,
-      ),
-    )
-        .fold(
-      Future.value({}),
-      (ids, rootTypename) async => await ids
-        ..add(rootTypename)
-        ..addAll(
-          await _idsInObject(
-            await read(rootTypename),
-            read,
-            referenceKey,
-            {},
+          (type) => typenameForOperationType(
+            type,
+            typePolicies,
           ),
-        ),
-    );
+        )
+        .fold(
+          Future.value({}),
+          (ids, rootTypename) async => await ids
+            ..add(rootTypename)
+            ..addAll(
+              await _idsInObject(
+                await read(rootTypename),
+                read,
+                referenceKey,
+                {},
+              ),
+            ),
+        );
 
 /// Returns a set of all IDs reachable from the given data ID.
 ///
@@ -38,7 +38,8 @@ Future<Set<String>> reachableIdsFromDataId(
   Future<Map<String, dynamic>?> Function(String dataId) read, [
   String referenceKey = kDefaultReferenceKey,
 ]) async =>
-    await _idsInObject(read(dataId), read, referenceKey, {})..add(dataId);
+    await _idsInObject(read(dataId), read, referenceKey, {})
+      ..add(dataId);
 
 /// Recursively finds reachable IDs in [object]
 Future<Set<String>> _idsInObject(

--- a/packages/normalize/lib/src/utils/reachable_ids.dart
+++ b/packages/normalize/lib/src/utils/reachable_ids.dart
@@ -4,8 +4,8 @@ import 'package:normalize/src/utils/resolve_root_typename.dart';
 import 'constants.dart';
 
 /// Returns a set of dataIds that can be reached by any root query.
-Set<String> reachableIds(
-  Map<String, dynamic>? Function(String dataId) read, [
+Future<Set<String>> reachableIds(
+  Future<Map<String, dynamic>?> Function(String dataId) read, [
   Map<String, TypePolicy> typePolicies = const {},
   String referenceKey = kDefaultReferenceKey,
 ]) =>
@@ -17,12 +17,12 @@ Set<String> reachableIds(
       ),
     )
         .fold(
-      {},
-      (ids, rootTypename) => ids
+      Future.value({}),
+      (ids, rootTypename) async => await ids
         ..add(rootTypename)
         ..addAll(
-          _idsInObject(
-            read(rootTypename),
+          await _idsInObject(
+            await read(rootTypename),
             read,
             referenceKey,
             {},
@@ -33,26 +33,26 @@ Set<String> reachableIds(
 /// Returns a set of all IDs reachable from the given data ID.
 ///
 /// Includes the given [dataId] itself.
-Set<String> reachableIdsFromDataId(
+Future<Set<String>> reachableIdsFromDataId(
   String dataId,
-  Map<String, dynamic>? Function(String dataId) read, [
+  Future<Map<String, dynamic>?> Function(String dataId) read, [
   String referenceKey = kDefaultReferenceKey,
-]) =>
-    _idsInObject(read(dataId), read, referenceKey, {})..add(dataId);
+]) async =>
+    await _idsInObject(read(dataId), read, referenceKey, {})..add(dataId);
 
 /// Recursively finds reachable IDs in [object]
-Set<String> _idsInObject(
+Future<Set<String>> _idsInObject(
   Object? object,
-  Map<String, dynamic>? Function(String dataId) read,
+  Future<Map<String, dynamic>?> Function(String dataId) read,
   String referenceKey,
   Set<String> visited,
-) {
+) async {
   if (object is Map) {
     if (object.containsKey(referenceKey)) {
       if (visited.contains(object[referenceKey])) return {};
       return {object[referenceKey]}..addAll(
-          _idsInObject(
-            read(object[referenceKey]),
+          await _idsInObject(
+            await read(object[referenceKey]),
             read,
             referenceKey,
             visited..add(object[referenceKey]),
@@ -61,9 +61,9 @@ Set<String> _idsInObject(
     }
     return object.values.fold(
       {},
-      (ids, element) => ids
+      (ids, element) async => await ids
         ..addAll(
-          _idsInObject(
+          await _idsInObject(
             element,
             read,
             referenceKey,
@@ -74,9 +74,9 @@ Set<String> _idsInObject(
   } else if (object is List) {
     return object.fold(
       {},
-      (ids, element) => ids
+      (ids, element) async => await ids
         ..addAll(
-          _idsInObject(
+          await _idsInObject(
             element,
             read,
             referenceKey,

--- a/packages/normalize/lib/src/utils/validate_structure.dart
+++ b/packages/normalize/lib/src/utils/validate_structure.dart
@@ -1,17 +1,16 @@
 import 'package:gql/ast.dart';
-import 'package:normalize/src/denormalize_node.dart';
-
-import 'package:normalize/src/denormalize_operation.dart';
 import 'package:normalize/src/denormalize_fragment.dart';
+import 'package:normalize/src/denormalize_node.dart';
+import 'package:normalize/src/denormalize_operation.dart';
 import 'package:normalize/src/utils/constants.dart';
 import 'package:normalize/src/utils/exceptions.dart';
 import 'package:normalize/utils.dart';
 
-Map<String, dynamic>? _unsupportedRead(String _key) {
+Future<Map<String, dynamic>?> _unsupportedRead(String key) {
   throw UnsupportedError('Should never read while validating');
 }
 
-String? _stubDataIdFromObject(Map<String, dynamic> _data) => null;
+String? _stubDataIdFromObject(Map<String, dynamic> data) => null;
 
 /// Validates the structure of [data] against the operation [operationName] in [document].
 ///
@@ -24,7 +23,7 @@ String? _stubDataIdFromObject(Map<String, dynamic> _data) => null;
 /// Calls [denormalizeOperation] internally.
 ///
 /// [spec]: https://spec.graphql.org/June2018/#sec-Data
-bool validateOperationDataStructure({
+Future<bool> validateOperationDataStructure({
   required DocumentNode document,
   required Map<String, dynamic>? data,
   String? operationName,
@@ -52,7 +51,7 @@ bool validateOperationDataStructure({
 /// we treat it as invalid here, maintaining consistency with [denormalizeOperation].
 ///
 /// Calls [denormalizeFragment] internally.
-bool validateFragmentDataStructure({
+Future<bool> validateFragmentDataStructure({
   required DocumentNode document,
   required Map<String, dynamic>? data,
   String? fragmentName,
@@ -80,14 +79,14 @@ typedef SelectionSetFinder = SelectionSetNode Function({
   required Map<String, FragmentDefinitionNode> fragmentMap,
 });
 
-bool _validateSelectionSet({
+Future<bool> _validateSelectionSet({
   required DocumentNode document,
   required SelectionSetFinder getSelectionSet,
   required Map<String, dynamic>? data,
   required Map<String, dynamic> variables,
   required bool addTypename,
   required bool handleException,
-}) {
+}) async {
   if (data == null) {
     if (handleException) {
       return false;
@@ -114,7 +113,7 @@ bool _validateSelectionSet({
     possibleTypes: const {},
   );
   try {
-    return denormalizeNode(
+    return await denormalizeNode(
           selectionSet: getSelectionSet(
             document: document,
             fragmentMap: fragmentMap,

--- a/packages/normalize/test/evictions/dangling_reference_test.dart
+++ b/packages/normalize/test/evictions/dangling_reference_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -65,11 +65,11 @@ void main() {
       }
     };
 
-    test('can filter out dangling references', () {
+    test('can filter out dangling references', () async {
       expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
           ),
           equals(sharedResponse));
     });

--- a/packages/normalize/test/field_policy/field_function_options_test.dart
+++ b/packages/normalize/test/field_policy/field_function_options_test.dart
@@ -39,7 +39,8 @@ void main() {
                 'posts': FieldPolicy(
                   read: (existing, options) async {
                     expect(options.isReference(existing[0]), equals(true));
-                    final posts = await options.readField(options.field, existing ?? []);
+                    final posts =
+                        await options.readField(options.field, existing ?? []);
                     expect(options.toReference(posts[0]), equals(existing[0]));
                     return posts;
                   },

--- a/packages/normalize/test/field_policy/field_function_options_test.dart
+++ b/packages/normalize/test/field_policy/field_function_options_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -26,21 +26,20 @@ void main() {
       }
     ''');
 
-    test('helper methods work correctly', () {
+    test('helper methods work correctly', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           addTypename: true,
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
           typePolicies: {
             'Query': TypePolicy(
               queryType: true,
               fields: {
                 'posts': FieldPolicy(
-                  read: (existing, options) {
+                  read: (existing, options) async {
                     expect(options.isReference(existing[0]), equals(true));
-                    final posts =
-                        options.readField(options.field, existing ?? []);
+                    final posts = await options.readField(options.field, existing ?? []);
                     expect(options.toReference(posts[0]), equals(existing[0]));
                     return posts;
                   },

--- a/packages/normalize/test/field_policy/key_args_test.dart
+++ b/packages/normalize/test/field_policy/key_args_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -62,11 +62,11 @@ void main() {
       })
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
         typePolicies: typePolicies,
@@ -78,11 +78,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           typePolicies: typePolicies,
         ),
         equals(sharedResponse),

--- a/packages/normalize/test/field_policy/merge_test.dart
+++ b/packages/normalize/test/field_policy/merge_test.dart
@@ -1,11 +1,10 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('FetchPolicy.merge', () {
-    test('can merge arrays on root field', () {
+    test('can merge arrays on root field', () async {
       final query = parseString('''
         query TestQuery {
           posts {
@@ -55,18 +54,18 @@ void main() {
         },
       };
 
-      normalizeOperation(
+      await normalizeOperation(
         addTypename: true,
         data: response,
         document: query,
-        read: (dataId) => existing[dataId],
-        write: (dataId, value) => existing[dataId] = value,
+        read: (dataId) async => existing[dataId],
+        write: (dataId, value) async => existing[dataId] = value,
         typePolicies: {
           'Query': TypePolicy(
             queryType: true,
             fields: {
               'posts': FieldPolicy(
-                merge: (existing, incoming, options) {
+                merge: (existing, incoming, options) async {
                   return [...existing ?? [], ...incoming];
                 },
               )
@@ -78,7 +77,7 @@ void main() {
       expect(existing, equals(result));
     });
 
-    test('can merge arrays on child field', () {
+    test('can merge arrays on child field', () async {
       final query = parseString('''
         query TestQuery {
           posts {
@@ -151,17 +150,17 @@ void main() {
         },
       };
 
-      normalizeOperation(
+      await normalizeOperation(
         addTypename: true,
         data: response,
         document: query,
-        read: (dataId) => existing[dataId],
-        write: (dataId, value) => existing[dataId] = value,
+        read: (dataId) async => existing[dataId],
+        write: (dataId, value) async => existing[dataId] = value,
         typePolicies: {
           'Post': TypePolicy(
             fields: {
               'comments': FieldPolicy(
-                merge: (existing, incoming, options) {
+                merge: (existing, incoming, options) async {
                   return [...existing ?? [], ...incoming];
                 },
               )
@@ -173,7 +172,7 @@ void main() {
       expect(existing, equals(result));
     });
 
-    test('can replace data', () {
+    test('can replace data', () async {
       final query = parseString('''
         query TestQuery {
           posts {
@@ -226,18 +225,18 @@ void main() {
         },
       };
 
-      normalizeOperation(
+      await normalizeOperation(
         addTypename: true,
         data: response,
         document: query,
-        read: (dataId) => existing[dataId],
-        write: (dataId, value) => existing[dataId] = value,
+        read: (dataId) async => existing[dataId],
+        write: (dataId, value) async => existing[dataId] = value,
         typePolicies: {
           'Post': TypePolicy(
             fields: {
               'comments': FieldPolicy(
-                merge: (_, incoming, options) {
-                  return [options.readField(options.field, incoming[0])];
+                merge: (_, incoming, options) async {
+                  return [await options.readField(options.field, incoming[0])];
                 },
               )
             },
@@ -248,7 +247,7 @@ void main() {
       expect(existing, equals(result));
     });
 
-    test('can merge maps', () {
+    test('can merge maps', () async {
       final query = parseString('''
       query PostAuthorWithName {
         posts {
@@ -309,17 +308,17 @@ void main() {
         },
       };
 
-      normalizeOperation(
+      await normalizeOperation(
         addTypename: true,
         data: response,
         document: query,
-        read: (dataId) => existing[dataId],
-        write: (dataId, value) => existing[dataId] = value,
+        read: (dataId) async => existing[dataId],
+        write: (dataId, value) async => existing[dataId] = value,
         typePolicies: {
           'Post': TypePolicy(
             fields: {
               'author': FieldPolicy(
-                merge: (existing, incoming, options) {
+                merge: (existing, incoming, options) async {
                   return <String, dynamic>{...existing ?? {}, ...incoming};
                 },
               )

--- a/packages/normalize/test/field_policy/read_test.dart
+++ b/packages/normalize/test/field_policy/read_test.dart
@@ -53,8 +53,12 @@ void main() {
                 fields: {
                   'posts': FieldPolicy(
                     read: (existing, options) async {
-                      final fields = List<Map<String, dynamic>>.from(await options.readField(options.field, existing ?? []));
-                      return fields.where((post) => post['id'] == '123').toList();
+                      final fields = List<Map<String, dynamic>>.from(
+                          await options.readField(
+                              options.field, existing ?? []));
+                      return fields
+                          .where((post) => post['id'] == '123')
+                          .toList();
                     },
                   )
                 },

--- a/packages/normalize/test/fragments_test.dart
+++ b/packages/normalize/test/fragments_test.dart
@@ -1,11 +1,10 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Normalizing and denormalizing fragments', () {
-    test('Simple fragment', () {
+    test('Simple fragment', () async {
       final fragment = parseString('''
         fragment user on Author {
           id
@@ -19,18 +18,18 @@ void main() {
       };
 
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
           idFields: {'id': '1'},
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );
 
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: fragment,
         idFields: {'id': '1'},
         data: data,
@@ -41,7 +40,7 @@ void main() {
       );
     });
 
-    test('Nested entities', () {
+    test('Nested entities', () async {
       final fragment = parseString('''
         fragment commentData on Comment {
           id
@@ -68,18 +67,18 @@ void main() {
       };
 
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
           idFields: {'id': '324'},
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );
 
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: fragment,
         idFields: {'id': '324'},
         data: data,
@@ -91,7 +90,7 @@ void main() {
       );
     });
 
-    test('Nested entities with addTypename', () {
+    test('Nested entities with addTypename', () async {
       final fragment = parseString('''
         fragment commentData on Comment {
           id
@@ -118,19 +117,19 @@ void main() {
       };
 
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
           idFields: {'id': '324'},
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           addTypename: true,
         ),
         equals(data),
       );
 
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: fragment,
         idFields: {'id': '324'},
         data: data,
@@ -142,7 +141,7 @@ void main() {
       );
     });
 
-    test('Multiple named fragment definitions', () {
+    test('Multiple named fragment definitions', () async {
       final fragment = parseString('''
         fragment user on Author {
           id
@@ -173,19 +172,19 @@ void main() {
         'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
       };
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
           fragmentName: 'commentData',
           idFields: {'id': '324'},
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );
 
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: fragment,
         fragmentName: 'commentData',
         idFields: {'id': '324'},
@@ -198,7 +197,7 @@ void main() {
       );
     });
 
-    test('Override __typename on denormalize', () {
+    test('Override __typename on denormalize', () async {
       final fragment = parseString('''
         fragment user on Author {
           id
@@ -212,10 +211,10 @@ void main() {
       };
 
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
           idFields: {'id': '1', '__typename': 'NotAuthor'},
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/partial_input_test.dart
+++ b/packages/normalize/test/partial_input_test.dart
@@ -1,8 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
 import 'package:normalize/utils.dart';
+import 'package:test/test.dart';
 
 Map<String, dynamic> get fullQueryData => {
       '__typename': 'Query',
@@ -46,12 +45,12 @@ final query = parseString('''
 
 void main() {
   group('normalizeOperation acceptPartialData behavior', () {
-    test('Accepts partial data by default', () {
+    test('Accepts partial data by default', () async {
       final normalizedResult = {};
 
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: partialQueryData,
       );
@@ -62,13 +61,13 @@ void main() {
       );
     });
 
-    test('Rejects partial data when acceptPartialData=false', () {
+    test('Rejects partial data when acceptPartialData=false', () async {
       final normalizedResult = {};
 
-      expect(
+      await expectLater(
         () => normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           acceptPartialData: false,
           document: query,
           data: partialQueryData,
@@ -81,12 +80,12 @@ void main() {
       );
     });
 
-    test('Accepts explicit null when acceptPartialData=false', () {
+    test('Accepts explicit null when acceptPartialData=false', () async {
       final normalizedResult = {};
 
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         acceptPartialData: false,
         document: query,
         data: fullQueryData,
@@ -100,9 +99,9 @@ void main() {
   });
 
   group('validateOperationDataStructure', () {
-    test('rejects partial data', () {
+    test('rejects partial data', () async {
       expect(
-        validateOperationDataStructure(
+        await validateOperationDataStructure(
           handleException: true,
           document: query,
           data: partialQueryData,
@@ -110,7 +109,7 @@ void main() {
         equals(false),
       );
 
-      expect(
+      await expectLater(
         () => validateOperationDataStructure(
           document: query,
           data: partialQueryData,
@@ -123,9 +122,9 @@ void main() {
       );
     });
 
-    test('accepts valid data', () {
+    test('accepts valid data', () async {
       expect(
-        validateOperationDataStructure(
+        await validateOperationDataStructure(
           document: query,
           data: fullQueryData,
         ),
@@ -133,8 +132,8 @@ void main() {
       );
     });
 
-    test('rejects null data', () {
-      expect(
+    test('rejects null data', () async {
+      await expectLater(
         () => validateOperationDataStructure(data: null, document: query),
         throwsA(isA<PartialDataException>().having(
           (e) => e.path,
@@ -153,14 +152,14 @@ void main() {
       }
     ''');
 
-    test('rejects partial data', () {
+    test('rejects partial data', () async {
       final partialFragmentData = {
         'id': '123',
         '__typename': 'Post',
       };
 
       expect(
-        validateFragmentDataStructure(
+        await validateFragmentDataStructure(
           data: partialFragmentData,
           document: fragment,
           handleException: true,
@@ -168,7 +167,7 @@ void main() {
         equals(false),
       );
 
-      expect(
+      await expectLater(
         () => validateFragmentDataStructure(
           data: partialFragmentData,
           document: fragment,
@@ -181,7 +180,7 @@ void main() {
       );
     });
 
-    test('accepts valid data', () {
+    test('accepts valid data', () async {
       final fullFragmentData = {
         'id': '123',
         '__typename': 'Post',
@@ -189,15 +188,15 @@ void main() {
       };
 
       expect(
-        validateFragmentDataStructure(
+        await validateFragmentDataStructure(
           data: fullFragmentData,
           document: fragment,
         ),
         equals(true),
       );
     });
-    test('rejects null data', () {
-      expect(
+    test('rejects null data', () async {
+      await expectLater(
         () => validateFragmentDataStructure(data: null, document: fragment),
         throwsA(isA<PartialDataException>().having(
           (e) => e.path,

--- a/packages/normalize/test/partial_results_test.dart
+++ b/packages/normalize/test/partial_results_test.dart
@@ -43,7 +43,7 @@ void main() {
     );
   });
 
-  test("Don't return partial data", () async{
+  test("Don't return partial data", () async {
     final data = {
       'Query': {
         'posts': [

--- a/packages/normalize/test/partial_results_test.dart
+++ b/packages/normalize/test/partial_results_test.dart
@@ -1,10 +1,9 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
-  test('Return partial data', () {
+  test('Return partial data', () async {
     final data = {
       'Query': {
         'posts': [
@@ -34,9 +33,9 @@ void main() {
       ]
     };
     expect(
-      denormalizeOperation(
+      await denormalizeOperation(
         document: query,
-        read: (dataId) => data[dataId],
+        read: (dataId) async => data[dataId],
         addTypename: true,
         returnPartialData: true,
       ),
@@ -44,7 +43,7 @@ void main() {
     );
   });
 
-  test("Don't return partial data", () {
+  test("Don't return partial data", () async{
     final data = {
       'Query': {
         'posts': [
@@ -66,9 +65,9 @@ void main() {
       }
     ''');
     expect(
-      denormalizeOperation(
+      await denormalizeOperation(
         document: query,
-        read: (dataId) => data[dataId],
+        read: (dataId) async => data[dataId],
         addTypename: true,
         returnPartialData: false,
       ),
@@ -76,7 +75,7 @@ void main() {
     );
   });
 
-  test('Explicit null', () {
+  test('Explicit null', () async {
     final data = {
       'Query': {
         '__typename': 'Query',
@@ -109,9 +108,9 @@ void main() {
       ]
     };
     expect(
-      denormalizeOperation(
+      await denormalizeOperation(
         document: query,
-        read: (dataId) => data[dataId],
+        read: (dataId) async => data[dataId],
         addTypename: true,
         returnPartialData: false,
       ),

--- a/packages/normalize/test/possible_types_test.dart
+++ b/packages/normalize/test/possible_types_test.dart
@@ -1,11 +1,10 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Normalizing and denormalizing with possible type of', () {
-    test('Mutiple fragments', () {
+    test('Multiple fragments', () async {
       final possibleTypes = {
         'User': {'Author', 'Audience'},
       };
@@ -73,9 +72,9 @@ void main() {
         },
       };
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: document,
         data: data,
         acceptPartialData: false,
@@ -87,10 +86,10 @@ void main() {
       );
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: document,
           handleException: false,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           possibleTypes: possibleTypes,
         ),
         equals(data),

--- a/packages/normalize/test/query/add_typename_test.dart
+++ b/packages/normalize/test/query/add_typename_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -10,7 +10,7 @@ void main() {
     () {
       test(
         'Simple query',
-        () {
+        () async {
           final query = parseString('''
             query TestQuery {
               posts {
@@ -31,21 +31,21 @@ void main() {
             }
           ''');
           expect(
-            denormalizeOperation(
+            await denormalizeOperation(
               document: query,
-              read: (dataId) => sharedNormalizedMap[dataId],
+              read: (dataId) async => sharedNormalizedMap[dataId],
               addTypename: true,
             ),
             equals(sharedResponse),
           );
 
           final normalizedResult = {};
-          normalizeOperation(
-            read: (dataId) => normalizedResult[dataId],
+          await normalizeOperation(
+            read: (dataId) async => normalizedResult[dataId],
             addTypename: true,
             document: query,
             data: sharedResponse,
-            write: (dataId, value) => normalizedResult[dataId] = value,
+            write: (dataId, value) async => normalizedResult[dataId] = value,
           );
 
           expect(
@@ -57,7 +57,7 @@ void main() {
 
       test(
         'Inline Fragments',
-        () {
+        () async {
           final query = parseString('''
             query TestQuery {
               posts {
@@ -80,21 +80,21 @@ void main() {
             }
           ''');
           expect(
-            denormalizeOperation(
+            await denormalizeOperation(
               document: query,
-              read: (dataId) => sharedNormalizedMap[dataId],
+              read: (dataId) async => sharedNormalizedMap[dataId],
               addTypename: true,
             ),
             equals(sharedResponse),
           );
 
           final normalizedResult = {};
-          normalizeOperation(
-            read: (dataId) => normalizedResult[dataId],
+          await normalizeOperation(
+            read: (dataId) async => normalizedResult[dataId],
             addTypename: true,
             document: query,
             data: sharedResponse,
-            write: (dataId, value) => normalizedResult[dataId] = value,
+            write: (dataId, value) async => normalizedResult[dataId] = value,
           );
 
           expect(
@@ -106,7 +106,7 @@ void main() {
 
       test(
         'Fragment Definition',
-        () {
+        () async {
           final query = parseString('''
             query TestQuery {
               posts {
@@ -131,21 +131,21 @@ void main() {
             }
           ''');
           expect(
-            denormalizeOperation(
+            await denormalizeOperation(
               document: query,
-              read: (dataId) => sharedNormalizedMap[dataId],
+              read: (dataId) async => sharedNormalizedMap[dataId],
               addTypename: true,
             ),
             equals(sharedResponse),
           );
 
           final normalizedResult = {};
-          normalizeOperation(
-            read: (dataId) => normalizedResult[dataId],
+          await normalizeOperation(
+            read: (dataId) async => normalizedResult[dataId],
             addTypename: true,
             document: query,
             data: sharedResponse,
-            write: (dataId, value) => normalizedResult[dataId] = value,
+            write: (dataId, value) async => normalizedResult[dataId] = value,
           );
 
           expect(

--- a/packages/normalize/test/query/missing_id_test.dart
+++ b/packages/normalize/test/query/missing_id_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group(
@@ -92,17 +91,16 @@ void main() {
         'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'},
       };
 
-      final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        document: query,
-        data: data,
-        write: (dataId, value) => normalizedResult[dataId] = value,
-      );
-
       test(
         'Produces correct normalized object',
-        () {
+        () async {
+          final normalizedResult = {};
+          await normalizeOperation(
+            read: (dataId) async => normalizedResult[dataId],
+            document: query,
+            data: data,
+            write: (dataId, value) async => normalizedResult[dataId] = value,
+          );
           expect(
               normalizedResult,
               equals(
@@ -113,11 +111,11 @@ void main() {
 
       test(
         'Produces correct nested data object',
-        () {
+        () async {
           expect(
-            denormalizeOperation(
+            await denormalizeOperation(
               document: query,
-              read: (dataId) => normalizedMap[dataId],
+              read: (dataId) async => normalizedMap[dataId],
             ),
             equals(data),
           );

--- a/packages/normalize/test/query/multiple_operations_test.dart
+++ b/packages/normalize/test/query/multiple_operations_test.dart
@@ -1,12 +1,12 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
   group('Multiple Operations', () {
-    test('With operationName', () {
+    test('With operationName', () async {
       final query = parseString('''
         query FirstQuery {
           author {
@@ -33,9 +33,9 @@ void main() {
       ''');
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
           operationName: 'TestQuery',
           addTypename: true,
         ),
@@ -43,10 +43,10 @@ void main() {
       );
 
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
         addTypename: true,
-        write: (dataId, value) => normalizedResult[dataId] = value,
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
         operationName: 'TestQuery',
@@ -58,7 +58,7 @@ void main() {
       );
     });
 
-    test('Without operationName', () {
+    test('Without operationName', () async {
       final query = parseString('''
         query TestQuery {
           posts {
@@ -85,19 +85,19 @@ void main() {
         }
       ''');
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
           addTypename: true,
         ),
         equals(sharedResponse),
       );
 
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
         addTypename: true,
-        write: (dataId, value) => normalizedResult[dataId] = value,
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
         operationName: 'TestQuery',

--- a/packages/normalize/test/query/same_entity_different_fields_test.dart
+++ b/packages/normalize/test/query/same_entity_different_fields_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Same Entity Different Fields', () {
@@ -76,11 +75,11 @@ void main() {
       'Author:1': {'id': '1', '__typename': 'Author', 'name': 'Paul', 'age': 33}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -91,11 +90,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
           ),
           equals(data));
     });

--- a/packages/normalize/test/query/same_query_same_object_with_less_fields_test.dart
+++ b/packages/normalize/test/query/same_query_same_object_with_less_fields_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Same Object with less fields in the Same Operation', () {
@@ -43,11 +42,11 @@ void main() {
       }
     };
 
-    test('Doesn\'t lose fields', () {
+    test('Doesn\'t lose fields', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );

--- a/packages/normalize/test/query/simple_test.dart
+++ b/packages/normalize/test/query/simple_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -31,11 +31,11 @@ void main() {
       }
     ''');
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -46,11 +46,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => sharedNormalizedMap[dataId],
+            read: (dataId) async => sharedNormalizedMap[dataId],
           ),
           equals(sharedResponse));
     });

--- a/packages/normalize/test/query_aliases/alias_test.dart
+++ b/packages/normalize/test/query_aliases/alias_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -50,11 +50,11 @@ void main() {
       ]
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -65,11 +65,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_data_types/array_of_strings_test.dart
+++ b/packages/normalize/test/query_data_types/array_of_strings_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Array of Strings', () {
@@ -38,11 +37,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -53,11 +52,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_data_types/deep_null_test.dart
+++ b/packages/normalize/test/query_data_types/deep_null_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Deep Null', () {
@@ -57,11 +56,11 @@ void main() {
       'Author:1': {'id': '1', '__typename': 'Author', 'name': 'Paul'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -72,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_data_types/nested_array_of_entities_test.dart
+++ b/packages/normalize/test/query_data_types/nested_array_of_entities_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Nested Array of Entities', () {
@@ -70,11 +69,11 @@ void main() {
       'Cell:3.2': {'id': '3.2', '__typename': 'Cell', 'value': 'value 3.2'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -85,11 +84,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_data_types/nested_array_of_strings_test.dart
+++ b/packages/normalize/test/query_data_types/nested_array_of_strings_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Nested Array of Strings', () {
@@ -29,11 +28,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -44,11 +43,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
           ),
           equals(data));
     });

--- a/packages/normalize/test/query_data_types/null_object_test.dart
+++ b/packages/normalize/test/query_data_types/null_object_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Null Object', () {
@@ -29,11 +28,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
         variables: variables,
@@ -45,11 +44,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             variables: variables,
           ),
           equals(data));

--- a/packages/normalize/test/query_data_types/null_value_test.dart
+++ b/packages/normalize/test/query_data_types/null_value_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Null Value', () {
@@ -70,11 +69,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -85,11 +84,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_data_types/object_and_null_array_test.dart
+++ b/packages/normalize/test/query_data_types/object_and_null_array_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Object and null array', () {
@@ -40,11 +39,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
         variables: variables,
@@ -56,11 +55,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           variables: variables,
         ),
         equals(data),

--- a/packages/normalize/test/query_data_types/root_array_of_strings_test.dart
+++ b/packages/normalize/test/query_data_types/root_array_of_strings_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Root Array of Strings', () {
@@ -21,11 +20,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -36,11 +35,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_fragments/fragment_variables_test.dart
+++ b/packages/normalize/test/query_fragments/fragment_variables_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Fragment Variables', () {
@@ -41,11 +40,11 @@ void main() {
       ],
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: fragment,
         data: response,
         idFields: {'id': 1},
@@ -58,11 +57,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeFragment(
+        await denormalizeFragment(
           document: fragment,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           variables: {'first': 10},
           idFields: {'id': 1},
         ),

--- a/packages/normalize/test/query_fragments/inline_and_named_fragments_are_same_test.dart
+++ b/packages/normalize/test/query_fragments/inline_and_named_fragments_are_same_test.dart
@@ -99,7 +99,8 @@ void main() {
       final namedFragmentNormalizedResult = {};
       await normalizeOperation(
         read: (dataId) async => namedFragmentNormalizedResult[dataId],
-        write: (dataId, value) async => namedFragmentNormalizedResult[dataId] = value,
+        write: (dataId, value) async =>
+            namedFragmentNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
         possibleTypes: possibleTypes,
@@ -125,7 +126,8 @@ void main() {
       final namedFragmentNormalizedResult = {};
       await normalizeOperation(
         read: (dataId) async => namedFragmentNormalizedResult[dataId],
-        write: (dataId, value) async => namedFragmentNormalizedResult[dataId] = value,
+        write: (dataId, value) async =>
+            namedFragmentNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
       );
@@ -165,7 +167,8 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object without possible types', () async {
+    test('Produces correct nested data object without possible types',
+        () async {
       expect(
         await denormalizeOperation(
           document: inlineFragmentQuery,

--- a/packages/normalize/test/query_fragments/inline_and_named_fragments_are_same_test.dart
+++ b/packages/normalize/test/query_fragments/inline_and_named_fragments_are_same_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Union Type Inline Fragments With Possible Types', () {
@@ -88,19 +87,19 @@ void main() {
     final possibleTypes = {
       'BookAndAuthor': {'Book', 'Author'}
     };
-    test('Produces same normalized object with possible types', () {
+    test('Produces same normalized object with possible types', () async {
       final inlineNormalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => inlineNormalizedResult[dataId],
-        write: (dataId, value) => inlineNormalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => inlineNormalizedResult[dataId],
+        write: (dataId, value) async => inlineNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
         possibleTypes: possibleTypes,
       );
       final namedFragmentNormalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => namedFragmentNormalizedResult[dataId],
-        write: (dataId, value) => namedFragmentNormalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => namedFragmentNormalizedResult[dataId],
+        write: (dataId, value) async => namedFragmentNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
         possibleTypes: possibleTypes,
@@ -115,18 +114,18 @@ void main() {
         equals(normalizedMapWithPossibleTypes),
       );
     });
-    test('Produces same normalized object without possible types', () {
+    test('Produces same normalized object without possible types', () async {
       final inlineNormalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => inlineNormalizedResult[dataId],
-        write: (dataId, value) => inlineNormalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => inlineNormalizedResult[dataId],
+        write: (dataId, value) async => inlineNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
       );
       final namedFragmentNormalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => namedFragmentNormalizedResult[dataId],
-        write: (dataId, value) => namedFragmentNormalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => namedFragmentNormalizedResult[dataId],
+        write: (dataId, value) async => namedFragmentNormalizedResult[dataId] = value,
         document: inlineFragmentQuery,
         data: data,
       );
@@ -141,48 +140,48 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object with possible types', () {
+    test('Produces correct nested data object with possible types', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: inlineFragmentQuery,
-          read: (dataId) => normalizedMapWithPossibleTypes[dataId],
+          read: (dataId) async => normalizedMapWithPossibleTypes[dataId],
           possibleTypes: possibleTypes,
         ),
         equals(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: namedFragmentQuery,
-            read: (dataId) => normalizedMapWithPossibleTypes[dataId],
+            read: (dataId) async => normalizedMapWithPossibleTypes[dataId],
             possibleTypes: possibleTypes,
           ),
         ),
       );
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: inlineFragmentQuery,
-          read: (dataId) => normalizedMapWithPossibleTypes[dataId],
+          read: (dataId) async => normalizedMapWithPossibleTypes[dataId],
           possibleTypes: possibleTypes,
         ),
         equals(data),
       );
     });
 
-    test('Produces correct nested data object without possible types', () {
+    test('Produces correct nested data object without possible types', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: inlineFragmentQuery,
-          read: (dataId) => normalizedMapWithoutPossibleTypes[dataId],
+          read: (dataId) async => normalizedMapWithoutPossibleTypes[dataId],
         ),
         equals(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: namedFragmentQuery,
-            read: (dataId) => normalizedMapWithoutPossibleTypes[dataId],
+            read: (dataId) async => normalizedMapWithoutPossibleTypes[dataId],
           ),
         ),
       );
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: inlineFragmentQuery,
-          read: (dataId) => normalizedMapWithoutPossibleTypes[dataId],
+          read: (dataId) async => normalizedMapWithoutPossibleTypes[dataId],
         ),
         equals(dataDeserializedWithoutPossibleTypes),
       );

--- a/packages/normalize/test/query_fragments/inline_fragment_test.dart
+++ b/packages/normalize/test/query_fragments/inline_fragment_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -35,11 +35,11 @@ void main() {
       }
     ''');
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -50,11 +50,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_fragments/named_fragments_test.dart
+++ b/packages/normalize/test/query_fragments/named_fragments_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -39,11 +39,11 @@ void main() {
       }
     ''');
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           document: query,
           data: sharedResponse,
           possibleTypes: {
@@ -56,11 +56,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
             document: query,
-            read: (dataId) => sharedNormalizedMap[dataId],
+            read: (dataId) async => sharedNormalizedMap[dataId],
             possibleTypes: {
               'Person': {'Author'}
             }),

--- a/packages/normalize/test/query_fragments/same_object_different_fields_test.dart
+++ b/packages/normalize/test/query_fragments/same_object_different_fields_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -45,11 +45,11 @@ void main() {
       }
     ''');
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => sharedNormalizedMap[dataId],
+          read: (dataId) async => sharedNormalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_fragments/union_type_inline_fragments_test.dart
+++ b/packages/normalize/test/query_fragments/union_type_inline_fragments_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Union Type Inline Fragments', () {
@@ -68,11 +67,11 @@ void main() {
       }
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -83,11 +82,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(denormalizedData),
       );

--- a/packages/normalize/test/query_fragments/union_type_inline_fragments_with_possible_types_test.dart
+++ b/packages/normalize/test/query_fragments/union_type_inline_fragments_with_possible_types_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Union Type Inline Fragments With Possible Types', () {
@@ -44,11 +43,11 @@ void main() {
     final possibleTypes = {
       'BookAndAuthor': {'Book', 'Author'}
     };
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
         possibleTypes: possibleTypes,
@@ -60,11 +59,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           possibleTypes: possibleTypes,
         ),
         equals(data),

--- a/packages/normalize/test/query_variables/existing_data_different_variables_test.dart
+++ b/packages/normalize/test/query_variables/existing_data_different_variables_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Existing data different variables', () {
@@ -29,19 +28,19 @@ void main() {
       }
     ''');
 
-    test('With no data', () {
+    test('With no data', () async {
       final normalizedMap = {};
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           variables: {'a': false},
         ),
         equals(null),
       );
     });
 
-    test('With data that uses different variables', () {
+    test('With data that uses different variables', () async {
       final normalizedMap = {
         'Query': {
           'posts({"b":true})': [
@@ -67,23 +66,23 @@ void main() {
       };
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             variables: {'a': false}),
         equals(null),
       );
     });
 
-    test('Explicit null', () {
+    test('Explicit null', () async {
       final normalizedMap = {
         'Query': {'posts({"b":false})': null},
       };
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             variables: {'a': false}),
         equals({'posts': null}),
       );
@@ -114,7 +113,7 @@ void main() {
       }
     ''');
 
-    test('With data that uses different nested variables', () {
+    test('With data that uses different nested variables', () async {
       final normalizedMap = {
         'Query': {
           'posts': [
@@ -151,9 +150,9 @@ void main() {
       };
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           returnPartialData: true,
           variables: {'a': false},
         ),
@@ -161,7 +160,7 @@ void main() {
       );
     });
 
-    test('Explicit null', () {
+    test('Explicit null', () async {
       final normalizedMap = {
         'Query': {
           'posts': [
@@ -200,9 +199,9 @@ void main() {
       };
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           variables: {'a': false},
         ),
         equals(response),

--- a/packages/normalize/test/query_variables/variable_order_test.dart
+++ b/packages/normalize/test/query_variables/variable_order_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -81,11 +81,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query1,
         data: sharedResponse,
       );
@@ -96,19 +96,19 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object for both queries', () {
+    test('Produces correct nested data object for both queries', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query1,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );
 
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query2,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_variables/variables_bool_external_test.dart
+++ b/packages/normalize/test/query_variables/variables_bool_external_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -58,11 +58,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
         variables: variables,
@@ -74,11 +74,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           variables: variables,
         ),
         equals(sharedResponse),

--- a/packages/normalize/test/query_variables/variables_bool_simple_test.dart
+++ b/packages/normalize/test/query_variables/variables_bool_simple_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -56,11 +56,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -71,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_variables/variables_int_simple_test.dart
+++ b/packages/normalize/test/query_variables/variables_int_simple_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -56,11 +56,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -71,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_variables/variables_list_simple_test.dart
+++ b/packages/normalize/test/query_variables/variables_list_simple_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -56,11 +56,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -71,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_variables/variables_no_id_test.dart
+++ b/packages/normalize/test/query_variables/variables_no_id_test.dart
@@ -1,7 +1,6 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Variables No ID', () {
@@ -55,11 +54,11 @@ void main() {
       'Author:1': {'id': '1', '__typename': 'Author', 'name': 'Paul'},
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
       );
@@ -70,11 +69,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(data),
       );

--- a/packages/normalize/test/query_variables/variables_object_nested_test.dart
+++ b/packages/normalize/test/query_variables/variables_object_nested_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -56,11 +56,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -71,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/query_variables/variables_object_simple_test.dart
+++ b/packages/normalize/test/query_variables/variables_object_simple_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -56,11 +56,11 @@ void main() {
       'Author:2': {'id': '2', '__typename': 'Author', 'name': 'Nicole'}
     };
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: sharedResponse,
       );
@@ -71,11 +71,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
         ),
         equals(sharedResponse),
       );

--- a/packages/normalize/test/root_type_test.dart
+++ b/packages/normalize/test/root_type_test.dart
@@ -1,8 +1,7 @@
+import 'package:gql/language.dart';
+import 'package:normalize/normalize.dart';
 import 'package:normalize/utils.dart';
 import 'package:test/test.dart';
-import 'package:gql/language.dart';
-
-import 'package:normalize/normalize.dart';
 
 void main() {
   group('Root Fragments', () {
@@ -33,11 +32,11 @@ void main() {
         'age': null,
       }
     };
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeFragment(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeFragment(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: data,
         possibleTypes: {
@@ -51,9 +50,9 @@ void main() {
         equals(normalizedData),
       );
     });
-    test('Produces correct denormalized object', () {
-      final result = denormalizeFragment(
-        read: (dataId) => normalizedData[dataId],
+    test('Produces correct denormalized object', () async {
+      final result = await denormalizeFragment(
+        read: (dataId) async => normalizedData[dataId],
         document: query,
         possibleTypes: {
           'Person': {'Author'}
@@ -66,8 +65,8 @@ void main() {
         equals(data),
       );
     });
-    test('Validate Fragment', () {
-      validateFragmentDataStructure(document: query, data: data);
+    test('Validate Fragment', () async {
+      await validateFragmentDataStructure(document: query, data: data);
     });
   });
 
@@ -96,28 +95,28 @@ void main() {
         'age': 31
       }
     };
-    test('Normalizes nested root types', () {
+    test('Normalizes nested root types', () async {
       final normalized = {};
-      normalizeOperation(
-        write: (key, data) {
+      await normalizeOperation(
+        write: (key, data) async {
           normalized[key] = data;
         },
-        read: (key) => normalized[key],
+        read: (key) async => normalized[key],
         document: document,
         data: data,
       );
       expect(normalized, equals(normalizedData));
     });
-    test('Denormalizes nested root types', () {
+    test('Denormalizes nested root types', () async {
       expect(
-          denormalizeOperation(
-            read: (key) => normalizedData[key],
+          await denormalizeOperation(
+            read: (key) async => normalizedData[key],
             document: document,
           ),
           equals(data));
     });
-    test('Validate Query', () {
-      validateOperationDataStructure(document: document, data: data);
+    test('Validate Query', () async {
+      await validateOperationDataStructure(document: document, data: data);
     });
   });
 }

--- a/packages/normalize/test/type_policy/custom_root_test.dart
+++ b/packages/normalize/test/type_policy/custom_root_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -63,11 +63,11 @@ void main() {
 
     final typePolicies = {'CustomQueryRoot': TypePolicy(queryType: true)};
 
-    test('Produces correct normalized object', () {
+    test('Produces correct normalized object', () async {
       final normalizedResult = {};
-      normalizeOperation(
-        read: (dataId) => normalizedResult[dataId],
-        write: (dataId, value) => normalizedResult[dataId] = value,
+      await normalizeOperation(
+        read: (dataId) async => normalizedResult[dataId],
+        write: (dataId, value) async => normalizedResult[dataId] = value,
         document: query,
         data: response,
         typePolicies: typePolicies,
@@ -79,11 +79,11 @@ void main() {
       );
     });
 
-    test('Produces correct nested data object', () {
+    test('Produces correct nested data object', () async {
       expect(
-        denormalizeOperation(
+        await denormalizeOperation(
           document: query,
-          read: (dataId) => normalizedMap[dataId],
+          read: (dataId) async => normalizedMap[dataId],
           typePolicies: typePolicies,
         ),
         equals(response),

--- a/packages/normalize/test/type_policy/key_fields_test.dart
+++ b/packages/normalize/test/type_policy/key_fields_test.dart
@@ -1,7 +1,7 @@
-import 'package:test/test.dart';
 import 'package:gql/language.dart';
-
 import 'package:normalize/normalize.dart';
+import 'package:test/test.dart';
+
 import '../shared_data.dart';
 
 void main() {
@@ -73,11 +73,11 @@ void main() {
         )
       };
 
-      test('Produces correct normalized object', () {
+      test('Produces correct normalized object', () async {
         final normalizedResult = {};
-        normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+        await normalizeOperation(
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           document: query,
           data: sharedResponse,
           typePolicies: typePolicies,
@@ -89,11 +89,11 @@ void main() {
         );
       });
 
-      test('Produces correct nested data object', () {
+      test('Produces correct nested data object', () async {
         expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             typePolicies: typePolicies,
           ),
           equals(sharedResponse),
@@ -141,11 +141,11 @@ void main() {
         )
       };
 
-      test('Produces correct normalized object', () {
+      test('Produces correct normalized object', () async {
         final normalizedResult = {};
-        normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+        await normalizeOperation(
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           document: query,
           data: sharedResponse,
           typePolicies: typePolicies,
@@ -157,11 +157,11 @@ void main() {
         );
       });
 
-      test('Produces correct nested data object', () {
+      test('Produces correct nested data object', () async {
         expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             typePolicies: typePolicies,
           ),
           equals(sharedResponse),
@@ -206,11 +206,11 @@ void main() {
         )
       };
 
-      test('Produces correct normalized object', () {
+      test('Produces correct normalized object', () async {
         final normalizedResult = {};
-        normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+        await normalizeOperation(
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           document: query,
           data: sharedResponse,
           typePolicies: typePolicies,
@@ -222,11 +222,11 @@ void main() {
         );
       });
 
-      test('Produces correct nested data object', () {
+      test('Produces correct nested data object', () async {
         expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             typePolicies: typePolicies,
           ),
           equals(sharedResponse),
@@ -265,11 +265,11 @@ void main() {
         )
       };
 
-      test('Produces correct normalized object', () {
+      test('Produces correct normalized object', () async {
         final normalizedResult = {};
-        normalizeOperation(
-          read: (dataId) => normalizedResult[dataId],
-          write: (dataId, value) => normalizedResult[dataId] = value,
+        await normalizeOperation(
+          read: (dataId) async => normalizedResult[dataId],
+          write: (dataId, value) async => normalizedResult[dataId] = value,
           document: query,
           data: sharedResponse,
           typePolicies: typePolicies,
@@ -281,11 +281,11 @@ void main() {
         );
       });
 
-      test('Produces correct nested data object', () {
+      test('Produces correct nested data object', () async {
         expect(
-          denormalizeOperation(
+          await denormalizeOperation(
             document: query,
-            read: (dataId) => normalizedMap[dataId],
+            read: (dataId) async => normalizedMap[dataId],
             typePolicies: typePolicies,
           ),
           equals(sharedResponse),

--- a/packages/normalize/test/utils/reachable_ids_test.dart
+++ b/packages/normalize/test/utils/reachable_ids_test.dart
@@ -24,7 +24,7 @@ void main() {
              "trainer":{"\$ref":"Trainer:ckhi5hgou5038xppf9phzteph"}
           }''');
 
-    reachableIds((dataId) {
+    reachableIds((dataId) async {
       if (dataId == 'Query') return queryMap;
       if (dataId == 'Trainer:ckhi5hgou5038xppf9phzteph') return trainerMap;
       if (dataId == 'Pokemon:ckhie3ik16650xnpfyvjmb1lq') return pokemonMap;


### PR DESCRIPTION
Hello!

Here's a PR to make the `Store` async as we discussed on Discord.

BREAKING CHANGE: All the read/writeQuery/Fragment are now async

Closes #64

I tried running the example pokemon app in Chrome and it seemed to work fine.
I didn't do anything regarding the race conditions that you mentioned though (like when the network is faster than the cache).
Do you think this could be handled in the Operation widget for example?