### PR TITLE
fix(ferry)!: remove optimistic response when listener cancels stream

### DIFF
--- a/packages/ferry/lib/src/fetch_policy_typed_link.dart
+++ b/packages/ferry/lib/src/fetch_policy_typed_link.dart
@@ -76,7 +76,7 @@ class FetchPolicyTypedLink extends TypedLink {
             .doOnData(_writeToCache);
         break;
       case FetchPolicy.CacheOnly:
-        stream= _cacheTypedLink.request(operationRequest);
+        stream = _cacheTypedLink.request(operationRequest);
         break;
       case FetchPolicy.CacheFirst:
         stream = _cacheTypedLink.request(operationRequest).take(1).switchMap(
@@ -98,7 +98,7 @@ class FetchPolicyTypedLink extends TypedLink {
         final sharedNetworkStream =
             _optimisticLinkTypedLink.request(operationRequest).shareValue();
 
-        stream= _cacheTypedLink
+        stream = _cacheTypedLink
             .request(operationRequest)
             .where((response) => response.data != null)
             .takeUntil(
@@ -125,13 +125,11 @@ class FetchPolicyTypedLink extends TypedLink {
       default:
         throw Exception('Unrecognized FetchPolicy');
     }
-    return stream
-        .doOnDone(() {
-          cache.removeOptimisticPatch(operationRequest);
-    })
-        .doOnCancel(() {
-       cache.removeOptimisticPatch(operationRequest);
-   });
+    return stream.doOnDone(() {
+      cache.removeOptimisticPatch(operationRequest);
+    }).doOnCancel(() {
+      cache.removeOptimisticPatch(operationRequest);
+    });
   }
 
   /// Removes any previous optimistic patch for the request.

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -27,3 +27,5 @@ dev_dependencies:
   async: ^2.5.0
   build_runner: ^2.0.2
   benchmarking: ^0.6.1
+  pokemon_explorer:
+    path: ../../examples/pokemon_explorer

--- a/packages/ferry/test/remove_optimistic_response_test.dart
+++ b/packages/ferry/test/remove_optimistic_response_test.dart
@@ -1,0 +1,83 @@
+
+
+// ignore_for_file: prefer_single_quotes
+
+import 'dart:async';
+
+import 'package:ferry/ferry.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:pokemon_explorer/src/graphql/__generated__/all_pokemon.data.gql.dart';
+import 'package:pokemon_explorer/src/graphql/__generated__/all_pokemon.req.gql.dart';
+import 'package:test/test.dart';
+
+final optimistic = GAllPokemonData((b) => b
+  ..pokemons.results.add(GAllPokemonData_pokemons_results((b) => b
+    ..id = 1
+    ..name = "optimisitc"
+    ..avatar = ""
+    ..height.in_meter = "123"
+    ..weight.in_kg = "345")));
+
+void main() {
+  test("can remove optimistic entries", () async {
+    final client = Client(link: _FakeLink());
+
+    final res = await client
+        .request(GAllPokemonReq((b) => b
+      ..optimisticResponse = optimistic.toBuilder()
+      ..vars.offset = 0
+      ..vars.limit = 100))
+        .first;
+
+    print(res.linkException);
+
+    expect(res.dataSource, DataSource.Optimistic);
+
+    await Future.delayed(Duration.zero);
+
+    expect(client.cache.optimisticPatchesStream.value, isEmpty);
+  });
+
+  test("can remove optimistic entries when listen", () async {
+    final client = Client(link: _FakeLink());
+
+    final completer = Completer();
+
+    client
+        .request(GAllPokemonReq((b) => b
+      ..optimisticResponse = optimistic.toBuilder()
+      ..vars.offset = 0
+      ..vars.limit = 100))
+        .listen((res) async {
+      expect(client.cache.optimisticPatchesStream.value,
+          res.dataSource == DataSource.Optimistic ? isNotEmpty : isEmpty);
+
+      if (res.dataSource == DataSource.Link) {
+        completer.complete();
+      }
+    });
+
+    await completer.future;
+  });
+
+
+
+}
+
+class _FakeLink extends Link {
+  @override
+  Stream<Response> request(Request request, [NextLink? forward]) async* {
+    final data = GAllPokemonData((b) => b
+      ..pokemons.results.add(GAllPokemonData_pokemons_results((b) => b
+        ..id = 1
+        ..name = "Pikachu"
+        ..avatar = ""
+        ..height.in_meter = "123"
+        ..weight.in_kg = "345"))).toJson();
+
+    await Future.delayed(Duration.zero);
+
+
+    yield Response(response: const {}, data: data);
+  }
+}

--- a/packages/ferry/test/remove_optimistic_response_test.dart
+++ b/packages/ferry/test/remove_optimistic_response_test.dart
@@ -1,5 +1,3 @@
-
-
 // ignore_for_file: prefer_single_quotes
 
 import 'dart:async';
@@ -24,9 +22,9 @@ void main() {
 
     final res = await client
         .request(GAllPokemonReq((b) => b
-      ..optimisticResponse = optimistic.toBuilder()
-      ..vars.offset = 0
-      ..vars.limit = 100))
+          ..optimisticResponse = optimistic.toBuilder()
+          ..vars.offset = 0
+          ..vars.limit = 100))
         .first;
 
     print(res.linkException);
@@ -45,9 +43,9 @@ void main() {
 
     client
         .request(GAllPokemonReq((b) => b
-      ..optimisticResponse = optimistic.toBuilder()
-      ..vars.offset = 0
-      ..vars.limit = 100))
+          ..optimisticResponse = optimistic.toBuilder()
+          ..vars.offset = 0
+          ..vars.limit = 100))
         .listen((res) async {
       expect(client.cache.optimisticPatchesStream.value,
           res.dataSource == DataSource.Optimistic ? isNotEmpty : isEmpty);
@@ -59,9 +57,6 @@ void main() {
 
     await completer.future;
   });
-
-
-
 }
 
 class _FakeLink extends Link {
@@ -76,7 +71,6 @@ class _FakeLink extends Link {
         ..weight.in_kg = "345"))).toJson();
 
     await Future.delayed(Duration.zero);
-
 
     yield Response(response: const {}, data: data);
   }

--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -99,8 +99,7 @@ class Cache {
         // We add null at the beginning of the stream to trigger the initial getData().
         // getChangeStream = operationDataChangeStream or fragmentDataChangeStream and
         // they both end with .skip(1).
-        .startWith(const <String>{})
-        .map((_) => getData());
+        .startWith(const <String>{}).map((_) => getData());
   }
 
   /// Reads denormalized data from the Cache for the given operation.
@@ -222,11 +221,9 @@ class Cache {
           : store.put(dataId, value);
 
   void removeOptimisticPatch(OperationRequest request) {
-
-    if(optimisticPatchesStream.value!.containsKey(request)) {
+    if (optimisticPatchesStream.value!.containsKey(request)) {
       optimisticPatchesStream.add(
-        Map.from(optimisticPatchesStream.value!)
-          ..remove(request),
+        Map.from(optimisticPatchesStream.value!)..remove(request),
       );
     }
   }

--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -92,14 +92,14 @@ class Cache {
       );
 
   Stream<TData?> _watch<TData>({
-    required Stream Function() getChangeStream,
+    required Stream<Set<String>> Function() getChangeStream,
     required TData? Function() getData,
   }) {
     return getChangeStream()
         // We add null at the beginning of the stream to trigger the initial getData().
         // getChangeStream = operationDataChangeStream or fragmentDataChangeStream and
         // they both end with .skip(1).
-        .startWith(null)
+        .startWith(const <String>{})
         .map((_) => getData());
   }
 
@@ -222,9 +222,13 @@ class Cache {
           : store.put(dataId, value);
 
   void removeOptimisticPatch(OperationRequest request) {
-    optimisticPatchesStream.add(
-      Map.from(optimisticPatchesStream.value!)..remove(request),
-    );
+
+    if(optimisticPatchesStream.value!.containsKey(request)) {
+      optimisticPatchesStream.add(
+        Map.from(optimisticPatchesStream.value!)
+          ..remove(request),
+      );
+    }
   }
 
   /// Returns the canonical ID for a given object or reference.


### PR DESCRIPTION
fixes #396 

It might be considered a breaking change though, as some users might rely on the old behavior.

I would consider it a bug though as the optimistic patch would never be removed and would overwrite the actual cache data.