### PR TITLE
fix(ferry): Re-use the same stream for multiple requests when possible

### DIFF
--- a/packages/ferry/lib/src/request_controller_typed_link.dart
+++ b/packages/ferry/lib/src/request_controller_typed_link.dart
@@ -26,59 +26,92 @@ class RequestControllerTypedLink extends TypedLink {
         controller ??= _defaultRequestController = StreamController.broadcast();
   }
 
+  /// The cache of streams for each request.
+  ///
+  /// When [request] is called 2 times with the same request, the same stream
+  /// will be returned to both callers. this ensures that the same request is
+  /// not executed twice by the `FetchPolicyTypedLink`.
+  final _cachedStreams = <OperationRequest, Stream<OperationResponse>>{};
+
   @override
   Stream<OperationResponse<TData, TVars>> request<TData, TVars>(
     request, [
     forward,
   ]) {
-    var initial = true;
-    ValueStream<OperationResponse<TData, TVars>>? prev;
-
-    return requestController.stream
-        .whereType<OperationRequest<TData, TVars>>()
-        .where(
-          (req) => req.requestId == null
-              ? identical(req, request)
-              : req.requestId == request.requestId,
-        )
-        .doOnData(
-      (_) {
-        /// Temporarily add a listener so that [prev] doesn't shut down when
-        /// switchMap is updating the stream.
-        final sub = prev?.listen(null);
-        scheduleMicrotask(() => sub?.cancel());
-      },
-    ).switchMap(
-      (req) {
-        final stream = req.updateResult == null
-            ? forward!(req)
-            : CombineLatestStream.combine2<
-                OperationResponse<TData, TVars>?,
-                OperationResponse<TData, TVars>,
-                OperationResponse<TData, TVars>>(
-                prev ?? Stream.value(null),
-                forward!(req),
-                (previous, response) => OperationResponse<TData, TVars>(
-                  operationRequest: response.operationRequest,
-                  data: response.operationRequest.updateResult!(
-                    previous?.data,
-                    response.data,
+    // The cached request is the request that is used as the key in the
+    // [_cachedStreams].
+    final OperationRequest<TData, TVars> cachedRequest;
+    if (request.requestId == null) {
+      cachedRequest = request;
+    } else {
+      cachedRequest = _cachedStreams.keys
+          .whereType<OperationRequest<TData, TVars>>()
+          .firstWhere(
+            (req) => req.requestId == request.requestId,
+            orElse: () => request,
+          );
+    }
+    var stream = _cachedStreams[cachedRequest]
+        as Stream<OperationResponse<TData, TVars>>?;
+    if (stream == null) {
+      // If no stream has been cached for this request, create a new one.
+      ValueStream<OperationResponse<TData, TVars>>? prev;
+      var initial = true;
+      stream = requestController.stream
+          .whereType<OperationRequest<TData, TVars>>()
+          .where(
+            (req) => req.requestId == null
+                ? req == request
+                : req.requestId == request.requestId,
+          )
+          .doOnData(
+        (_) {
+          /// Temporarily add a listener so that [prev] doesn't shut down when
+          /// switchMap is updating the stream.
+          final sub = prev?.listen(null);
+          scheduleMicrotask(() => sub?.cancel());
+        },
+      ).switchMap(
+        (req) {
+          final stream = req.updateResult == null
+              ? forward!(req)
+              : CombineLatestStream.combine2<
+                  OperationResponse<TData, TVars>?,
+                  OperationResponse<TData, TVars>,
+                  OperationResponse<TData, TVars>>(
+                  prev ?? Stream.value(null),
+                  forward!(req),
+                  (previous, response) => OperationResponse<TData, TVars>(
+                    operationRequest: response.operationRequest,
+                    data: response.operationRequest.updateResult!(
+                      previous?.data,
+                      response.data,
+                    ),
+                    dataSource: response.dataSource,
+                    linkException: response.linkException,
+                    graphqlErrors: response.graphqlErrors,
                   ),
-                  dataSource: response.dataSource,
-                  linkException: response.linkException,
-                  graphqlErrors: response.graphqlErrors,
-                ),
-              );
-        return prev = stream.shareValue();
-      },
-    ).doOnListen(
-      () {
-        if (initial && request.executeOnListen) {
-          scheduleMicrotask(() => requestController.add(request));
-        }
-        initial = false;
-      },
-    );
+                );
+          return prev = stream.shareValue();
+        },
+      ).doOnListen(
+        () {
+          if (initial && request.executeOnListen) {
+            scheduleMicrotask(() => requestController.add(request));
+          }
+          initial = false;
+        },
+      ).doOnCancel(() {
+        // Once the stream is not listened to anymore, remove it from the cache.
+        _cachedStreams.remove(request);
+      });
+      _cachedStreams[cachedRequest] = stream;
+    } else {
+      // Trigger a new request to update the already cached stream.
+      requestController.add(request);
+    }
+
+    return stream;
   }
 
   @override


### PR DESCRIPTION
Fixes: https://github.com/gql-dart/ferry/issues/451

This PR adds `Map<OperationRequest, Stream<OperationResponse>> _cachedStreams` to `RequestControllerTypedLink`.

It is used to cache the streams from a request and reuse it for the requests with the same `requestId` or `==`.