### PR TITLE
fix(cache): Fix memory leak.

### DIFF
--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -96,11 +96,11 @@ class Cache {
     required TData? Function() getData,
   }) {
     return getChangeStream()
-    // We add null at the beginning of the stream to trigger the initial getData().
-    // getChangeStream = operationDataChangeStream or fragmentDataChangeStream and
-    // they both end with .skip(1).
-    .startWith(null) 
-    .map((_) => getData());
+        // We add null at the beginning of the stream to trigger the initial getData().
+        // getChangeStream = operationDataChangeStream or fragmentDataChangeStream and
+        // they both end with .skip(1).
+        .startWith(null)
+        .map((_) => getData());
   }
 
   /// Reads denormalized data from the Cache for the given operation.


### PR DESCRIPTION
The issue was caused by this line: https://github.com/gql-dart/ferry/blob/201980f313a98aa94ef45146ff229f24a95c3125/packages/ferry_cache/lib/src/cache.dart#L105

As per the [docs](https://api.flutter.dev/flutter/dart-async/Stream/isEmpty.html), isEmpty `waits for the first element of this stream`. The problem is that `operationDataChangeStream` and `fragmentDataChangeStream` end with `.skip(1)` so the stream never emits and the Future is pending forever.

My fix seems extremely simple, so maybe I missed some complexity but all the tests are passing...
Also, I don't know how to write an additional test to make sure that we don't leak.

If you want to manual test, I've created a branch where I added the original memory-leak repo: https://github.com/GP4cK/ferry/tree/memory-leak-example (it overrides the ferry dependencies to make sure to use my version of the code).

Closes #343