### PR TITLE
refactor(ferry_cache): use jsonMapEquals instead of DeepCollectionEquality.equals() to avoid it's O(n^2) complexity, remove duplicated .distinct() call

### DIFF
--- a/packages/ferry_cache/lib/src/cache.dart
+++ b/packages/ferry_cache/lib/src/cache.dart
@@ -16,6 +16,7 @@ class Cache {
   final bool addTypename;
   final Store store;
   final utils.DataIdResolver? dataIdFromObject;
+  final JsonEquals jsonEquals;
 
   /// this stream is used to debounce updates from watchQuery/watchFragment
   /// to avoid emitting multiple times for the same change when multiple
@@ -38,9 +39,11 @@ class Cache {
     this.addTypename = true,
     Map<OperationRequest, Map<String, Map<String, dynamic>?>>
         seedOptimisticPatches = const {},
+    JsonEquals? jsonEquals,
   })  : store = store ?? MemoryStore(),
         _eventStream = BehaviorSubject.seeded(null),
-        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches);
+        optimisticPatchesStream = BehaviorSubject.seeded(seedOptimisticPatches),
+        jsonEquals = jsonEquals ?? jsonMapEquals;
 
   /// Reads data for the given [dataId] from the [Store], merging in any data from optimistic patches
   @visibleForTesting
@@ -73,6 +76,7 @@ class Cache {
           addTypename,
           dataIdFromObject,
           possibleTypes,
+          jsonEquals,
         ),
         getData: () => readQuery(request, optimistic: optimistic),
       );
@@ -93,6 +97,7 @@ class Cache {
           addTypename,
           dataIdFromObject,
           possibleTypes,
+          jsonEquals,
         ),
         getData: () => readFragment(request, optimistic: optimistic),
       );

--- a/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/fragment_data_change_stream.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
 import 'package:normalize/normalize.dart';
@@ -21,6 +22,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
+  JsonEquals jsonEquals,
 ) {
   final dataIdStreamController = StreamController<void>();
   final result = dataIdStreamController.stream
@@ -63,8 +65,7 @@ Stream<Set<String>> fragmentDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual =
-                  const DeepCollectionEquality().equals(prev, next);
+              final areEqual = jsonEquals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds

--- a/packages/ferry_cache/lib/src/operation_data_change_stream.dart
+++ b/packages/ferry_cache/lib/src/operation_data_change_stream.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:collection/collection.dart';
+import 'package:ferry_cache/ferry_cache.dart';
 import 'package:ferry_exec/ferry_exec.dart';
 import 'package:ferry_store/ferry_store.dart';
 import 'package:normalize/normalize.dart';
@@ -22,6 +23,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
   bool addTypename,
   DataIdResolver? dataIdFromObject,
   Map<String, Set<String>> possibleTypes,
+  JsonEquals jsonEquals,
 ) {
   final operationDefinition = getOperationDefinition(
     request.operation.document,
@@ -84,8 +86,7 @@ Stream<Set<String>> operationDataChangeStream<TData, TVars>(
 
           return stream.distinct(
             (prev, next) {
-              final areEqual =
-                  const DeepCollectionEquality().equals(prev, next);
+              final areEqual = jsonEquals(prev, next);
               if (!areEqual) {
                 // Maybe a new element was added to an array,
                 // we need to recompute the dataIds

--- a/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
+++ b/packages/ferry_cache/lib/src/utils/data_for_id_stream.dart
@@ -18,8 +18,8 @@ Stream<Map<String, dynamic>?> dataForIdStream(
             Map<OperationRequest<dynamic, dynamic>,
                 Map<String, Map<String, dynamic>?>>?,
             Map<String, dynamic>?>(
-            store.watch(dataId),
+            store.watch(dataId, distinct: false),
             optimisticPatchesStream,
             (_, __) => optimisticReader(dataId),
           )
-        : store.watch(dataId);
+        : store.watch(dataId, distinct: false);

--- a/packages/ferry_cache/test/test/data_change_streams_test.dart
+++ b/packages/ferry_cache/test/test/data_change_streams_test.dart
@@ -66,6 +66,7 @@ void main() {
         true,
         null,
         {},
+        jsonMapEquals,
       );
 
       expect(
@@ -90,6 +91,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -115,6 +117,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -137,6 +140,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -162,6 +166,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -195,6 +200,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -231,6 +237,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(stream, emitsInOrder([emitsDone]));
@@ -262,6 +269,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -299,6 +307,7 @@ void main() {
           true,
           null,
           {},
+          jsonMapEquals,
         );
 
         expect(
@@ -328,15 +337,17 @@ void main() {
     group('fragmentDataChangeStream', () {
       test("doesn't trigger before a change", () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -349,15 +360,17 @@ void main() {
 
       test("doesn't trigger with the same data", () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(stream, emitsInOrder([emitsDone]));
 
@@ -370,15 +383,17 @@ void main() {
 
       test('triggers with different data', () async {
         final stream = fragmentDataChangeStream(
-            lukeFragment,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeFragment,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -401,15 +416,17 @@ void main() {
       test('triggers with change to dependent reference', () async {
         final hanFrag = GheroDataReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
-            hanFrag,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          hanFrag,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,
@@ -435,15 +452,17 @@ void main() {
         final lukeAndFriends =
             GcomparisonFieldsReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
-            lukeAndFriends,
-            true,
-            cache.optimisticPatchesStream,
-            cache.optimisticReader,
-            cache.store,
-            {},
-            true,
-            null,
-            {});
+          lukeAndFriends,
+          true,
+          cache.optimisticPatchesStream,
+          cache.optimisticReader,
+          cache.store,
+          {},
+          true,
+          null,
+          {},
+          jsonMapEquals,
+        );
 
         expect(
           stream,


### PR DESCRIPTION
 use jsonMapEquals instead of DeepCollectionEquality.equals() to avoid it's O(n^2) complexity, remove duplicated .distinct() call