### PR TITLE
fix(ferry_cache): fix regression in watch() methods 

### DIFF
--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -18,7 +18,8 @@ class Cache {
   final utils.DataIdResolver? dataIdFromObject;
 
   @visibleForTesting
-  final BehaviorSubject<Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
+  final BehaviorSubject<
+          Map<OperationRequest, Map<String, Map<String, dynamic>?>>?>
       optimisticPatchesStream;
 
   /// A set of entity IDs to retain when the cache is garbage collected.
@@ -30,7 +31,8 @@ class Cache {
     this.typePolicies = const {},
     this.possibleTypes = const {},
     this.addTypename = true,
-    Map<OperationRequest, Map<String, Map<String, dynamic>?>> seedOptimisticPatches = const {},
+    Map<OperationRequest, Map<String, Map<String, dynamic>?>>
+        seedOptimisticPatches = const {},
   })  : store = store ?? MemoryStore(),
         optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches);
 
@@ -124,7 +126,8 @@ class Cache {
               sc.addError(e, s);
             }
           });
-          await Future.any<Object?>([streamControllerDone, isEmptyCompleter.future]);
+          await Future.any<Object?>(
+              [streamControllerDone, isEmptyCompleter.future]);
           unawaited(sub.cancel());
 
           if (wasEmpty) {
@@ -204,7 +207,9 @@ class Cache {
     OperationRequest? optimisticRequest,
   }) =>
       normalizeOperation(
-        read: optimisticRequest != null ? optimisticReader : (dataId) => store.get(dataId),
+        read: optimisticRequest != null
+            ? optimisticReader
+            : (dataId) => store.get(dataId),
         write: (dataId, value) => _writeData(
           dataId,
           value,
@@ -232,7 +237,9 @@ class Cache {
     OperationRequest? optimisticRequest,
   }) =>
       normalizeFragment(
-        read: optimisticRequest != null ? optimisticReader : (dataId) => store.get(dataId),
+        read: optimisticRequest != null
+            ? optimisticReader
+            : (dataId) => store.get(dataId),
         write: (dataId, value) => _writeData(
           dataId,
           value,
@@ -260,7 +267,8 @@ class Cache {
               {
                 ...optimisticPatchesStream.value!,
                 optimisticRequest: {
-                  ...optimisticPatchesStream.value![optimisticRequest] ?? const {},
+                  ...optimisticPatchesStream.value![optimisticRequest] ??
+                      const {},
                   dataId: value,
                 }
               },
@@ -349,7 +357,9 @@ class Cache {
         optimisticRequest: {
           ...(optimisticPatchesStream.value![optimisticRequest] ?? {}),
           entityId: {
-            ...((optimisticPatchesStream.value![optimisticRequest] ?? {})[entityId]) ?? {},
+            ...((optimisticPatchesStream.value![optimisticRequest] ??
+                    {})[entityId]) ??
+                {},
             utils.FieldKey.from(fieldName, args).toString(): null
           },
         }
@@ -416,7 +426,8 @@ class Cache {
     );
     final keysToRemove = store.keys
         .where(
-          (key) => !reachable.contains(key) && !_retainedEntityIds.contains(key),
+          (key) =>
+              !reachable.contains(key) && !_retainedEntityIds.contains(key),
         )
         .toSet();
     store.deleteAll(keysToRemove);

--- a/packages/ferry_cache/test/watch_test.dart
+++ b/packages/ferry_cache/test/watch_test.dart
@@ -150,22 +150,28 @@ void main() {
     test('can receive updates when child objects are updated by other queries',
         () async {
       final cache = Cache();
-      cache.writeQuery(reviewsReq, reviewsData2);
+      cache.writeQuery(reviewsReq, reviewsData);
 
       final updatedReview =
-          reviewsData.reviews!.first.rebuild((b) => b.commentary = 'first');
+          reviewsData2.reviews![1].rebuild((b) => b.commentary = 'first');
 
       expect(
           cache.watchQuery(reviewsReq),
           emitsInOrder([
+            reviewsData,
             reviewsData2,
-            reviewsData2.rebuild((b) => b..reviews[0] = updatedReview),
+            reviewsData2.rebuild((b) => b..reviews[1] = updatedReview),
             emitsDone,
           ]));
 
       await Future.delayed(Duration.zero);
+
+      cache.writeQuery(reviewsReq, reviewsData2);
+
+      await Future.delayed(Duration.zero);
+
       cache.writeQuery(
-          GReviewsByIDReq((b) => b..vars.id = reviewsData.reviews!.first.id),
+          GReviewsByIDReq((b) => b..vars.id = reviewsData2.reviews![1].id),
           GReviewsByIDData((b) => b.review
             ..id = updatedReview.id
             ..stars = updatedReview.stars


### PR DESCRIPTION
this fixes the regression I was talking about in #385 in https://github.com/gql-dart/ferry/pull/385#issuecomment-1229184574. It also fixes the test that was not testing the thing it was supposed to test.

@GP4cK If you have suggestions for better implementations, please share them