### PR TITLE
fix/remove optimistic response when unsubscribe

### DIFF
--- a/examples/pokemon_explorer/pubspec.yaml
+++ b/examples/pokemon_explorer/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   gql_http_link: ^0.4.0
   ferry: ^0.11.0
   ferry_hive_store: ^0.5.0
-  ferry_flutter: ^0.8.0
+  ferry_flutter: ^0.8.0-dev.0+1
   hive: ^2.0.0
   hive_flutter: ^1.1.0
   get_it: ^7.1.3

--- a/examples/pokemon_explorer/pubspec.yaml
+++ b/examples/pokemon_explorer/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   gql_http_link: ^0.4.0
   ferry: ^0.11.0
   ferry_hive_store: ^0.5.0
-  ferry_flutter: ^0.8.0-dev.1
+  ferry_flutter: ^0.8.0-dev.2
   hive: ^2.0.0
   hive_flutter: ^1.1.0
   get_it: ^7.1.3

--- a/examples/pokemon_explorer/pubspec.yaml
+++ b/examples/pokemon_explorer/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   gql_http_link: ^0.4.0
   ferry: ^0.11.0
   ferry_hive_store: ^0.5.0
-  ferry_flutter: ^0.8.0-dev.0+1
+  ferry_flutter: ^0.8.0-dev.1
   hive: ^2.0.0
   hive_flutter: ^1.1.0
   get_it: ^7.1.3

--- a/packages/ferry/CHANGELOG.md
+++ b/packages/ferry/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.1-dev.1
+
+ - **FEAT**: add watchQuery, watchFragment, clearOptimisticPatches to IsolateClient  (#460).
+
 ## 0.13.1
 
  - **FIX**: send error to main isolate when data message could not be serialized (#455).

--- a/packages/ferry/CHANGELOG.md
+++ b/packages/ferry/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0-dev.1
+
+ - **FEAT**: add watchQuery, watchFragment, clearOptimisticPatches to IsolateClient  (#460).
+
 ## 0.13.0-dev.0+1
 
  - **FIX**: send error to main isolate when data message could not be serialized (#455).

--- a/packages/ferry/CHANGELOG.md
+++ b/packages/ferry/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.13.1
+
+ - **FIX**: send error to main isolate when data message could not be serialized (#455).
+ - **FEAT**: add watchQuery, watchFragment, clearOptimisticPatches to IsolateClient  (#460).
+
 ## 0.13.0-dev.1
 
  - **FEAT**: add watchQuery, watchFragment, clearOptimisticPatches to IsolateClient  (#460).

--- a/packages/ferry/CHANGELOG.md
+++ b/packages/ferry/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.0-dev.0+1
+
+ - **FIX**: send error to main isolate when data message could not be serialized (#455).
+
 ## 0.13.0
 
  - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.

--- a/packages/ferry/lib/src/fetch_policy_typed_link.dart
+++ b/packages/ferry/lib/src/fetch_policy_typed_link.dart
@@ -65,12 +65,14 @@ class FetchPolicyTypedLink extends TypedLink {
       case FetchPolicy.NoCache:
         return _optimisticLinkTypedLink
             .request(operationRequest)
-            .doOnData(_removeOptimisticPatch);
+            .doOnData(_removeOptimisticPatch)
+            .doOnCancel(() => cache.removeOptimisticPatch(operationRequest));
       case FetchPolicy.NetworkOnly:
         return _optimisticLinkTypedLink
             .request(operationRequest)
             .doOnData(_removeOptimisticPatch)
-            .doOnData(_writeToCache);
+            .doOnData(_writeToCache)
+            .doOnCancel(() => cache.removeOptimisticPatch(operationRequest));
       case FetchPolicy.CacheOnly:
         return _cacheTypedLink.request(operationRequest);
       case FetchPolicy.CacheFirst:
@@ -81,6 +83,8 @@ class FetchPolicyTypedLink extends TypedLink {
                       .request(operationRequest)
                       .doOnData(_removeOptimisticPatch)
                       .doOnData(_writeToCache)
+                      .doOnCancel(
+                          () => cache.removeOptimisticPatch(operationRequest))
                       .switchMap(
                         (networkResponse) => ConcatStream([
                           Stream.value(networkResponse),
@@ -100,6 +104,7 @@ class FetchPolicyTypedLink extends TypedLink {
           sharedNetworkStream
               .doOnData(_removeOptimisticPatch)
               .doOnData(_writeToCache)
+              .doOnCancel(() => cache.removeOptimisticPatch(operationRequest))
               .concatWith([_cacheTypedLink.request(operationRequest).skip(1)])
         ]);
       default:

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.13.0
+version: 0.13.0-dev.0+1
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry
@@ -16,7 +16,7 @@ dependencies:
   built_value: ^8.0.4
   ferry_exec: ^0.3.0
   normalize: ^0.8.0
-  ferry_cache: ^0.7.0
+  ferry_cache: ^0.7.1-dev.0
 dev_dependencies:
   test: ^1.16.8
   mockito: ^5.3.1

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.13.1
+version: 0.13.1-dev.1
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.13.0-dev.1
+version: 0.13.1
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry
-version: 0.13.0-dev.0+1
+version: 0.13.0-dev.1
 homepage: https://ferrygraphql.com/
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry_cache/CHANGELOG.md
+++ b/packages/ferry_cache/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1-dev.0
+
+ - **FEAT**: add `clearOptimisticPatches()` (#459).
+
 ## 0.7.0
 
  - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.

--- a/packages/ferry_cache/pubspec.yaml
+++ b/packages/ferry_cache/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_cache
-version: 0.7.0
+version: 0.7.1-dev.0
 homepage: https://ferrygraphql.com/
 description: A normalized, strongly typed, optimistic cache for GraphQL Operations and Fragments
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry_flutter/CHANGELOG.md
+++ b/packages/ferry_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-dev.0+1
+
+ - Update a dependency to the latest release.
+
 ## 0.8.0
 
  - Graduate package to a stable release. See pre-releases prior to this version for changelog entries.

--- a/packages/ferry_flutter/CHANGELOG.md
+++ b/packages/ferry_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-dev.2
+
+ - Update a dependency to the latest release.
+
 ## 0.8.0-dev.1
 
  - Update a dependency to the latest release.

--- a/packages/ferry_flutter/CHANGELOG.md
+++ b/packages/ferry_flutter/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.0-dev.1
+
+ - Update a dependency to the latest release.
+
 ## 0.8.0-dev.0+1
 
  - Update a dependency to the latest release.

--- a/packages/ferry_flutter/pubspec.yaml
+++ b/packages/ferry_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_flutter
-version: 0.8.0
+version: 0.8.0-dev.0+1
 homepage: https://ferrygraphql.com/
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry_flutter/pubspec.yaml
+++ b/packages/ferry_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_flutter
-version: 0.8.0-dev.0+1
+version: 0.8.0-dev.1
 homepage: https://ferrygraphql.com/
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry

--- a/packages/ferry_flutter/pubspec.yaml
+++ b/packages/ferry_flutter/pubspec.yaml
@@ -1,5 +1,5 @@
 name: ferry_flutter
-version: 0.8.0-dev.1
+version: 0.8.0-dev.2
 homepage: https://ferrygraphql.com/
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry


### PR DESCRIPTION
- fix(ferry!): remove optimistic patch when listener unsubscribes before link responds with data instead of leaking optimistic patch forever
