### PR TITLE
feat(normalize)!: respect skip/include directives when checking for partial data

### DIFF
--- a/packages/normalize/lib/src/denormalize_node.dart
+++ b/packages/normalize/lib/src/denormalize_node.dart
@@ -47,6 +47,7 @@ Object? denormalizeNode({
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
       possibleTypes: config.possibleTypes,
+      variables: config.variables,
     );
 
     final result = subNodes.fold<Map<String, dynamic>>(

--- a/packages/normalize/lib/src/denormalize_node.dart
+++ b/packages/normalize/lib/src/denormalize_node.dart
@@ -6,6 +6,7 @@ import 'package:normalize/src/utils/exceptions.dart';
 import 'package:normalize/src/config/normalization_config.dart';
 import 'package:normalize/src/utils/is_dangling_reference.dart';
 import 'package:normalize/src/policies/field_policy.dart';
+import 'package:normalize/src/utils/well_known_directives.dart';
 
 /// Returns a denormalized object for a given [SelectionSetNode].
 ///
@@ -66,11 +67,17 @@ Object? denormalizeNode({
         /// If the policy can't read,
         /// and the key is missing from the data,
         /// we have partial data
-        if (!policyCanRead && !denormalizedData.containsKey(fieldName)) {
+        bool isSkippedValue = false;
+        if (!policyCanRead &&
+            !denormalizedData.containsKey(fieldName) &&
+            !(isSkippedValue = isSkipped(fieldNode, config.variables))) {
           if (config.allowPartialData) {
             return result;
           }
           throw PartialDataException(path: [resultKey]);
+        }
+        if (isSkippedValue) {
+          return result;
         }
 
         try {

--- a/packages/normalize/lib/src/normalize_node.dart
+++ b/packages/normalize/lib/src/normalize_node.dart
@@ -53,6 +53,7 @@ Object? normalizeNode({
       selectionSet: selectionSet,
       fragmentMap: config.fragmentMap,
       possibleTypes: config.possibleTypes,
+      variables: config.variables,
     );
 
     final dataToMerge = <String, dynamic>{

--- a/packages/normalize/lib/src/utils/expand_fragments.dart
+++ b/packages/normalize/lib/src/utils/expand_fragments.dart
@@ -1,4 +1,5 @@
 import 'package:gql/ast.dart';
+import 'package:normalize/src/utils/well_known_directives.dart';
 
 /// Adds fragment fields to selections if fragment type matches [typename]
 /// and deeply merges nested field nodes.
@@ -7,10 +8,14 @@ List<FieldNode> expandFragments({
   required SelectionSetNode selectionSet,
   required Map<String, FragmentDefinitionNode> fragmentMap,
   required Map<String, Set<String>> possibleTypes,
+  required Map<String, dynamic> variables,
 }) {
   final fieldNodes = <FieldNode>[];
 
   for (var selectionNode in selectionSet.selections) {
+    if (isSkipped(selectionNode, variables)) {
+      continue;
+    }
     if (selectionNode is FieldNode) {
       fieldNodes.add(selectionNode);
       continue;
@@ -45,6 +50,7 @@ List<FieldNode> expandFragments({
           selectionSet: fragmentSelectionSet,
           fragmentMap: fragmentMap,
           possibleTypes: possibleTypes,
+          variables: variables,
         ),
       );
     }

--- a/packages/normalize/lib/src/utils/operation_field_names.dart
+++ b/packages/normalize/lib/src/utils/operation_field_names.dart
@@ -29,6 +29,7 @@ List<String> operationFieldNames<TData, TVars>(
     selectionSet: operationDefinition.selectionSet,
     fragmentMap: fragmentMap,
     possibleTypes: possibleTypes,
+    variables: vars,
   );
   final typePolicy = typePolicies[rootTypename];
   return fields.map((fieldNode) {

--- a/packages/normalize/lib/src/utils/well_known_directives.dart
+++ b/packages/normalize/lib/src/utils/well_known_directives.dart
@@ -1,0 +1,64 @@
+import 'package:collection/collection.dart';
+import 'package:gql/ast.dart';
+
+/// returns true iff node has either
+/// - a @skip directive with an if-argument that evaluates to true
+/// - a @include directive with an if-argument that evaluates to false
+bool isSkipped(FieldNode node, Map<String, dynamic> variables) {
+  final directives = node.directives;
+
+  if (directives.isEmpty) {
+    return false;
+  }
+
+  final DirectiveNode? skipOrIncludeDirective;
+  final bool isSkipDirective;
+
+  final skipDirective = directives
+      .firstWhereOrNull((directive) => directive.name.value == 'skip');
+  if (skipDirective != null) {
+    skipOrIncludeDirective = skipDirective;
+    isSkipDirective = true;
+  } else {
+    final includeDirective = directives
+        .firstWhereOrNull((directive) => directive.name.value == 'include');
+    if (includeDirective != null) {
+      skipOrIncludeDirective = includeDirective;
+      isSkipDirective = false;
+    } else {
+      skipOrIncludeDirective = null;
+      isSkipDirective = false;
+    }
+  }
+
+  if (skipOrIncludeDirective == null) {
+    return false;
+  }
+
+  final ifArgument = skipOrIncludeDirective.arguments
+      .firstWhereOrNull((argument) => argument.name.value == 'if');
+
+  if (ifArgument == null) {
+    return false;
+  }
+
+  final ifValue = ifArgument.value;
+
+  // argument to if: is boolean literal -> use that literal directly
+  if (ifValue is BooleanValueNode) {
+    return isSkipDirective ? ifValue.value : !ifValue.value;
+  }
+  // argument to if is a variable -> look up value of that variable in variables map
+  if (ifValue is VariableNode) {
+    final variableName = ifValue.name.value;
+    final variableValue = variables[variableName];
+    if (variableValue is bool) {
+      return isSkipDirective ? variableValue : !variableValue;
+    }
+
+    /// TODO: throw error if variable is not a boolean?
+  }
+
+  /// TODO: throw error if ifValue is neither a boolean literal nor a variable?
+  return false;
+}

--- a/packages/normalize/lib/src/utils/well_known_directives.dart
+++ b/packages/normalize/lib/src/utils/well_known_directives.dart
@@ -4,16 +4,15 @@ import 'package:gql/ast.dart';
 /// returns true iff node has either
 /// - a @skip directive with an if-argument that evaluates to true
 /// - a @include directive with an if-argument that evaluates to false
-bool isSkipped(FieldNode node, Map<String, dynamic> variables) {
-  final directives = node.directives;
+bool isSkipped(SelectionNode node, Map<String, dynamic> variables) {
+  final directives = node.accept(_SelectionNodeDirectiveVisitor.instance);
 
- 
-  final skipDirective = directives
-      .firstWhereOrNull((directive) => const {'skip', 'include'}.contains( directive.name.value) );
-  if (skipDirective == null) {
+  final skipOrIncludeDirective = directives?.firstWhereOrNull(
+      (directive) => const {'skip', 'include'}.contains(directive.name.value));
+  if (skipOrIncludeDirective == null) {
     return false;
   }
-  final isSkipDirective = skipDirective.name.value === 'skip';
+  final isSkipDirective = skipOrIncludeDirective.name.value == 'skip';
 
   final ifArgument = skipOrIncludeDirective.arguments
       .firstWhereOrNull((argument) => argument.name.value == 'if');
@@ -30,14 +29,32 @@ bool isSkipped(FieldNode node, Map<String, dynamic> variables) {
   }
   // argument to if is a variable -> look up value of that variable in variables map
   if (ifValue is! VariableNode) {
-    /// TODO: throw error if ifValue is neither a boolean literal nor a variable?
     return false;
   }
   final variableName = ifValue.name.value;
   final variableValue = variables[variableName];
   if (variableValue is! bool) {
-   /// TODO: throw error if variable is not a boolean?
     return false;
   }
   return isSkipDirective ? variableValue : !variableValue;
+}
+
+class _SelectionNodeDirectiveVisitor
+    extends SimpleVisitor<List<DirectiveNode>?> {
+  static final instance = _SelectionNodeDirectiveVisitor();
+
+  @override
+  List<DirectiveNode> visitFieldNode(FieldNode node) {
+    return node.directives;
+  }
+
+  @override
+  List<DirectiveNode> visitFragmentSpreadNode(FragmentSpreadNode node) {
+    return node.directives;
+  }
+
+  @override
+  List<DirectiveNode> visitInlineFragmentNode(InlineFragmentNode node) {
+    return node.directives;
+  }
 }

--- a/packages/normalize/lib/src/utils/well_known_directives.dart
+++ b/packages/normalize/lib/src/utils/well_known_directives.dart
@@ -7,33 +7,13 @@ import 'package:gql/ast.dart';
 bool isSkipped(FieldNode node, Map<String, dynamic> variables) {
   final directives = node.directives;
 
-  if (directives.isEmpty) {
-    return false;
-  }
-
-  final DirectiveNode? skipOrIncludeDirective;
-  final bool isSkipDirective;
-
+ 
   final skipDirective = directives
-      .firstWhereOrNull((directive) => directive.name.value == 'skip');
-  if (skipDirective != null) {
-    skipOrIncludeDirective = skipDirective;
-    isSkipDirective = true;
-  } else {
-    final includeDirective = directives
-        .firstWhereOrNull((directive) => directive.name.value == 'include');
-    if (includeDirective != null) {
-      skipOrIncludeDirective = includeDirective;
-      isSkipDirective = false;
-    } else {
-      skipOrIncludeDirective = null;
-      isSkipDirective = false;
-    }
-  }
-
-  if (skipOrIncludeDirective == null) {
+      .firstWhereOrNull((directive) => const {'skip', 'include'}.contains( directive.name.value) );
+  if (skipDirective == null) {
     return false;
   }
+  final isSkipDirective = skipDirective.name.value === 'skip';
 
   final ifArgument = skipOrIncludeDirective.arguments
       .firstWhereOrNull((argument) => argument.name.value == 'if');
@@ -49,16 +29,15 @@ bool isSkipped(FieldNode node, Map<String, dynamic> variables) {
     return isSkipDirective ? ifValue.value : !ifValue.value;
   }
   // argument to if is a variable -> look up value of that variable in variables map
-  if (ifValue is VariableNode) {
-    final variableName = ifValue.name.value;
-    final variableValue = variables[variableName];
-    if (variableValue is bool) {
-      return isSkipDirective ? variableValue : !variableValue;
-    }
-
-    /// TODO: throw error if variable is not a boolean?
+  if (ifValue is! VariableNode) {
+    /// TODO: throw error if ifValue is neither a boolean literal nor a variable?
+    return false;
   }
-
-  /// TODO: throw error if ifValue is neither a boolean literal nor a variable?
-  return false;
+  final variableName = ifValue.name.value;
+  final variableValue = variables[variableName];
+  if (variableValue is! bool) {
+   /// TODO: throw error if variable is not a boolean?
+    return false;
+  }
+  return isSkipDirective ? variableValue : !variableValue;
 }

--- a/packages/normalize/test/partial_results_test.dart
+++ b/packages/normalize/test/partial_results_test.dart
@@ -473,5 +473,630 @@ void main() {
         }),
       );
     });
+
+    test('respects skip directives with value true on fragments', () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          ...PostTitle @skip(if: \$skip)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with value false on fragments', () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          ...PostTitle @skip(if: \$skip)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello',
+            }
+          ]
+        }),
+      );
+    });
+
+    test(
+        'throws when skip directives with value false on fragments is used but data is missing',
+        () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          ...PostTitle @skip(if: \$skip)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        () => denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          handleException: false,
+          variables: {
+            'skip': false,
+          },
+        ),
+        throwsA(isA<PartialDataException>()),
+      );
+    });
+
+    test('respects include directives with value true on fragments', () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ...PostTitle @include(if: \$include)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello World',
+          '__typename': 'Post',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello World',
+            }
+          ]
+        }),
+      );
+    });
+
+    test(
+        'respects include directives with value false on fragments, returns null on missing data',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ...PostTitle @include(if: \$include)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+          'title': 'hello',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with value false on fragments', () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ...PostTitle @include(if: \$include)
+        }
+      }
+
+      fragment PostTitle on Post {
+        title
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with variable true on inline fragments', () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          ... on Post @skip(if: \$skip) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with variable false on inline fragments',
+        () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          ... @skip(if: \$skip) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello World',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello World',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with variable true on inline fragments',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ... on Post @include(if: \$include) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello World',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello World',
+            }
+          ]
+        }),
+      );
+    });
+
+    test(
+        'respects include directives with variable true on inline fragments with partial data',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ... on Post @include(if: \$include) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': true,
+          },
+        ),
+        isNull,
+      );
+    });
+
+    test('respects include directives with variable false on inline fragments',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          ... on Post @include(if: \$include) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test(
+        'throws, when a field once specified twice, once in an skipped context and once without and data is missing',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          title
+          ... on Post @include(if: \$include) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        () => denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          handleException: false,
+          variables: {
+            'include': false,
+          },
+        ),
+        throwsA(isA<PartialDataException>()),
+      );
+    });
+
+    test(
+        'works when a field once specified twice, once in an skipped context and once without and data is there',
+        () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          title
+          ... @include(if: \$include) {
+            title
+          }
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello World',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          handleException: false,
+          variables: {
+            'include': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              'title': 'Hello World',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
   });
 }

--- a/packages/normalize/test/partial_results_test.dart
+++ b/packages/normalize/test/partial_results_test.dart
@@ -118,4 +118,360 @@ void main() {
       equals(response),
     );
   });
+
+  group(
+      'does not count missing data due to skip/include directives as partial data',
+      () {
+    test('respects skip directives with literal true', () {
+      final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          title @skip(if: true)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with literal false', () {
+      final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          title @skip(if: false)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with literal true', () {
+      final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          title @include(if: true)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+          'title': 'Hello World',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello World',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with literal false', () {
+      final query = parseString('''
+      query TestQuery {
+        posts {
+          id
+          title @include(if: false)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with variable true', () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          title @skip(if: \$skip)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects skip directives with variable false', () {
+      final query = parseString('''
+      query TestQuery(\$skip: Boolean!) {
+        posts {
+          id
+          title @skip(if: \$skip)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          'title': 'Hello',
+          '__typename': 'Post',
+        },
+      };
+
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'skip': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with variable true', () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          title @include(if: \$include)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+          'title': 'Hello World',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': true,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+              'title': 'Hello World',
+            }
+          ]
+        }),
+      );
+    });
+
+    test('respects include directives with variable false', () {
+      final query = parseString('''
+      query TestQuery(\$include: Boolean!) {
+        posts {
+          id
+          title @include(if: \$include)
+        }
+      }
+    ''');
+
+      final data = {
+        'Query': {
+          '__typename': 'Query',
+          'posts': [
+            {'\$ref': 'Post:123'}
+          ]
+        },
+        'Post:123': {
+          'id': '123',
+          '__typename': 'Post',
+        },
+      };
+      expect(
+        denormalizeOperation(
+          document: query,
+          read: (dataId) => data[dataId],
+          addTypename: true,
+          returnPartialData: false,
+          variables: {
+            'include': false,
+          },
+        ),
+        equals({
+          '__typename': 'Query',
+          'posts': [
+            {
+              'id': '123',
+              '__typename': 'Post',
+            }
+          ]
+        }),
+      );
+    });
+  });
 }

--- a/packages/normalize/test/utils/expand_fragment_test.dart
+++ b/packages/normalize/test/utils/expand_fragment_test.dart
@@ -1,0 +1,198 @@
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
+import 'package:normalize/src/utils/expand_fragments.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("expands fragments", () {
+    final query = parseString('''
+query AllPokemons {
+    allPokemons {
+        id
+        ...nameAndAvatar
+    }
+}
+fragment nameAndAvatar on Pokemon {
+    name
+    avatar
+}''');
+
+    final fragmentMap = {
+      'nameAndAvatar': query.definitions[1] as FragmentDefinitionNode,
+    };
+
+    final expanded = expandFragments(
+      typename: 'Pokemon',
+      selectionSet: ((query.definitions.first as OperationDefinitionNode)
+              .selectionSet
+              .selections
+              .first as FieldNode)
+          .selectionSet!,
+      fragmentMap: fragmentMap,
+      possibleTypes: {},
+      variables: {},
+    );
+
+    expect(expanded, [
+      FieldNode(
+        name: NameNode(value: 'id'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+      FieldNode(
+        name: NameNode(value: 'name'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+      FieldNode(
+        name: NameNode(value: 'avatar'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]);
+  });
+
+  test("does not expand skipped fragments", () {
+    final query = parseString('''
+query AllPokemons {
+    allPokemons {
+        id
+        ...nameAndAvatar @skip(if: true)
+    }
+}    
+fragment nameAndAvatar on Pokemon {
+    name
+    avatar
+}''');
+
+    final fragmentMap = {
+      'nameAndAvatar': query.definitions[1] as FragmentDefinitionNode,
+    };
+
+    final expanded = expandFragments(
+      typename: 'Pokemon',
+      selectionSet: ((query.definitions.first as OperationDefinitionNode)
+              .selectionSet
+              .selections
+              .first as FieldNode)
+          .selectionSet!,
+      fragmentMap: fragmentMap,
+      possibleTypes: {},
+      variables: {},
+    );
+
+    expect(expanded, [
+      FieldNode(
+        name: NameNode(value: 'id'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]);
+  });
+
+  test("does not expand skipped fragments with variables", () {
+    final query = parseString('''query AllPokemons {  
+        allPokemons {
+          id
+          ...nameAndAvatar @skip(if: \$skip)
+        }
+      }
+      fragment nameAndAvatar on Pokemon {
+        name
+        avatar
+      }''');
+
+    final fragmentMap = {
+      'nameAndAvatar': query.definitions[1] as FragmentDefinitionNode,
+    };
+
+    final expanded = expandFragments(
+      typename: 'Pokemon',
+      selectionSet: ((query.definitions.first as OperationDefinitionNode)
+              .selectionSet
+              .selections
+              .first as FieldNode)
+          .selectionSet!,
+      fragmentMap: fragmentMap,
+      possibleTypes: {},
+      variables: {
+        'skip': true,
+      },
+    );
+
+    expect(expanded, [
+      FieldNode(
+        name: NameNode(value: 'id'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]);
+  });
+
+  test(
+      "expands fragments with skip directive with argument that evaluates to false",
+      () {
+    final query = parseString('''query AllPokemons {  
+        allPokemons {
+          id
+          ...nameAndAvatar @skip(if: \$skip)
+        }
+      }
+      fragment nameAndAvatar on Pokemon {
+        name
+        avatar
+      }''');
+
+    final fragmentMap = {
+      'nameAndAvatar': query.definitions[1] as FragmentDefinitionNode,
+    };
+
+    final expanded = expandFragments(
+      typename: 'Pokemon',
+      selectionSet: ((query.definitions.first as OperationDefinitionNode)
+              .selectionSet
+              .selections
+              .first as FieldNode)
+          .selectionSet!,
+      fragmentMap: fragmentMap,
+      possibleTypes: {},
+      variables: {
+        'skip': false,
+      },
+    );
+
+    expect(expanded, [
+      FieldNode(
+        name: NameNode(value: 'id'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+      FieldNode(
+        name: NameNode(value: 'name'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+      FieldNode(
+        name: NameNode(value: 'avatar'),
+        alias: null,
+        arguments: [],
+        directives: [],
+        selectionSet: null,
+      ),
+    ]);
+  });
+}

--- a/packages/normalize/test/utils/is_skipped_test.dart
+++ b/packages/normalize/test/utils/is_skipped_test.dart
@@ -4,8 +4,9 @@ import 'package:normalize/src/utils/well_known_directives.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("fields without directives are not skipped", () {
-    final fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+  group("skipped fields", () {
+    test("fields without directives are not skipped", () {
+      final fields = _getFieldsOfSimpleQuery('''query AllPokemon {
       pokemons {
         id
         name
@@ -13,13 +14,13 @@ void main() {
       }
     }''');
 
-    for (final field in fields) {
-      expect(isSkipped(field, const {}), false);
-    }
-  });
+      for (final field in fields) {
+        expect(isSkipped(field, const {}), false);
+      }
+    });
 
-  test("fields with skip directive with true literal are skipped", () {
-    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+    test("fields with skip directive with true literal are skipped", () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
       pokemons {
         id
         name
@@ -27,23 +28,23 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarSkipped = false;
+      bool isAvatarSkipped = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, const {}), true);
-        isAvatarSkipped = true;
-      } else {
-        expect(isSkipped(field, const {}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, const {}), true);
+          isAvatarSkipped = true;
+        } else {
+          expect(isSkipped(field, const {}), false);
+        }
       }
-    }
-    expect(isAvatarSkipped, true);
-  });
+      expect(isAvatarSkipped, true);
+    });
 
-  test("fields with skip directive with false literal are not skipped", () {
-    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+    test("fields with skip directive with false literal are not skipped", () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
       pokemons {
         id
         name
@@ -51,23 +52,23 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvaterVisited = false;
+      bool isAvaterVisited = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, const {}), false);
-        isAvaterVisited = true;
-      } else {
-        expect(isSkipped(field, const {}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, const {}), false);
+          isAvaterVisited = true;
+        } else {
+          expect(isSkipped(field, const {}), false);
+        }
       }
-    }
-    expect(isAvaterVisited, true);
-  });
+      expect(isAvaterVisited, true);
+    });
 
-  test("fields with include directive with false literal are skipped", () {
-    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+    test("fields with include directive with false literal are skipped", () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
       pokemons {
         id
         name
@@ -75,23 +76,23 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarSkipped = false;
+      bool isAvatarSkipped = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, const {}), true);
-        isAvatarSkipped = true;
-      } else {
-        expect(isSkipped(field, const {}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, const {}), true);
+          isAvatarSkipped = true;
+        } else {
+          expect(isSkipped(field, const {}), false);
+        }
       }
-    }
-    expect(isAvatarSkipped, true);
-  });
+      expect(isAvatarSkipped, true);
+    });
 
-  test("fields with include directive with true literal are not skipped", () {
-    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+    test("fields with include directive with true literal are not skipped", () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
       pokemons {
         id
         name
@@ -99,24 +100,25 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarVisited = false;
+      bool isAvatarVisited = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, const {}), false);
-        isAvatarVisited = true;
-      } else {
-        expect(isSkipped(field, const {}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, const {}), false);
+          isAvatarVisited = true;
+        } else {
+          expect(isSkipped(field, const {}), false);
+        }
       }
-    }
-    expect(isAvatarVisited, true);
-  });
+      expect(isAvatarVisited, true);
+    });
 
-  test("fields with skip directive with variable set to true are skipped", () {
-    Iterable<FieldNode> fields =
-        _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
+    test("fields with skip directive with variable set to true are skipped",
+        () {
+      Iterable<FieldNode> fields =
+          _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
       pokemons {
         id
         name
@@ -124,25 +126,26 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarSkipped = false;
+      bool isAvatarSkipped = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, {"skipAvatar": true}), true);
-        isAvatarSkipped = true;
-      } else {
-        expect(isSkipped(field, {"skipAvatar": true}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, {"skipAvatar": true}), true);
+          isAvatarSkipped = true;
+        } else {
+          expect(isSkipped(field, {"skipAvatar": true}), false);
+        }
       }
-    }
-    expect(isAvatarSkipped, true);
-  });
+      expect(isAvatarSkipped, true);
+    });
 
-  test("fields with skip directive with variable set to false are not skipped",
-      () {
-    Iterable<FieldNode> fields =
-        _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
+    test(
+        "fields with skip directive with variable set to false are not skipped",
+        () {
+      Iterable<FieldNode> fields =
+          _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
       pokemons {
         id
         name
@@ -150,26 +153,26 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarVisited = false;
+      bool isAvatarVisited = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, {"skipAvatar": false}), false);
-        isAvatarVisited = true;
-      } else {
-        expect(isSkipped(field, {"skipAvatar": false}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, {"skipAvatar": false}), false);
+          isAvatarVisited = true;
+        } else {
+          expect(isSkipped(field, {"skipAvatar": false}), false);
+        }
       }
-    }
-    expect(isAvatarVisited, true);
-  });
+      expect(isAvatarVisited, true);
+    });
 
-  test(
-      "fields with include directive with variable set to true are not skipped",
-      () {
-    Iterable<FieldNode> fields =
-        _getFieldsOfSimpleQuery('''query AllPokemon(\$includeAvatar: Boolean!) {
+    test(
+        "fields with include directive with variable set to true are not skipped",
+        () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery(
+          '''query AllPokemon(\$includeAvatar: Boolean!) {
       pokemons {
         id
         name
@@ -177,25 +180,25 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarVisited = false;
+      bool isAvatarVisited = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, {"includeAvatar": true}), false);
-        isAvatarVisited = true;
-      } else {
-        expect(isSkipped(field, {"includeAvatar": true}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, {"includeAvatar": true}), false);
+          isAvatarVisited = true;
+        } else {
+          expect(isSkipped(field, {"includeAvatar": true}), false);
+        }
       }
-    }
-    expect(isAvatarVisited, true);
-  });
+      expect(isAvatarVisited, true);
+    });
 
-  test("fields with include directive with variable set to false are skipped",
-      () {
-    Iterable<FieldNode> fields =
-        _getFieldsOfSimpleQuery('''query AllPokemon(\$includeAvatar: Boolean!) {
+    test("fields with include directive with variable set to false are skipped",
+        () {
+      Iterable<FieldNode> fields = _getFieldsOfSimpleQuery(
+          '''query AllPokemon(\$includeAvatar: Boolean!) {
       pokemons {
         id
         name
@@ -203,19 +206,325 @@ void main() {
       }
     }''');
 
-    expect(fields.length, 3);
+      expect(fields.length, 3);
 
-    bool isAvatarSkipped = false;
+      bool isAvatarSkipped = false;
 
-    for (final field in fields) {
-      if (field.name.value == "avatar") {
-        expect(isSkipped(field, {"includeAvatar": false}), true);
-        isAvatarSkipped = true;
-      } else {
-        expect(isSkipped(field, {"includeAvatar": false}), false);
+      for (final field in fields) {
+        if (field.name.value == "avatar") {
+          expect(isSkipped(field, {"includeAvatar": false}), true);
+          isAvatarSkipped = true;
+        } else {
+          expect(isSkipped(field, {"includeAvatar": false}), false);
+        }
       }
-    }
-    expect(isAvatarSkipped, true);
+      expect(isAvatarSkipped, true);
+    });
+  });
+
+  group("skipped fragments", () {
+    test("fragments with skip directive with true literal are skipped", () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ...AvatarNameFragment @skip(if: true)
+        }
+        fragment AvatarNameFragment on Pokemon {
+          name
+          avatar
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), true);
+    });
+
+    test("fragments with skip directive with false literal are not skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ...AvatarNameFragment @skip(if: false)
+        }
+        fragment AvatarNameFragment on Pokemon {
+          name
+          avatar
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), false);
+    });
+
+    test("fragments with include directive with true literal are not skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ...AvatarNameFragment @include(if: true)
+        }
+        fragment AvatarNameFragment on Pokemon {
+          name
+          avatar
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), false);
+    });
+
+    test("fragments with include directive with false literal are skipped", () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ...AvatarNameFragment @include(if: false)
+        }
+        fragment AvatarNameFragment on Pokemon {
+          name
+          avatar
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), true);
+    });
+
+    test(
+        "fragments with skip directive with variable is skipped iff true variable is true",
+        () {
+      final query = parseString('''query AllPokemon(\$skipAvatar: Boolean!) {
+        pokemons {
+          id
+          ...AvatarNameFragment @skip(if: \$skipAvatar)
+        }
+        fragment AvatarNameFragment on Pokemon {
+          name
+          avatar
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, {"skipAvatar": false}), false);
+      expect(isSkipped(fragment, {"skipAvatar": false}), false);
+      expect(isSkipped(id, {"skipAvatar": true}), false);
+      expect(isSkipped(fragment, {"skipAvatar": true}), true);
+    });
+
+    test(
+        "fragments with include directive with variable is skipped iff true variable is false",
+        () {
+      final query = parseString('''query AllPokemon(\$includeAvatar: Boolean!) {
+      pokemons {
+        id
+        ...AvatarNameFragment @include(if: \$includeAvatar)
+      }
+      fragment AvatarNameFragment on Pokemon {
+        name
+        avatar
+      }
+    }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as FragmentSpreadNode;
+
+      expect(isSkipped(id, {"includeAvatar": true}), false);
+      expect(isSkipped(fragment, {"includeAvatar": true}), false);
+      expect(isSkipped(id, {"includeAvatar": false}), false);
+      expect(isSkipped(fragment, {"includeAvatar": false}), true);
+    });
+  });
+
+  group("inline fragments", () {
+    test("inline fragments with skip directive with true literal are skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ... on Pikachu @skip(if: true) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), true);
+    });
+
+    test(
+        "inline fragments with skip directive with false literal are not skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ... on Pikachu @skip(if: false) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), false);
+    });
+
+    test(
+        "inline fragments with include directive with true literal are not skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ... on Pikachu @include(if: true) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), false);
+    });
+
+    test(
+        "inline fragments with include directive with false literal are skipped",
+        () {
+      final query = parseString('''query AllPokemon {
+        pokemons {
+          id
+          ... on Pikachu @include(if: false) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, const {}), false);
+      expect(isSkipped(fragment, const {}), true);
+    });
+
+    test(
+        "inline fragments with skip directive with variable is skipped iff true variable is true",
+        () {
+      final query = parseString('''query AllPokemon(\$skipAvatar: Boolean!) {
+        pokemons {
+          id
+          ... on Pikachu @skip(if: \$skipAvatar) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, {"skipAvatar": false}), false);
+      expect(isSkipped(fragment, {"skipAvatar": false}), false);
+      expect(isSkipped(id, {"skipAvatar": true}), false);
+      expect(isSkipped(fragment, {"skipAvatar": true}), true);
+    });
+
+    test(
+        "inline fragments with include directive with variable is skipped iff true variable is false",
+        () {
+      final query = parseString('''query AllPokemon(\$includeAvatar: Boolean!) {
+        pokemons {
+          id
+          ... on Pikachu @include(if: \$includeAvatar) {
+            isFavorite
+          }
+        }
+      }''');
+
+      final selections = (query.definitions[0] as OperationDefinitionNode)
+          .selectionSet
+          .selections[0] as FieldNode;
+
+      final id = selections.selectionSet!.selections[0] as FieldNode;
+      final fragment =
+          selections.selectionSet!.selections[1] as InlineFragmentNode;
+
+      expect(isSkipped(id, {"includeAvatar": true}), false);
+      expect(isSkipped(fragment, {"includeAvatar": true}), false);
+      expect(isSkipped(id, {"includeAvatar": false}), false);
+      expect(isSkipped(fragment, {"includeAvatar": false}), true);
+    });
   });
 }
 

--- a/packages/normalize/test/utils/is_skipped_test.dart
+++ b/packages/normalize/test/utils/is_skipped_test.dart
@@ -1,0 +1,233 @@
+import 'package:gql/ast.dart';
+import 'package:gql/language.dart';
+import 'package:normalize/src/utils/well_known_directives.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("fields without directives are not skipped", () {
+    final fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+      pokemons {
+        id
+        name
+        avatar
+      }
+    }''');
+
+    for (final field in fields) {
+      expect(isSkipped(field, const {}), false);
+    }
+  });
+
+  test("fields with skip directive with true literal are skipped", () {
+    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+      pokemons {
+        id
+        name
+        avatar @skip(if: true)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarSkipped = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, const {}), true);
+        isAvatarSkipped = true;
+      } else {
+        expect(isSkipped(field, const {}), false);
+      }
+    }
+    expect(isAvatarSkipped, true);
+  });
+
+  test("fields with skip directive with false literal are not skipped", () {
+    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+      pokemons {
+        id
+        name
+        avatar @skip(if: false)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvaterVisited = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, const {}), false);
+        isAvaterVisited = true;
+      } else {
+        expect(isSkipped(field, const {}), false);
+      }
+    }
+    expect(isAvaterVisited, true);
+  });
+
+  test("fields with include directive with false literal are skipped", () {
+    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+      pokemons {
+        id
+        name
+        avatar @include(if: false)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarSkipped = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, const {}), true);
+        isAvatarSkipped = true;
+      } else {
+        expect(isSkipped(field, const {}), false);
+      }
+    }
+    expect(isAvatarSkipped, true);
+  });
+
+  test("fields with include directive with true literal are not skipped", () {
+    Iterable<FieldNode> fields = _getFieldsOfSimpleQuery('''query AllPokemon {
+      pokemons {
+        id
+        name
+        avatar @include(if: true)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarVisited = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, const {}), false);
+        isAvatarVisited = true;
+      } else {
+        expect(isSkipped(field, const {}), false);
+      }
+    }
+    expect(isAvatarVisited, true);
+  });
+
+  test("fields with skip directive with variable set to true are skipped", () {
+    Iterable<FieldNode> fields =
+        _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
+      pokemons {
+        id
+        name
+        avatar @skip(if: \$skipAvatar)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarSkipped = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, {"skipAvatar": true}), true);
+        isAvatarSkipped = true;
+      } else {
+        expect(isSkipped(field, {"skipAvatar": true}), false);
+      }
+    }
+    expect(isAvatarSkipped, true);
+  });
+
+  test("fields with skip directive with variable set to false are not skipped",
+      () {
+    Iterable<FieldNode> fields =
+        _getFieldsOfSimpleQuery('''query AllPokemon(\$skipAvatar: Boolean!) {
+      pokemons {
+        id
+        name
+        avatar @skip(if: \$skipAvatar)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarVisited = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, {"skipAvatar": false}), false);
+        isAvatarVisited = true;
+      } else {
+        expect(isSkipped(field, {"skipAvatar": false}), false);
+      }
+    }
+    expect(isAvatarVisited, true);
+  });
+
+  test(
+      "fields with include directive with variable set to true are not skipped",
+      () {
+    Iterable<FieldNode> fields =
+        _getFieldsOfSimpleQuery('''query AllPokemon(\$includeAvatar: Boolean!) {
+      pokemons {
+        id
+        name
+        avatar @include(if: \$includeAvatar)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarVisited = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, {"includeAvatar": true}), false);
+        isAvatarVisited = true;
+      } else {
+        expect(isSkipped(field, {"includeAvatar": true}), false);
+      }
+    }
+    expect(isAvatarVisited, true);
+  });
+
+  test("fields with include directive with variable set to false are skipped",
+      () {
+    Iterable<FieldNode> fields =
+        _getFieldsOfSimpleQuery('''query AllPokemon(\$includeAvatar: Boolean!) {
+      pokemons {
+        id
+        name
+        avatar @include(if: \$includeAvatar)
+      }
+    }''');
+
+    expect(fields.length, 3);
+
+    bool isAvatarSkipped = false;
+
+    for (final field in fields) {
+      if (field.name.value == "avatar") {
+        expect(isSkipped(field, {"includeAvatar": false}), true);
+        isAvatarSkipped = true;
+      } else {
+        expect(isSkipped(field, {"includeAvatar": false}), false);
+      }
+    }
+    expect(isAvatarSkipped, true);
+  });
+}
+
+Iterable<FieldNode> _getFieldsOfSimpleQuery(String queryString) {
+  final query = parseString(queryString);
+
+  final selectionSet =
+      (query.definitions.first as OperationDefinitionNode).selectionSet;
+
+  final fields = (selectionSet.selections.first as FieldNode)
+      .selectionSet!
+      .selections
+      .whereType<FieldNode>();
+  return fields;
+}


### PR DESCRIPTION
When checking for partial data, do not treat missing fields as partial data, if the field has a `skip` directive with an `if:` argument that evaluates to `true` or an `include` directive with an `if:` argument that evaluates to `false`
or if the field is in a fragment or an inline fragment with such a directive


fixes #432