### PR TITLE
fix(ferry_cache): fix cache emits update too often

### DIFF
--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -63,7 +63,8 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual = const MapEquality().equals(prev, next);
+              final areEqual =
+                  const DeepCollectionEquality().equals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -84,7 +84,8 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual = const MapEquality().equals(prev, next);
+              final areEqual =
+                  const DeepCollectionEquality().equals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds


### PR DESCRIPTION
In one of the later PR, we changed operationChangeDataStream() and fragmentChangeDataStream() to watch for changed data ids.

There was a mistake though, we used MapEquality to filter updates, but the maps we compare can contain other maps.

MapEquality only works for flat maps.


see
```dart
import 'package:collection/collection.dart';

void main() {
    print(const MapEquality().equals({"a" : 1}, {"a" : 1}));
    print(const MapEquality().equals({"a" : {}}, {"a" : {}}));
}
```

this PR changes the comparison back to DeepCollectionEquality, as the current behaviour caused many duplicate updates from the cache on every query

might fix #394 

cc @GP4cK 
