### PR TITLE
fix(ferry_cache): fix regression in watch() methods by making changeStream emit when new item is added to the cache

### DIFF
--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -102,7 +102,9 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
             changed.clear();
             return result;
           },
-        )
+        ).doOnDone(() {
+          dataIdStreamController.close();
+        })
 
             /// Skip the first result since this returns the existing data
             .skip(1);

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -55,7 +55,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
 
         return dataIds;
       })
-      .distinct()
+      .distinct((prev, next) => const SetEquality<String>().equals(prev, next))
       .switchMap((dataIds) {
         /// IDs that have changed
         final changed = <String>{};

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -1,11 +1,12 @@
-import 'package:normalize/policies.dart';
-import 'package:normalize/utils.dart';
-import 'package:normalize/normalize.dart';
+import 'dart:async';
+
 import 'package:collection/collection.dart';
+import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
+import 'package:normalize/normalize.dart';
+import 'package:normalize/utils.dart';
 import 'package:rxdart/rxdart.dart';
 
-import 'package:ferry_exec/ferry_exec.dart';
 import './utils/data_for_id_stream.dart';
 import './utils/operation_root_data.dart';
 
@@ -31,67 +32,81 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
     typePolicies,
   );
 
-  final dataIds = <String>{};
+  final dataIdStreamController = StreamController<void>();
+  final result = dataIdStreamController.stream
+      .map((_) {
+        final dataIds = <String>{};
 
-  denormalizeOperation(
-      read: (dataId) {
-        dataIds.add(dataId);
-        return optimistic ? optimisticReader(dataId) : store.get(dataId);
-      },
-      document: request.operation.document,
-      operationName: request.operation.operationName,
-      // TODO: don't cast to dynamic
-      variables: (request.vars as dynamic)?.toJson(),
-      typePolicies: typePolicies,
-      addTypename: addTypename,
-      returnPartialData: true,
-      dataIdFromObject: dataIdFromObject,
-      possibleTypes: possibleTypes);
+        denormalizeOperation(
+          read: (dataId) {
+            dataIds.add(dataId);
+            return optimistic ? optimisticReader(dataId) : store.get(dataId);
+          },
+          document: request.operation.document,
+          operationName: request.operation.operationName,
+          // TODO: don't cast to dynamic
+          variables: (request.vars as dynamic)?.toJson(),
+          typePolicies: typePolicies,
+          addTypename: addTypename,
+          returnPartialData: true,
+          dataIdFromObject: dataIdFromObject,
+          possibleTypes: possibleTypes,
+        );
 
-  /// IDs that have changed
-  final changed = <String>{};
+        return dataIds;
+      })
+      .distinct()
+      .switchMap((dataIds) {
+        /// IDs that have changed
+        final changed = <String>{};
 
-  /// Streams for each dataId referenced in data, including the [rootTypename]
-  final streams = dataIds.map((dataId) {
-    var stream = dataForIdStream(
-      dataId,
-      store,
-      optimistic,
-      optimisticPatchesStream,
-      optimisticReader,
-    );
+        /// Streams for each dataId referenced in data, including the [rootTypename]
+        final streams = dataIds.map((dataId) {
+          var stream = dataForIdStream(
+            dataId,
+            store,
+            optimistic,
+            optimisticPatchesStream,
+            optimisticReader,
+          );
 
-    /// we only want to subscribe to changes on the operation fields, not the entire operation type)
-    if (dataId == rootTypename) {
-      stream = stream.map(
-        (data) => operationRootData(
-          data,
-          request,
-          typePolicies,
-          possibleTypes,
-        ),
-      );
-    }
+          /// we only want to subscribe to changes on the operation fields, not the entire operation type)
+          if (dataId == rootTypename) {
+            stream = stream.map(
+              (data) => operationRootData(
+                data,
+                request,
+                typePolicies,
+                possibleTypes,
+              ),
+            );
+          }
 
-    return stream
-        .distinct(
-          (prev, next) => const DeepCollectionEquality().equals(
-            prev,
-            next,
-          ),
+          return stream.distinct(
+            (prev, next) {
+              final areEqual = const MapEquality().equals(prev, next);
+              if (!areEqual) {
+                // Maybe a new element was added to an array,
+                // we need to recompute the dataIds
+                dataIdStreamController.add(null);
+              }
+              return areEqual;
+            },
+          ).doOnData((_) => changed.add(dataId));
+        });
+
+        return CombineLatestStream<Map<String, dynamic>?, Set<String>>(
+          streams,
+          (_) {
+            final result = {...changed};
+            changed.clear();
+            return result;
+          },
         )
-        .doOnData((_) => changed.add(dataId));
-  });
 
-  return CombineLatestStream<Map<String, dynamic>?, Set<String>>(
-    streams,
-    (_) {
-      final result = {...changed};
-      changed.clear();
-      return result;
-    },
-  )
-
-      /// Skip the first result since this returns the existsing data
-      .skip(1);
+            /// Skip the first result since this returns the existing data
+            .skip(1);
+      });
+  dataIdStreamController.add(null);
+  return result;
 }

--- a/packages/ferry_cache/test/watch_test.dart
+++ b/packages/ferry_cache/test/watch_test.dart
@@ -1,12 +1,11 @@
 import 'dart:async';
 
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_test_graphql/queries/__generated__/review_by_id.data.gql.dart';
 import 'package:ferry_test_graphql/queries/__generated__/review_by_id.req.gql.dart';
-import 'package:test/test.dart';
-import 'package:ferry_cache/ferry_cache.dart';
-
-import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
 import 'package:ferry_test_graphql/queries/__generated__/reviews.data.gql.dart';
+import 'package:ferry_test_graphql/queries/__generated__/reviews.req.gql.dart';
+import 'package:test/test.dart';
 
 final reviewsReq = GReviewsReq();
 
@@ -150,22 +149,25 @@ void main() {
     test('can receive updates when child objects are updated by other queries',
         () async {
       final cache = Cache();
-      cache.writeQuery(reviewsReq, reviewsData2);
+      cache.writeQuery(reviewsReq, reviewsData);
 
       final updatedReview =
-          reviewsData.reviews!.first.rebuild((b) => b.commentary = 'first');
+          reviewsData2.reviews![1].rebuild((b) => b.commentary = 'first');
 
       expect(
           cache.watchQuery(reviewsReq),
           emitsInOrder([
+            reviewsData,
             reviewsData2,
-            reviewsData2.rebuild((b) => b..reviews[0] = updatedReview),
+            reviewsData2.rebuild((b) => b..reviews[1] = updatedReview),
             emitsDone,
           ]));
 
       await Future.delayed(Duration.zero);
+      cache.writeQuery(reviewsReq, reviewsData2);
+      await Future.delayed(Duration.zero);
       cache.writeQuery(
-          GReviewsByIDReq((b) => b..vars.id = reviewsData.reviews!.first.id),
+          GReviewsByIDReq((b) => b..vars.id = reviewsData2.reviews![1].id),
           GReviewsByIDData((b) => b.review
             ..id = updatedReview.id
             ..stars = updatedReview.stars


### PR DESCRIPTION
@knaeckeKami this is an alternative to https://github.com/gql-dart/ferry/pull/401/files to fix the regression in the watch method based on your todo:

```dart
// todo: refactor operationDataChangeStream / fragmentChangeDataStream so that they can
// deal with added ids, so we don't have to maintain this ugly block below
```

I've only modified the `operationDataChangeStream` for now to test the idea with you. I would need to update the `fragmentDataChangeStream` too before this gets merged.

~~The issue that I have though is that in the tests, [we are expecting the watchQuery() to emit a done event](https://github.com/gql-dart/ferry/blob/0c3cccc787d85135f2189a670d485614a5cf51fa/packages/ferry_cache/test/watch_test.dart#L163) but this implementation doesn't. If we comment the line, the test will pass. From what I understand, the done event should be emitted when the cache is disposed, but currently we have no way to subscribe to this event. I don't even understand how that works on master.~~
**Edit**: nvm, I figured it out by looking at the implementation of `CombineLatestStream`. See this commit [852046d](https://github.com/gql-dart/ferry/pull/403/commits/852046dd864a2c57825c12b3d0e9c154bac73401).

The first commit is just copying your failing test.
I suggest to review the second commit by ignoring the whitespaces, it'll make it easier to see the real changes.

