### PR TITLE
refactor(ferry_cache): use jsonMapEquals instead of DeepCollectionEquality().equals to avoid it's O(n^2) complexity, add distinct: param to watch() method 

### DIFF
--- a/examples/auth_token_with_isolate/client/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/auth_token_with_isolate/client/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,7 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_macos
-import shared_preferences_macos
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -16,6 +16,7 @@ class Cache {
   final bool addTypename;
   final Store store;
   final utils.DataIdResolver? dataIdFromObject;
+  final JsonEquals jsonEquals;
 
   /// this stream is used to debounce updates from watchQuery/watchFragment
   /// to avoid emitting multiple times for the same change when multiple
@@ -38,9 +39,11 @@ class Cache {
     this.addTypename = true,
     Map<OperationRequest, Map<String, Map<String, dynamic>?>>
         seedOptimisticPatches = const {},
+    JsonEquals? jsonEquals,
   })  : store = store ?? MemoryStore(),
         _eventStream = BehaviorSubject.seeded(null),
-        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches);
+        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches),
+        jsonEquals = jsonEquals ?? jsonMapEquals;
 
   /// Reads data for the given [dataId] from the [Store], merging in any data from optimistic patches
   @visibleForTesting
@@ -73,6 +76,7 @@ class Cache {
           addTypename,
           dataIdFromObject,
           possibleTypes,
+          jsonEquals,
         ),
         getData: () => readQuery(request, optimistic: optimistic),
       );
@@ -93,6 +97,7 @@ class Cache {
           addTypename,
           dataIdFromObject,
           possibleTypes,
+          jsonEquals,
         ),
         getData: () => readFragment(request, optimistic: optimistic),
       );

--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
 import 'package:normalize/normalize.dart';
@@ -21,6 +22,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
+  JsonEquals jsonEquals,
 ) {
   final dataIdStreamController = StreamController<void>();
   final result = dataIdStreamController.stream
@@ -63,8 +65,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual =
-                  const DeepCollectionEquality().equals(prev, next);
+              final areEqual = jsonEquals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
 import 'package:normalize/normalize.dart';
@@ -22,6 +23,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
+  JsonEquals jsonEquals,
 ) {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
@@ -84,8 +86,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual =
-                  const DeepCollectionEquality().equals(prev, next);
+              final areEqual = jsonEquals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds

--- a/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
+++ b/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
@@ -18,8 +18,8 @@ Stream<Map<String, dynamic>?> dataForIdStream(
             Map<OperationRequest<dynamic, dynamic>,
                 Map<String, Map<String, dynamic>?>>?,
             Map<String, dynamic>?>(
-            store.watch(dataId),
+            store.watch(dataId, distinct: false),
             optimisticPatchesStream,
             (_, __) => optimisticReader(dataId),
           )
-        : store.watch(dataId);
+        : store.watch(dataId, distinct: false);

--- a/packages/ferry_cache/lib/src/utils/json_equals.dart
+++ b/packages/ferry_cache/lib/src/utils/json_equals.dart
@@ -1,0 +1,35 @@
+/// compare two json-like objects for equality
+/// parameters must be either null, num, bool, String or a List or Map of these types
+/// this is an alternative too DeepCollectionEquality().equals, which is very slow and has
+/// O(n^2) complexity:
+bool jsonMapEquals(Object? a, Object? b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a == b) {
+    return true;
+  }
+  if (a is Map) {
+    if (b is! Map) {
+      return false;
+    }
+    if (a.length != b.length) return false;
+    for (var key in a.keys) {
+      if (!b.containsKey(key)) return false;
+      if (!jsonMapEquals(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  if (a is List) {
+    if (b is! List) {
+      return false;
+    }
+    final length = a.length;
+    if (length != b.length) return false;
+    for (var i = 0; i < length; i++) {
+      if (!jsonMapEquals(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  return false;
+}

--- a/packages/ferry_cache/test/test/data_change_streams_test.dart
+++ b/packages/ferry_cache/test/test/data_change_streams_test.dart
@@ -66,6 +66,7 @@ void main() {
         true,
         null,
         {},
+        jsonMapEquals,
       );
 
       expect(
@@ -90,6 +91,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -115,6 +117,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -137,6 +140,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -162,6 +166,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -195,6 +200,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -231,6 +237,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -262,6 +269,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -299,6 +307,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -328,15 +337,17 @@ void main() {
     group('fragmentDataChangeStream', () {
       test("doesn't trigger before a change", () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -349,15 +360,17 @@ void main() {
 
       test("doesn't trigger with the same data", () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(stream, emitsInOrder([emitsDone]));
 
@@ -370,15 +383,17 @@ void main() {
 
       test('triggers with different data', () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -401,15 +416,17 @@ void main() {
       test('triggers with change to dependent reference', () async {
         final hanFrag = GheroDataReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
-            hanFrag,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          hanFrag,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -435,15 +452,17 @@ void main() {
         final lukeAndFriends =
             GcomparisonFieldsReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
-            lukeAndFriends,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeAndFriends,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,

--- a/packages/ferry_store/lib/ferry_store.dart
+++ b/packages/ferry_store/lib/ferry_store.dart
@@ -1,2 +1,3 @@
 export './src/store.dart';
 export './src/memory_store.dart';
+export './src/json_equals.dart';

--- a/packages/ferry_store/lib/src/json_equals.dart
+++ b/packages/ferry_store/lib/src/json_equals.dart
@@ -1,0 +1,40 @@
+/// a function that compares two json-like maps for deep equality
+/// more performant alternative to DeepCollectionEquality which has O(n^2) time complexity (where n is the level of nesting)
+/// but also very slow on flat maps
+typedef JsonEquals = bool Function(Object? a, Object? b);
+
+/// compare two json-like objects for equality
+/// parameters must be either null, num, bool, String or a List or Map of these types
+/// this is an alternative too DeepCollectionEquality().equals, which is very slow and has
+/// O(n^2) complexity
+bool jsonMapEquals(Object? a, Object? b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a == b) {
+    return true;
+  }
+  if (a is Map) {
+    if (b is! Map) {
+      return false;
+    }
+    if (a.length != b.length) return false;
+    for (var key in a.keys) {
+      if (!b.containsKey(key)) return false;
+      if (!jsonMapEquals(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  if (a is List) {
+    if (b is! List) {
+      return false;
+    }
+    final length = a.length;
+    if (length != b.length) return false;
+    for (var i = 0; i < length; i++) {
+      if (!jsonMapEquals(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  return false;
+}

--- a/packages/ferry_store/lib/src/memory_store.dart
+++ b/packages/ferry_store/lib/src/memory_store.dart
@@ -5,21 +5,25 @@ import 'package:ferry_store/ferry_store.dart';
 
 class MemoryStore extends Store {
   final BehaviorSubject<Map<String, Map<String, dynamic>?>> _valueStream;
+  final JsonEquals _jsonEquals;
 
-  MemoryStore([Map<String, Map<String, dynamic>> initialData = const {}])
-      : _valueStream = BehaviorSubject.seeded(initialData);
+  MemoryStore(
+      [Map<String, Map<String, dynamic>> initialData = const {},
+      JsonEquals? jsonEquals])
+      : _valueStream = BehaviorSubject.seeded(initialData),
+        _jsonEquals = jsonEquals ?? jsonMapEquals;
 
   @override
   Iterable<String> get keys => _valueStream.value.keys;
 
   @override
-  Stream<Map<String, dynamic>?> watch(String dataId) =>
-      _valueStream.map((data) => data[dataId]).distinct(
-            (prev, next) => const DeepCollectionEquality().equals(
-              prev,
-              next,
-            ),
-          );
+  Stream<Map<String, dynamic>?> watch(String dataId, {bool distinct = true}) {
+    final stream = _valueStream.map((data) => data[dataId]);
+    if (distinct) {
+      return stream.distinct(_jsonEquals);
+    }
+    return stream;
+  }
 
   @override
   Map<String, dynamic>? get(String dataId) => _valueStream.value[dataId];

--- a/packages/ferry_store/lib/src/store.dart
+++ b/packages/ferry_store/lib/src/store.dart
@@ -1,7 +1,7 @@
 abstract class Store {
   Iterable<String> get keys;
 
-  Stream<Map<String, dynamic>?> watch(String dataId);
+  Stream<Map<String, dynamic>?> watch(String dataId, {bool distinct = true});
 
   Map<String, dynamic>? get(String dataId);
 

--- a/packages/ferry_store/test/json_map_equals.dart
+++ b/packages/ferry_store/test/json_map_equals.dart
@@ -1,0 +1,146 @@
+import 'package:ferry_store/src/json_equals.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('jsonMapEquals', () {
+    test('should return true for equal maps', () {
+      expect(jsonMapEquals({'a': 1}, {'a': 1}), isTrue);
+    });
+
+    test('should return false for unequal maps', () {
+      expect(jsonMapEquals({'a': 1}, {'a': 2}), isFalse);
+    });
+
+    test('should return true for equal lists', () {
+      expect(jsonMapEquals([1, 2], [1, 2]), isTrue);
+    });
+
+    test('should return false for unequal lists', () {
+      expect(jsonMapEquals([1, 2], [1, 3]), isFalse);
+    });
+
+    test('should return true for equal nested maps', () {
+      expect(
+          jsonMapEquals({
+            'a': {'b': 1}
+          }, {
+            'a': {'b': 1}
+          }),
+          isTrue);
+    });
+
+    test('should return false for unequal nested maps', () {
+      expect(
+          jsonMapEquals({
+            'a': {'b': 1}
+          }, {
+            'a': {'b': 2}
+          }),
+          isFalse);
+    });
+
+    test('should return true for equal nested lists', () {
+      expect(
+          jsonMapEquals([
+            {'a': 1}
+          ], [
+            {'a': 1}
+          ]),
+          isTrue);
+    });
+
+    test('should return false for unequal nested lists', () {
+      expect(
+          jsonMapEquals([
+            {'a': 1}
+          ], [
+            {'a': 2}
+          ]),
+          isFalse);
+    });
+
+    test('should return true for equal nested maps and lists', () {
+      expect(
+          jsonMapEquals({
+            'a': [1]
+          }, {
+            'a': [1]
+          }),
+          isTrue);
+    });
+
+    test('should return false for unequal nested maps and lists', () {
+      expect(
+          jsonMapEquals({
+            'a': [1]
+          }, {
+            'a': [2]
+          }),
+          isFalse);
+    });
+
+    test('should return true equal complex nested json map', () {
+      expect(
+          jsonMapEquals({
+            'a': {
+              'b': [1, 2, 3],
+              'c': {
+                'd': '4',
+                'e': 5,
+                'f': [6, 7, 8],
+                'g': null,
+                'h': true,
+                'i': false,
+                'j': 0.3
+              }
+            }
+          }, {
+            'a': {
+              'b': [1, 2, 3],
+              'c': {
+                'd': '4',
+                'e': 5,
+                'f': [6, 7, 8],
+                'g': null,
+                'h': true,
+                'i': false,
+                'j': 0.3
+              }
+            }
+          }),
+          isTrue);
+    });
+
+    test('should return false for unequal complex nested json map', () {
+      expect(
+          jsonMapEquals({
+            'a': {
+              'b': [1, 2, 3],
+              'c': {
+                'd': '4',
+                'e': 5,
+                'f': [6, 7, 8],
+                'g': null,
+                'h': true,
+                'i': false,
+                'j': 0.3
+              }
+            }
+          }, {
+            'a': {
+              'b': [1, 2, 3],
+              'c': {
+                'd': '4',
+                'e': 5,
+                'f': [6, 7, 8],
+                'g': null,
+                'h': true,
+                'i': false,
+                'j': 0.4
+              }
+            }
+          }),
+          isFalse);
+    });
+  });
+}


### PR DESCRIPTION
use jsonMapEquals instead of DeepCollectionEquality().equals to avoid it's O(n^2) complexity, add distinct: param to watch() method 