### PR TITLE
Add support for serialize_nulls build config option

### DIFF
--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -44,6 +44,9 @@ class GraphqlBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
+
+    print("jooo ${buildStep.inputId}");
+
     final doc = await readDocument(buildStep, config.sourceExtension);
     final schema =
         await readDocument(buildStep, config.sourceExtension, config.schemaId);
@@ -55,6 +58,20 @@ class GraphqlBuilder implements Builder {
           'When extensions require add_typenames to be true. Consider setting add_typenames to true in your build.yaml or disabling when_extensions in your build.yaml.');
     }
 
+    final schemaOutputAsset =
+    outputAssetId(config.schemaId, schemaExtension, config.outputDir);
+
+    final schemaUrl =
+     schemaOutputAsset.uri.toString();
+    final schemaAllocator = GqlAllocator(
+      buildStep.inputId.uri.toString(),
+      config.sourceExtension,
+      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir).uri.toString(),
+      schemaUrl,
+      config.outputDir,
+    );
+
+    final varAllocator = schemaAllocator;
     final libs = <String, Library>{
       astExtension: buildAstLibrary(doc),
       dataExtension: buildDataLibrary(
@@ -69,6 +86,7 @@ class GraphqlBuilder implements Builder {
         addTypenames(schema),
         p.basename(generatedFilePath(buildStep.inputId, varExtension)),
         config.typeOverrides,
+          varAllocator
       ),
       reqExtension: buildReqLibrary(
         doc,
@@ -80,6 +98,7 @@ class GraphqlBuilder implements Builder {
         config.typeOverrides,
         config.enumFallbackConfig,
         generatePossibleTypesMap: config.shouldGeneratePossibleTypes,
+        allocator: schemaAllocator,
       ),
     };
 
@@ -89,7 +108,12 @@ class GraphqlBuilder implements Builder {
       final schemaOutputAsset =
           outputAssetId(config.schemaId, schemaExtension, config.outputDir);
 
-      final allocator = GqlAllocator(
+      final allocator =
+
+      entry.key == schemaExtension ? schemaAllocator :
+      entry.key == varExtension ? varAllocator :
+
+      GqlAllocator(
         buildStep.inputId.uri.toString(),
         config.sourceExtension,
         generatedAsset.uri.toString(),

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -44,9 +44,6 @@ class GraphqlBuilder implements Builder {
 
   @override
   FutureOr<void> build(BuildStep buildStep) async {
-
-    print("jooo ${buildStep.inputId}");
-
     final doc = await readDocument(buildStep, config.sourceExtension);
     final schema =
         await readDocument(buildStep, config.sourceExtension, config.schemaId);

--- a/packages/ferry_generator/lib/src/utils/config.dart
+++ b/packages/ferry_generator/lib/src/utils/config.dart
@@ -14,6 +14,7 @@ class BuilderConfig {
   final AssetId schemaId;
   final bool shouldAddTypenames;
   final bool shouldGeneratePossibleTypes;
+  final bool serializeNulls;
   final Map<String, Reference> typeOverrides;
   final Set<Reference> customSerializers;
   final EnumFallbackConfig enumFallbackConfig;
@@ -27,6 +28,7 @@ class BuilderConfig {
         typeOverrides = _getTypeOverrides(config['type_overrides']),
         shouldGeneratePossibleTypes =
             config['generate_possible_types_map'] ?? true,
+        serializeNulls = config['serialize_nulls'] ?? false,
         customSerializers = _getCustomSerializers(config['custom_serializers']),
         enumFallbackConfig = _getEnumFallbackConfig(config),
         outputDir = config['output_dir'] ?? '__generated__',

--- a/packages/ferry_generator/lib/src/utils/writer.dart
+++ b/packages/ferry_generator/lib/src/utils/writer.dart
@@ -14,6 +14,8 @@ Future<void> writeDocument(
 ) {
   if (library.body.isEmpty) return Future.value(null);
 
+  print('writeDocument: ${outputId.path}');
+
   final libString = library
       .accept(
         DartEmitter(

--- a/packages/ferry_generator/lib/src/utils/writer.dart
+++ b/packages/ferry_generator/lib/src/utils/writer.dart
@@ -14,8 +14,6 @@ Future<void> writeDocument(
 ) {
   if (library.body.isEmpty) return Future.value(null);
 
-  print('writeDocument: ${outputId.path}');
-
   final libString = library
       .accept(
         DartEmitter(

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -19,8 +19,22 @@ dependencies:
   built_value_generator: ^8.1.1
   built_value: ^8.1.2
   analyzer: ">=4.2.0 <6.0.0"
+
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2
   build_test: ^2.0.0
   pedantic: ^1.11.0
+
+
+dependency_overrides:
+  gql_exec:
+    git:
+        url: https://github.com/gql-dart/gql.git
+        ref: feat/triStateNull
+        path: links/gql_exec
+  gql_code_builder:
+    git:
+      url: https://github.com/gql-dart/gql.git
+      ref: feat/triStateNull
+      path: codegen/gql_code_builder

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -28,13 +28,8 @@ dev_dependencies:
 
 
 dependency_overrides:
-  gql_exec:
-    git:
-        url: https://github.com/gql-dart/gql.git
-        ref: feat/triStateNull
-        path: links/gql_exec
   gql_code_builder:
     git:
-      url: https://github.com/gql-dart/gql.git
-      ref: feat/triStateNull
+      url: https://github.com/twklessor/gql.git
+      ref: feature/serialize-nulls
       path: codegen/gql_code_builder

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.data.gql.g.dart
@@ -113,8 +113,12 @@ class _$GReviewFragmentData extends GReviewFragmentData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, G__typename.hashCode), stars.hashCode),
-        commentary.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -185,4 +189,4 @@ class GReviewFragmentDataBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.g.dart
@@ -131,10 +131,13 @@ class _$GReviewFragmentReq extends GReviewFragmentReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, vars.hashCode), document.hashCode),
-            fragmentName.hashCode),
-        idFields.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, document.hashCode);
+    _$hash = $jc(_$hash, fragmentName.hashCode);
+    _$hash = $jc(_$hash, idFields.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -226,4 +229,4 @@ class GReviewFragmentReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.dart
@@ -16,8 +16,6 @@ abstract class GReviewFragmentVars
   factory GReviewFragmentVars(
       [Function(GReviewFragmentVarsBuilder b) updates]) = _$GReviewFragmentVars;
 
-  static Serializer<GReviewFragmentVars> get serializer =>
-      _$gReviewFragmentVarsSerializer;
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
         GReviewFragmentVars.serializer,
         this,
@@ -27,4 +25,44 @@ abstract class GReviewFragmentVars
         GReviewFragmentVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GReviewFragmentVars> get serializer =>
+      GReviewFragmentVarsSerializer();
+}
+
+class GReviewFragmentVarsSerializer
+    extends StructuredSerializer<GReviewFragmentVars> {
+  final String wireName = 'GReviewFragmentVars';
+
+  final Iterable<Type> types = const [
+    GReviewFragmentVars,
+    _$GReviewFragmentVars
+  ];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GReviewFragmentVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    return result;
+  }
+
+  GReviewFragmentVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GReviewFragmentVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.g.dart
@@ -6,34 +6,6 @@ part of 'review_fragment.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GReviewFragmentVars> _$gReviewFragmentVarsSerializer =
-    new _$GReviewFragmentVarsSerializer();
-
-class _$GReviewFragmentVarsSerializer
-    implements StructuredSerializer<GReviewFragmentVars> {
-  @override
-  final Iterable<Type> types = const [
-    GReviewFragmentVars,
-    _$GReviewFragmentVars
-  ];
-  @override
-  final String wireName = 'GReviewFragmentVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GReviewFragmentVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    return <Object?>[];
-  }
-
-  @override
-  GReviewFragmentVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    return new GReviewFragmentVarsBuilder().build();
-  }
-}
-
 class _$GReviewFragmentVars extends GReviewFragmentVars {
   factory _$GReviewFragmentVars(
           [void Function(GReviewFragmentVarsBuilder)? updates]) =>
@@ -94,4 +66,4 @@ class GReviewFragmentVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.data.gql.g.dart
@@ -181,7 +181,11 @@ class _$GCreateReviewData extends GCreateReviewData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), createReview.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, createReview.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -312,12 +316,14 @@ class _$GCreateReviewData_createReview extends GCreateReviewData_createReview {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc($jc($jc(0, G__typename.hashCode), id.hashCode),
-                episode.hashCode),
-            stars.hashCode),
-        commentary.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -405,4 +411,4 @@ class GCreateReviewData_createReviewBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.g.dart
@@ -196,20 +196,18 @@ class _$GCreateReviewReq extends GCreateReviewReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -354,4 +352,4 @@ class GCreateReviewReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.dart
@@ -7,7 +7,8 @@ import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/schema.schema.gql.dart'
     as _i1;
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i2;
+    as _i3;
+import 'package:gql_exec/value.dart' as _i2;
 
 part 'create_review.var.gql.g.dart';
 
@@ -18,17 +19,71 @@ abstract class GCreateReviewVars
   factory GCreateReviewVars([Function(GCreateReviewVarsBuilder b) updates]) =
       _$GCreateReviewVars;
 
-  _i1.GEpisode? get episode;
+  _i2.Value<_i1.GEpisode>? get episode;
   _i1.GReviewInput get review;
-  static Serializer<GCreateReviewVars> get serializer =>
-      _$gCreateReviewVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GCreateReviewVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GCreateReviewVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GCreateReviewVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GCreateReviewVars> get serializer =>
+      GCreateReviewVarsSerializer();
+}
+
+class GCreateReviewVarsSerializer
+    extends StructuredSerializer<GCreateReviewVars> {
+  final String wireName = 'GCreateReviewVars';
+
+  final Iterable<Type> types = const [GCreateReviewVars, _$GCreateReviewVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GCreateReviewVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    final _$episodevalue = object.episode;
+    if (_$episodevalue != null) {
+      result.add('episode');
+      result.add(serializers.serialize(_$episodevalue!.value,
+          specifiedType: const FullType(_i1.GEpisode)));
+    }
+    result.add('review');
+    result.add(serializers.serialize(object.review,
+        specifiedType: const FullType(_i1.GReviewInput)));
+    return result;
+  }
+
+  GCreateReviewVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GCreateReviewVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'episode':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.episode = _i2.Value(fieldValue);
+          break;
+        case 'review':
+          var fieldValue = serializers.deserialize(value,
+                  specifiedType: const FullType(_i1.GReviewInput))
+              as _i1.GReviewInput;
+          builder.review.replace(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.g.dart
@@ -6,66 +6,9 @@ part of 'create_review.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GCreateReviewVars> _$gCreateReviewVarsSerializer =
-    new _$GCreateReviewVarsSerializer();
-
-class _$GCreateReviewVarsSerializer
-    implements StructuredSerializer<GCreateReviewVars> {
-  @override
-  final Iterable<Type> types = const [GCreateReviewVars, _$GCreateReviewVars];
-  @override
-  final String wireName = 'GCreateReviewVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GCreateReviewVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'review',
-      serializers.serialize(object.review,
-          specifiedType: const FullType(_i1.GReviewInput)),
-    ];
-    Object? value;
-    value = object.episode;
-    if (value != null) {
-      result
-        ..add('episode')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(_i1.GEpisode)));
-    }
-    return result;
-  }
-
-  @override
-  GCreateReviewVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GCreateReviewVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'episode':
-          result.episode = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode?;
-          break;
-        case 'review':
-          result.review.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i1.GReviewInput))!
-              as _i1.GReviewInput);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GCreateReviewVars extends GCreateReviewVars {
   @override
-  final _i1.GEpisode? episode;
+  final _i2.Value<_i1.GEpisode>? episode;
   @override
   final _i1.GReviewInput review;
 
@@ -96,7 +39,11 @@ class _$GCreateReviewVars extends GCreateReviewVars {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, episode.hashCode), review.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, review.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -112,9 +59,9 @@ class GCreateReviewVarsBuilder
     implements Builder<GCreateReviewVars, GCreateReviewVarsBuilder> {
   _$GCreateReviewVars? _$v;
 
-  _i1.GEpisode? _episode;
-  _i1.GEpisode? get episode => _$this._episode;
-  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
+  _i2.Value<_i1.GEpisode>? _episode;
+  _i2.Value<_i1.GEpisode>? get episode => _$this._episode;
+  set episode(_i2.Value<_i1.GEpisode>? episode) => _$this._episode = episode;
 
   _i1.GReviewInputBuilder? _review;
   _i1.GReviewInputBuilder get review =>
@@ -168,4 +115,4 @@ class GCreateReviewVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.data.gql.g.dart
@@ -201,7 +201,11 @@ class _$GReviewWithDateData extends GReviewWithDateData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), createReview.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, createReview.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -337,14 +341,15 @@ class _$GReviewWithDateData_createReview
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc($jc($jc(0, G__typename.hashCode), episode.hashCode),
-                    stars.hashCode),
-                commentary.hashCode),
-            createdAt.hashCode),
-        seenOn.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, seenOn.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -452,4 +457,4 @@ class GReviewWithDateData_createReviewBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.g.dart
@@ -198,20 +198,18 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -356,4 +354,4 @@ class GReviewWithDateReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.dart
@@ -7,7 +7,8 @@ import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/schema.schema.gql.dart'
     as _i1;
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i2;
+    as _i3;
+import 'package:gql_exec/value.dart' as _i2;
 
 part 'review_with_date_scalar.var.gql.g.dart';
 
@@ -18,18 +19,86 @@ abstract class GReviewWithDateVars
   factory GReviewWithDateVars(
       [Function(GReviewWithDateVarsBuilder b) updates]) = _$GReviewWithDateVars;
 
-  _i1.GEpisode? get episode;
+  _i2.Value<_i1.GEpisode>? get episode;
   _i1.GReviewInput get review;
-  DateTime? get createdAt;
-  static Serializer<GReviewWithDateVars> get serializer =>
-      _$gReviewWithDateVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  _i2.Value<DateTime>? get createdAt;
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GReviewWithDateVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GReviewWithDateVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GReviewWithDateVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GReviewWithDateVars> get serializer =>
+      GReviewWithDateVarsSerializer();
+}
+
+class GReviewWithDateVarsSerializer
+    extends StructuredSerializer<GReviewWithDateVars> {
+  final String wireName = 'GReviewWithDateVars';
+
+  final Iterable<Type> types = const [
+    GReviewWithDateVars,
+    _$GReviewWithDateVars
+  ];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GReviewWithDateVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    final _$episodevalue = object.episode;
+    if (_$episodevalue != null) {
+      result.add('episode');
+      result.add(serializers.serialize(_$episodevalue!.value,
+          specifiedType: const FullType(_i1.GEpisode)));
+    }
+    result.add('review');
+    result.add(serializers.serialize(object.review,
+        specifiedType: const FullType(_i1.GReviewInput)));
+    final _$createdAtvalue = object.createdAt;
+    if (_$createdAtvalue != null) {
+      result.add('createdAt');
+      result.add(serializers.serialize(_$createdAtvalue!.value,
+          specifiedType: const FullType(DateTime)));
+    }
+    return result;
+  }
+
+  GReviewWithDateVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GReviewWithDateVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'episode':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.episode = _i2.Value(fieldValue);
+          break;
+        case 'review':
+          var fieldValue = serializers.deserialize(value,
+                  specifiedType: const FullType(_i1.GReviewInput))
+              as _i1.GReviewInput;
+          builder.review.replace(fieldValue);
+          break;
+        case 'createdAt':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(DateTime)) as DateTime;
+          builder.createdAt = _i2.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.g.dart
@@ -6,85 +6,13 @@ part of 'review_with_date_scalar.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GReviewWithDateVars> _$gReviewWithDateVarsSerializer =
-    new _$GReviewWithDateVarsSerializer();
-
-class _$GReviewWithDateVarsSerializer
-    implements StructuredSerializer<GReviewWithDateVars> {
-  @override
-  final Iterable<Type> types = const [
-    GReviewWithDateVars,
-    _$GReviewWithDateVars
-  ];
-  @override
-  final String wireName = 'GReviewWithDateVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GReviewWithDateVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'review',
-      serializers.serialize(object.review,
-          specifiedType: const FullType(_i1.GReviewInput)),
-    ];
-    Object? value;
-    value = object.episode;
-    if (value != null) {
-      result
-        ..add('episode')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(_i1.GEpisode)));
-    }
-    value = object.createdAt;
-    if (value != null) {
-      result
-        ..add('createdAt')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(DateTime)));
-    }
-    return result;
-  }
-
-  @override
-  GReviewWithDateVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GReviewWithDateVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'episode':
-          result.episode = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode?;
-          break;
-        case 'review':
-          result.review.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(_i1.GReviewInput))!
-              as _i1.GReviewInput);
-          break;
-        case 'createdAt':
-          result.createdAt = serializers.deserialize(value,
-              specifiedType: const FullType(DateTime)) as DateTime?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GReviewWithDateVars extends GReviewWithDateVars {
   @override
-  final _i1.GEpisode? episode;
+  final _i2.Value<_i1.GEpisode>? episode;
   @override
   final _i1.GReviewInput review;
   @override
-  final DateTime? createdAt;
+  final _i2.Value<DateTime>? createdAt;
 
   factory _$GReviewWithDateVars(
           [void Function(GReviewWithDateVarsBuilder)? updates]) =>
@@ -116,8 +44,12 @@ class _$GReviewWithDateVars extends GReviewWithDateVars {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc(0, episode.hashCode), review.hashCode), createdAt.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, review.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -134,18 +66,19 @@ class GReviewWithDateVarsBuilder
     implements Builder<GReviewWithDateVars, GReviewWithDateVarsBuilder> {
   _$GReviewWithDateVars? _$v;
 
-  _i1.GEpisode? _episode;
-  _i1.GEpisode? get episode => _$this._episode;
-  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
+  _i2.Value<_i1.GEpisode>? _episode;
+  _i2.Value<_i1.GEpisode>? get episode => _$this._episode;
+  set episode(_i2.Value<_i1.GEpisode>? episode) => _$this._episode = episode;
 
   _i1.GReviewInputBuilder? _review;
   _i1.GReviewInputBuilder get review =>
       _$this._review ??= new _i1.GReviewInputBuilder();
   set review(_i1.GReviewInputBuilder? review) => _$this._review = review;
 
-  DateTime? _createdAt;
-  DateTime? get createdAt => _$this._createdAt;
-  set createdAt(DateTime? createdAt) => _$this._createdAt = createdAt;
+  _i2.Value<DateTime>? _createdAt;
+  _i2.Value<DateTime>? get createdAt => _$this._createdAt;
+  set createdAt(_i2.Value<DateTime>? createdAt) =>
+      _$this._createdAt = createdAt;
 
   GReviewWithDateVarsBuilder();
 
@@ -196,4 +129,4 @@ class GReviewWithDateVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.data.gql.g.dart
@@ -253,8 +253,12 @@ class _$GAliasedHeroData extends GAliasedHeroData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, G__typename.hashCode), empireHero.hashCode),
-        jediHero.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, empireHero.hashCode);
+    _$hash = $jc(_$hash, jediHero.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -394,9 +398,13 @@ class _$GAliasedHeroData_empireHero extends GAliasedHeroData_empireHero {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode),
-        from.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, from.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -542,9 +550,13 @@ class _$GAliasedHeroData_jediHero extends GAliasedHeroData_jediHero {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode),
-        from.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, from.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -638,4 +650,4 @@ class GAliasedHeroData_jediHeroBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.g.dart
@@ -195,20 +195,18 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -352,4 +350,4 @@ class GAliasedHeroReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.dart
@@ -19,8 +19,6 @@ abstract class GAliasedHeroVars
       _$GAliasedHeroVars;
 
   _i1.GEpisode get ep;
-  static Serializer<GAliasedHeroVars> get serializer =>
-      _$gAliasedHeroVarsSerializer;
   Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GAliasedHeroVars.serializer,
         this,
@@ -30,4 +28,48 @@ abstract class GAliasedHeroVars
         GAliasedHeroVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GAliasedHeroVars> get serializer =>
+      GAliasedHeroVarsSerializer();
+}
+
+class GAliasedHeroVarsSerializer
+    extends StructuredSerializer<GAliasedHeroVars> {
+  final String wireName = 'GAliasedHeroVars';
+
+  final Iterable<Type> types = const [GAliasedHeroVars, _$GAliasedHeroVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GAliasedHeroVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('ep');
+    result.add(serializers.serialize(object.ep,
+        specifiedType: const FullType(_i1.GEpisode)));
+    return result;
+  }
+
+  GAliasedHeroVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GAliasedHeroVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'ep':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.ep = fieldValue;
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.g.dart
@@ -6,51 +6,6 @@ part of 'aliased_hero.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GAliasedHeroVars> _$gAliasedHeroVarsSerializer =
-    new _$GAliasedHeroVarsSerializer();
-
-class _$GAliasedHeroVarsSerializer
-    implements StructuredSerializer<GAliasedHeroVars> {
-  @override
-  final Iterable<Type> types = const [GAliasedHeroVars, _$GAliasedHeroVars];
-  @override
-  final String wireName = 'GAliasedHeroVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GAliasedHeroVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'ep',
-      serializers.serialize(object.ep,
-          specifiedType: const FullType(_i1.GEpisode)),
-    ];
-
-    return result;
-  }
-
-  @override
-  GAliasedHeroVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GAliasedHeroVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'ep':
-          result.ep = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode))! as _i1.GEpisode;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GAliasedHeroVars extends GAliasedHeroVars {
   @override
   final _i1.GEpisode ep;
@@ -79,7 +34,10 @@ class _$GAliasedHeroVars extends GAliasedHeroVars {
 
   @override
   int get hashCode {
-    return $jf($jc(0, ep.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ep.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -132,4 +90,4 @@ class GAliasedHeroVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.data.gql.g.dart
@@ -155,7 +155,11 @@ class _$GHeroNoVarsData extends GHeroNoVarsData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), hero.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, hero.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -274,8 +278,12 @@ class _$GHeroNoVarsData_hero extends GHeroNoVarsData_hero {
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -347,4 +355,4 @@ class GHeroNoVarsData_heroBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.g.dart
@@ -195,20 +195,18 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -352,4 +350,4 @@ class GHeroNoVarsReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.dart
@@ -16,8 +16,6 @@ abstract class GHeroNoVarsVars
   factory GHeroNoVarsVars([Function(GHeroNoVarsVarsBuilder b) updates]) =
       _$GHeroNoVarsVars;
 
-  static Serializer<GHeroNoVarsVars> get serializer =>
-      _$gHeroNoVarsVarsSerializer;
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
         GHeroNoVarsVars.serializer,
         this,
@@ -27,4 +25,40 @@ abstract class GHeroNoVarsVars
         GHeroNoVarsVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GHeroNoVarsVars> get serializer =>
+      GHeroNoVarsVarsSerializer();
+}
+
+class GHeroNoVarsVarsSerializer extends StructuredSerializer<GHeroNoVarsVars> {
+  final String wireName = 'GHeroNoVarsVars';
+
+  final Iterable<Type> types = const [GHeroNoVarsVars, _$GHeroNoVarsVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GHeroNoVarsVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    return result;
+  }
+
+  GHeroNoVarsVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GHeroNoVarsVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.g.dart
@@ -6,30 +6,6 @@ part of 'hero_no_vars.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GHeroNoVarsVars> _$gHeroNoVarsVarsSerializer =
-    new _$GHeroNoVarsVarsSerializer();
-
-class _$GHeroNoVarsVarsSerializer
-    implements StructuredSerializer<GHeroNoVarsVars> {
-  @override
-  final Iterable<Type> types = const [GHeroNoVarsVars, _$GHeroNoVarsVars];
-  @override
-  final String wireName = 'GHeroNoVarsVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GHeroNoVarsVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    return <Object?>[];
-  }
-
-  @override
-  GHeroNoVarsVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    return new GHeroNoVarsVarsBuilder().build();
-  }
-}
-
 class _$GHeroNoVarsVars extends GHeroNoVarsVars {
   factory _$GHeroNoVarsVars([void Function(GHeroNoVarsVarsBuilder)? updates]) =>
       (new GHeroNoVarsVarsBuilder()..update(updates))._build();
@@ -88,4 +64,4 @@ class GHeroNoVarsVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.dart
@@ -54,9 +54,9 @@ abstract class GHeroWithFragmentsData_hero
   @override
   String get id;
   @override
-  String get name;
-  @override
   GHeroWithFragmentsData_hero_friendsConnection get friendsConnection;
+  @override
+  String get name;
   static Serializer<GHeroWithFragmentsData_hero> get serializer =>
       _$gHeroWithFragmentsDataHeroSerializer;
   @override

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.g.dart
@@ -111,12 +111,12 @@ class _$GHeroWithFragmentsData_heroSerializer
           specifiedType: const FullType(String)),
       'id',
       serializers.serialize(object.id, specifiedType: const FullType(String)),
-      'name',
-      serializers.serialize(object.name, specifiedType: const FullType(String)),
       'friendsConnection',
       serializers.serialize(object.friendsConnection,
           specifiedType:
               const FullType(GHeroWithFragmentsData_hero_friendsConnection)),
+      'name',
+      serializers.serialize(object.name, specifiedType: const FullType(String)),
     ];
 
     return result;
@@ -142,15 +142,15 @@ class _$GHeroWithFragmentsData_heroSerializer
           result.id = serializers.deserialize(value,
               specifiedType: const FullType(String))! as String;
           break;
-        case 'name':
-          result.name = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
         case 'friendsConnection':
           result.friendsConnection.replace(serializers.deserialize(value,
                   specifiedType: const FullType(
                       GHeroWithFragmentsData_hero_friendsConnection))!
               as GHeroWithFragmentsData_hero_friendsConnection);
+          break;
+        case 'name':
+          result.name = serializers.deserialize(value,
+              specifiedType: const FullType(String))! as String;
           break;
       }
     }
@@ -709,7 +709,11 @@ class _$GHeroWithFragmentsData extends GHeroWithFragmentsData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), hero.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, hero.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -792,9 +796,9 @@ class _$GHeroWithFragmentsData_hero extends GHeroWithFragmentsData_hero {
   @override
   final String id;
   @override
-  final String name;
-  @override
   final GHeroWithFragmentsData_hero_friendsConnection friendsConnection;
+  @override
+  final String name;
 
   factory _$GHeroWithFragmentsData_hero(
           [void Function(GHeroWithFragmentsData_heroBuilder)? updates]) =>
@@ -803,17 +807,17 @@ class _$GHeroWithFragmentsData_hero extends GHeroWithFragmentsData_hero {
   _$GHeroWithFragmentsData_hero._(
       {required this.G__typename,
       required this.id,
-      required this.name,
-      required this.friendsConnection})
+      required this.friendsConnection,
+      required this.name})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         G__typename, r'GHeroWithFragmentsData_hero', 'G__typename');
     BuiltValueNullFieldError.checkNotNull(
         id, r'GHeroWithFragmentsData_hero', 'id');
     BuiltValueNullFieldError.checkNotNull(
-        name, r'GHeroWithFragmentsData_hero', 'name');
-    BuiltValueNullFieldError.checkNotNull(
         friendsConnection, r'GHeroWithFragmentsData_hero', 'friendsConnection');
+    BuiltValueNullFieldError.checkNotNull(
+        name, r'GHeroWithFragmentsData_hero', 'name');
   }
 
   @override
@@ -831,15 +835,19 @@ class _$GHeroWithFragmentsData_hero extends GHeroWithFragmentsData_hero {
     return other is GHeroWithFragmentsData_hero &&
         G__typename == other.G__typename &&
         id == other.id &&
-        name == other.name &&
-        friendsConnection == other.friendsConnection;
+        friendsConnection == other.friendsConnection &&
+        name == other.name;
   }
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode),
-        friendsConnection.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, friendsConnection.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -847,8 +855,8 @@ class _$GHeroWithFragmentsData_hero extends GHeroWithFragmentsData_hero {
     return (newBuiltValueToStringHelper(r'GHeroWithFragmentsData_hero')
           ..add('G__typename', G__typename)
           ..add('id', id)
-          ..add('name', name)
-          ..add('friendsConnection', friendsConnection))
+          ..add('friendsConnection', friendsConnection)
+          ..add('name', name))
         .toString();
   }
 }
@@ -867,10 +875,6 @@ class GHeroWithFragmentsData_heroBuilder
   String? get id => _$this._id;
   set id(String? id) => _$this._id = id;
 
-  String? _name;
-  String? get name => _$this._name;
-  set name(String? name) => _$this._name = name;
-
   GHeroWithFragmentsData_hero_friendsConnectionBuilder? _friendsConnection;
   GHeroWithFragmentsData_hero_friendsConnectionBuilder get friendsConnection =>
       _$this._friendsConnection ??=
@@ -879,6 +883,10 @@ class GHeroWithFragmentsData_heroBuilder
           GHeroWithFragmentsData_hero_friendsConnectionBuilder?
               friendsConnection) =>
       _$this._friendsConnection = friendsConnection;
+
+  String? _name;
+  String? get name => _$this._name;
+  set name(String? name) => _$this._name = name;
 
   GHeroWithFragmentsData_heroBuilder() {
     GHeroWithFragmentsData_hero._initializeBuilder(this);
@@ -889,8 +897,8 @@ class GHeroWithFragmentsData_heroBuilder
     if ($v != null) {
       _G__typename = $v.G__typename;
       _id = $v.id;
-      _name = $v.name;
       _friendsConnection = $v.friendsConnection.toBuilder();
+      _name = $v.name;
       _$v = null;
     }
     return this;
@@ -919,9 +927,9 @@ class GHeroWithFragmentsData_heroBuilder
                   G__typename, r'GHeroWithFragmentsData_hero', 'G__typename'),
               id: BuiltValueNullFieldError.checkNotNull(
                   id, r'GHeroWithFragmentsData_hero', 'id'),
+              friendsConnection: friendsConnection.build(),
               name: BuiltValueNullFieldError.checkNotNull(
-                  name, r'GHeroWithFragmentsData_hero', 'name'),
-              friendsConnection: friendsConnection.build());
+                  name, r'GHeroWithFragmentsData_hero', 'name'));
     } catch (_) {
       late String _$failedField;
       try {
@@ -982,8 +990,12 @@ class _$GHeroWithFragmentsData_hero_friendsConnection
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, G__typename.hashCode), totalCount.hashCode),
-        edges.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, totalCount.hashCode);
+    _$hash = $jc(_$hash, edges.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1125,7 +1137,11 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), node.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1269,8 +1285,12 @@ class _$GHeroWithFragmentsData_hero_friendsConnection_edges_node
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1393,8 +1413,12 @@ class _$GheroDataData extends GheroDataData {
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1516,9 +1540,13 @@ class _$GcomparisonFieldsData extends GcomparisonFieldsData {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode),
-        friendsConnection.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, friendsConnection.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1657,8 +1685,12 @@ class _$GcomparisonFieldsData_friendsConnection
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, G__typename.hashCode), totalCount.hashCode),
-        edges.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, totalCount.hashCode);
+    _$hash = $jc(_$hash, edges.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1792,7 +1824,11 @@ class _$GcomparisonFieldsData_friendsConnection_edges
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), node.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, node.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -1931,8 +1967,12 @@ class _$GcomparisonFieldsData_friendsConnection_edges_node
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -2011,4 +2051,4 @@ class GcomparisonFieldsData_friendsConnection_edges_nodeBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.g.dart
@@ -355,20 +355,18 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -561,10 +559,13 @@ class _$GheroDataReq extends GheroDataReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, vars.hashCode), document.hashCode),
-            fragmentName.hashCode),
-        idFields.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, document.hashCode);
+    _$hash = $jc(_$hash, fragmentName.hashCode);
+    _$hash = $jc(_$hash, idFields.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -705,10 +706,13 @@ class _$GcomparisonFieldsReq extends GcomparisonFieldsReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, vars.hashCode), document.hashCode),
-            fragmentName.hashCode),
-        idFields.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, document.hashCode);
+    _$hash = $jc(_$hash, fragmentName.hashCode);
+    _$hash = $jc(_$hash, idFields.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -800,4 +804,4 @@ class GcomparisonFieldsReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.dart
@@ -7,7 +7,8 @@ import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/schema.schema.gql.dart'
     as _i1;
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i2;
+    as _i3;
+import 'package:gql_exec/value.dart' as _i2;
 
 part 'hero_with_fragments.var.gql.g.dart';
 
@@ -19,18 +20,19 @@ abstract class GHeroWithFragmentsVars
           [Function(GHeroWithFragmentsVarsBuilder b) updates]) =
       _$GHeroWithFragmentsVars;
 
-  _i1.GEpisode? get episode;
-  static Serializer<GHeroWithFragmentsVars> get serializer =>
-      _$gHeroWithFragmentsVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  _i2.Value<_i1.GEpisode>? get episode;
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GHeroWithFragmentsVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GHeroWithFragmentsVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GHeroWithFragmentsVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GHeroWithFragmentsVars> get serializer =>
+      GHeroWithFragmentsVarsSerializer();
 }
 
 abstract class GheroDataVars
@@ -40,16 +42,17 @@ abstract class GheroDataVars
   factory GheroDataVars([Function(GheroDataVarsBuilder b) updates]) =
       _$GheroDataVars;
 
-  static Serializer<GheroDataVars> get serializer => _$gheroDataVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GheroDataVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GheroDataVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GheroDataVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GheroDataVars> get serializer => GheroDataVarsSerializer();
 }
 
 abstract class GcomparisonFieldsVars
@@ -60,16 +63,144 @@ abstract class GcomparisonFieldsVars
           [Function(GcomparisonFieldsVarsBuilder b) updates]) =
       _$GcomparisonFieldsVars;
 
-  int? get first;
-  static Serializer<GcomparisonFieldsVars> get serializer =>
-      _$gcomparisonFieldsVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  _i2.Value<int>? get first;
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GcomparisonFieldsVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GcomparisonFieldsVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GcomparisonFieldsVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GcomparisonFieldsVars> get serializer =>
+      GcomparisonFieldsVarsSerializer();
+}
+
+class GHeroWithFragmentsVarsSerializer
+    extends StructuredSerializer<GHeroWithFragmentsVars> {
+  final String wireName = 'GHeroWithFragmentsVars';
+
+  final Iterable<Type> types = const [
+    GHeroWithFragmentsVars,
+    _$GHeroWithFragmentsVars
+  ];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GHeroWithFragmentsVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    final _$episodevalue = object.episode;
+    if (_$episodevalue != null) {
+      result.add('episode');
+      result.add(serializers.serialize(_$episodevalue!.value,
+          specifiedType: const FullType(_i1.GEpisode)));
+    }
+    return result;
+  }
+
+  GHeroWithFragmentsVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GHeroWithFragmentsVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'episode':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.episode = _i2.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
+}
+
+class GheroDataVarsSerializer extends StructuredSerializer<GheroDataVars> {
+  final String wireName = 'GheroDataVars';
+
+  final Iterable<Type> types = const [GheroDataVars, _$GheroDataVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GheroDataVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    return result;
+  }
+
+  GheroDataVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GheroDataVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        
+      }
+    }
+    return builder.build();
+  }
+}
+
+class GcomparisonFieldsVarsSerializer
+    extends StructuredSerializer<GcomparisonFieldsVars> {
+  final String wireName = 'GcomparisonFieldsVars';
+
+  final Iterable<Type> types = const [
+    GcomparisonFieldsVars,
+    _$GcomparisonFieldsVars
+  ];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GcomparisonFieldsVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    final _$firstvalue = object.first;
+    if (_$firstvalue != null) {
+      result.add('first');
+      result.add(serializers.serialize(_$firstvalue!.value,
+          specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  GcomparisonFieldsVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GcomparisonFieldsVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'first':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.first = _i2.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.g.dart
@@ -6,133 +6,9 @@ part of 'hero_with_fragments.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GHeroWithFragmentsVars> _$gHeroWithFragmentsVarsSerializer =
-    new _$GHeroWithFragmentsVarsSerializer();
-Serializer<GheroDataVars> _$gheroDataVarsSerializer =
-    new _$GheroDataVarsSerializer();
-Serializer<GcomparisonFieldsVars> _$gcomparisonFieldsVarsSerializer =
-    new _$GcomparisonFieldsVarsSerializer();
-
-class _$GHeroWithFragmentsVarsSerializer
-    implements StructuredSerializer<GHeroWithFragmentsVars> {
-  @override
-  final Iterable<Type> types = const [
-    GHeroWithFragmentsVars,
-    _$GHeroWithFragmentsVars
-  ];
-  @override
-  final String wireName = 'GHeroWithFragmentsVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GHeroWithFragmentsVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.episode;
-    if (value != null) {
-      result
-        ..add('episode')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(_i1.GEpisode)));
-    }
-    return result;
-  }
-
-  @override
-  GHeroWithFragmentsVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GHeroWithFragmentsVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'episode':
-          result.episode = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
-class _$GheroDataVarsSerializer implements StructuredSerializer<GheroDataVars> {
-  @override
-  final Iterable<Type> types = const [GheroDataVars, _$GheroDataVars];
-  @override
-  final String wireName = 'GheroDataVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GheroDataVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    return <Object?>[];
-  }
-
-  @override
-  GheroDataVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    return new GheroDataVarsBuilder().build();
-  }
-}
-
-class _$GcomparisonFieldsVarsSerializer
-    implements StructuredSerializer<GcomparisonFieldsVars> {
-  @override
-  final Iterable<Type> types = const [
-    GcomparisonFieldsVars,
-    _$GcomparisonFieldsVars
-  ];
-  @override
-  final String wireName = 'GcomparisonFieldsVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GcomparisonFieldsVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.first;
-    if (value != null) {
-      result
-        ..add('first')
-        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
-    }
-    return result;
-  }
-
-  @override
-  GcomparisonFieldsVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GcomparisonFieldsVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'first':
-          result.first = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GHeroWithFragmentsVars extends GHeroWithFragmentsVars {
   @override
-  final _i1.GEpisode? episode;
+  final _i2.Value<_i1.GEpisode>? episode;
 
   factory _$GHeroWithFragmentsVars(
           [void Function(GHeroWithFragmentsVarsBuilder)? updates]) =>
@@ -157,7 +33,10 @@ class _$GHeroWithFragmentsVars extends GHeroWithFragmentsVars {
 
   @override
   int get hashCode {
-    return $jf($jc(0, episode.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -172,9 +51,9 @@ class GHeroWithFragmentsVarsBuilder
     implements Builder<GHeroWithFragmentsVars, GHeroWithFragmentsVarsBuilder> {
   _$GHeroWithFragmentsVars? _$v;
 
-  _i1.GEpisode? _episode;
-  _i1.GEpisode? get episode => _$this._episode;
-  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
+  _i2.Value<_i1.GEpisode>? _episode;
+  _i2.Value<_i1.GEpisode>? get episode => _$this._episode;
+  set episode(_i2.Value<_i1.GEpisode>? episode) => _$this._episode = episode;
 
   GHeroWithFragmentsVarsBuilder();
 
@@ -267,7 +146,7 @@ class GheroDataVarsBuilder
 
 class _$GcomparisonFieldsVars extends GcomparisonFieldsVars {
   @override
-  final int? first;
+  final _i2.Value<int>? first;
 
   factory _$GcomparisonFieldsVars(
           [void Function(GcomparisonFieldsVarsBuilder)? updates]) =>
@@ -292,7 +171,10 @@ class _$GcomparisonFieldsVars extends GcomparisonFieldsVars {
 
   @override
   int get hashCode {
-    return $jf($jc(0, first.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, first.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -307,9 +189,9 @@ class GcomparisonFieldsVarsBuilder
     implements Builder<GcomparisonFieldsVars, GcomparisonFieldsVarsBuilder> {
   _$GcomparisonFieldsVars? _$v;
 
-  int? _first;
-  int? get first => _$this._first;
-  set first(int? first) => _$this._first = first;
+  _i2.Value<int>? _first;
+  _i2.Value<int>? get first => _$this._first;
+  set first(_i2.Value<int>? first) => _$this._first = first;
 
   GcomparisonFieldsVarsBuilder();
 
@@ -343,4 +225,4 @@ class GcomparisonFieldsVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.g.dart
@@ -278,7 +278,11 @@ class _$GHeroForEpisodeData extends GHeroForEpisodeData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), hero.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, hero.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -379,7 +383,11 @@ class _$GHeroForEpisodeData_hero__base extends GHeroForEpisodeData_hero__base {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -488,8 +496,12 @@ class _$GHeroForEpisodeData_hero__asDroid
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, G__typename.hashCode), name.hashCode),
-        primaryFunction.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, primaryFunction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -599,7 +611,11 @@ class _$GDroidFragmentData extends GDroidFragmentData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), primaryFunction.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, primaryFunction.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -663,4 +679,4 @@ class GDroidFragmentDataBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.g.dart
@@ -273,20 +273,18 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -478,10 +476,13 @@ class _$GDroidFragmentReq extends GDroidFragmentReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, vars.hashCode), document.hashCode),
-            fragmentName.hashCode),
-        idFields.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, document.hashCode);
+    _$hash = $jc(_$hash, fragmentName.hashCode);
+    _$hash = $jc(_$hash, idFields.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -573,4 +574,4 @@ class GDroidFragmentReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.dart
@@ -19,8 +19,6 @@ abstract class GHeroForEpisodeVars
       [Function(GHeroForEpisodeVarsBuilder b) updates]) = _$GHeroForEpisodeVars;
 
   _i1.GEpisode get ep;
-  static Serializer<GHeroForEpisodeVars> get serializer =>
-      _$gHeroForEpisodeVarsSerializer;
   Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GHeroForEpisodeVars.serializer,
         this,
@@ -30,6 +28,9 @@ abstract class GHeroForEpisodeVars
         GHeroForEpisodeVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GHeroForEpisodeVars> get serializer =>
+      GHeroForEpisodeVarsSerializer();
 }
 
 abstract class GDroidFragmentVars
@@ -39,8 +40,6 @@ abstract class GDroidFragmentVars
   factory GDroidFragmentVars([Function(GDroidFragmentVarsBuilder b) updates]) =
       _$GDroidFragmentVars;
 
-  static Serializer<GDroidFragmentVars> get serializer =>
-      _$gDroidFragmentVarsSerializer;
   Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GDroidFragmentVars.serializer,
         this,
@@ -50,4 +49,85 @@ abstract class GDroidFragmentVars
         GDroidFragmentVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GDroidFragmentVars> get serializer =>
+      GDroidFragmentVarsSerializer();
+}
+
+class GHeroForEpisodeVarsSerializer
+    extends StructuredSerializer<GHeroForEpisodeVars> {
+  final String wireName = 'GHeroForEpisodeVars';
+
+  final Iterable<Type> types = const [
+    GHeroForEpisodeVars,
+    _$GHeroForEpisodeVars
+  ];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GHeroForEpisodeVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('ep');
+    result.add(serializers.serialize(object.ep,
+        specifiedType: const FullType(_i1.GEpisode)));
+    return result;
+  }
+
+  GHeroForEpisodeVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GHeroForEpisodeVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'ep':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.ep = fieldValue;
+          break;
+      }
+    }
+    return builder.build();
+  }
+}
+
+class GDroidFragmentVarsSerializer
+    extends StructuredSerializer<GDroidFragmentVars> {
+  final String wireName = 'GDroidFragmentVars';
+
+  final Iterable<Type> types = const [GDroidFragmentVars, _$GDroidFragmentVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GDroidFragmentVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    return result;
+  }
+
+  GDroidFragmentVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GDroidFragmentVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.g.dart
@@ -6,79 +6,6 @@ part of 'hero_with_inline_fragment.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GHeroForEpisodeVars> _$gHeroForEpisodeVarsSerializer =
-    new _$GHeroForEpisodeVarsSerializer();
-Serializer<GDroidFragmentVars> _$gDroidFragmentVarsSerializer =
-    new _$GDroidFragmentVarsSerializer();
-
-class _$GHeroForEpisodeVarsSerializer
-    implements StructuredSerializer<GHeroForEpisodeVars> {
-  @override
-  final Iterable<Type> types = const [
-    GHeroForEpisodeVars,
-    _$GHeroForEpisodeVars
-  ];
-  @override
-  final String wireName = 'GHeroForEpisodeVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GHeroForEpisodeVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'ep',
-      serializers.serialize(object.ep,
-          specifiedType: const FullType(_i1.GEpisode)),
-    ];
-
-    return result;
-  }
-
-  @override
-  GHeroForEpisodeVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GHeroForEpisodeVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'ep':
-          result.ep = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode))! as _i1.GEpisode;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
-class _$GDroidFragmentVarsSerializer
-    implements StructuredSerializer<GDroidFragmentVars> {
-  @override
-  final Iterable<Type> types = const [GDroidFragmentVars, _$GDroidFragmentVars];
-  @override
-  final String wireName = 'GDroidFragmentVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GDroidFragmentVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    return <Object?>[];
-  }
-
-  @override
-  GDroidFragmentVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    return new GDroidFragmentVarsBuilder().build();
-  }
-}
-
 class _$GHeroForEpisodeVars extends GHeroForEpisodeVars {
   @override
   final _i1.GEpisode ep;
@@ -108,7 +35,10 @@ class _$GHeroForEpisodeVars extends GHeroForEpisodeVars {
 
   @override
   int get hashCode {
-    return $jf($jc(0, ep.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, ep.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -221,4 +151,4 @@ class GDroidFragmentVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.data.gql.g.dart
@@ -309,7 +309,11 @@ class _$GHumanWithArgsData extends GHumanWithArgsData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), human.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, human.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -441,10 +445,14 @@ class _$GHumanWithArgsData_human extends GHumanWithArgsData_human {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode),
-            height.hashCode),
-        friendsConnection.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, height.hashCode);
+    _$hash = $jc(_$hash, friendsConnection.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -589,7 +597,11 @@ class _$GHumanWithArgsData_human_friendsConnection
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), friends.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, friends.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -729,8 +741,12 @@ class _$GHumanWithArgsData_human_friendsConnection_friends
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, G__typename.hashCode), id.hashCode), name.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -809,4 +825,4 @@ class GHumanWithArgsData_human_friendsConnection_friendsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.g.dart
@@ -196,20 +196,18 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -354,4 +352,4 @@ class GHumanWithArgsReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.dart
@@ -5,7 +5,8 @@
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i1;
+    as _i2;
+import 'package:gql_exec/value.dart' as _i1;
 
 part 'human_with_args.var.gql.g.dart';
 
@@ -17,16 +18,69 @@ abstract class GHumanWithArgsVars
       _$GHumanWithArgsVars;
 
   String get id;
-  String? get friendsAfter;
-  static Serializer<GHumanWithArgsVars> get serializer =>
-      _$gHumanWithArgsVarsSerializer;
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+  _i1.Value<String>? get friendsAfter;
+  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GHumanWithArgsVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GHumanWithArgsVars? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
+      _i2.serializers.deserializeWith(
         GHumanWithArgsVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GHumanWithArgsVars> get serializer =>
+      GHumanWithArgsVarsSerializer();
+}
+
+class GHumanWithArgsVarsSerializer
+    extends StructuredSerializer<GHumanWithArgsVars> {
+  final String wireName = 'GHumanWithArgsVars';
+
+  final Iterable<Type> types = const [GHumanWithArgsVars, _$GHumanWithArgsVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GHumanWithArgsVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('id');
+    result.add(serializers.serialize(object.id,
+        specifiedType: const FullType(String)));
+    final _$friendsAftervalue = object.friendsAfter;
+    if (_$friendsAftervalue != null) {
+      result.add('friendsAfter');
+      result.add(serializers.serialize(_$friendsAftervalue!.value,
+          specifiedType: const FullType(String)));
+    }
+    return result;
+  }
+
+  GHumanWithArgsVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GHumanWithArgsVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          builder.id = fieldValue;
+          break;
+        case 'friendsAfter':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          builder.friendsAfter = _i1.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.g.dart
@@ -6,67 +6,11 @@ part of 'human_with_args.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GHumanWithArgsVars> _$gHumanWithArgsVarsSerializer =
-    new _$GHumanWithArgsVarsSerializer();
-
-class _$GHumanWithArgsVarsSerializer
-    implements StructuredSerializer<GHumanWithArgsVars> {
-  @override
-  final Iterable<Type> types = const [GHumanWithArgsVars, _$GHumanWithArgsVars];
-  @override
-  final String wireName = 'GHumanWithArgsVars';
-
-  @override
-  Iterable<Object?> serialize(
-      Serializers serializers, GHumanWithArgsVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(String)),
-    ];
-    Object? value;
-    value = object.friendsAfter;
-    if (value != null) {
-      result
-        ..add('friendsAfter')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
-    }
-    return result;
-  }
-
-  @override
-  GHumanWithArgsVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GHumanWithArgsVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'id':
-          result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-        case 'friendsAfter':
-          result.friendsAfter = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GHumanWithArgsVars extends GHumanWithArgsVars {
   @override
   final String id;
   @override
-  final String? friendsAfter;
+  final _i1.Value<String>? friendsAfter;
 
   factory _$GHumanWithArgsVars(
           [void Function(GHumanWithArgsVarsBuilder)? updates]) =>
@@ -95,7 +39,11 @@ class _$GHumanWithArgsVars extends GHumanWithArgsVars {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, id.hashCode), friendsAfter.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, friendsAfter.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -115,9 +63,10 @@ class GHumanWithArgsVarsBuilder
   String? get id => _$this._id;
   set id(String? id) => _$this._id = id;
 
-  String? _friendsAfter;
-  String? get friendsAfter => _$this._friendsAfter;
-  set friendsAfter(String? friendsAfter) => _$this._friendsAfter = friendsAfter;
+  _i1.Value<String>? _friendsAfter;
+  _i1.Value<String>? get friendsAfter => _$this._friendsAfter;
+  set friendsAfter(_i1.Value<String>? friendsAfter) =>
+      _$this._friendsAfter = friendsAfter;
 
   GHumanWithArgsVarsBuilder();
 
@@ -156,4 +105,4 @@ class GHumanWithArgsVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.data.gql.g.dart
@@ -199,7 +199,11 @@ class _$GReviewsByIDData extends GReviewsByIDData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), review.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, review.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -338,16 +342,16 @@ class _$GReviewsByIDData_review extends GReviewsByIDData_review {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc($jc($jc(0, G__typename.hashCode), id.hashCode),
-                        episode.hashCode),
-                    stars.hashCode),
-                commentary.hashCode),
-            createdAt.hashCode),
-        seenOn.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, seenOn.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -462,4 +466,4 @@ class GReviewsByIDData_reviewBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.g.dart
@@ -195,20 +195,18 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -352,4 +350,4 @@ class GReviewsByIDReqBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.dart
@@ -17,8 +17,6 @@ abstract class GReviewsByIDVars
       _$GReviewsByIDVars;
 
   String get id;
-  static Serializer<GReviewsByIDVars> get serializer =>
-      _$gReviewsByIDVarsSerializer;
   Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
         GReviewsByIDVars.serializer,
         this,
@@ -28,4 +26,48 @@ abstract class GReviewsByIDVars
         GReviewsByIDVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GReviewsByIDVars> get serializer =>
+      GReviewsByIDVarsSerializer();
+}
+
+class GReviewsByIDVarsSerializer
+    extends StructuredSerializer<GReviewsByIDVars> {
+  final String wireName = 'GReviewsByIDVars';
+
+  final Iterable<Type> types = const [GReviewsByIDVars, _$GReviewsByIDVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GReviewsByIDVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('id');
+    result.add(serializers.serialize(object.id,
+        specifiedType: const FullType(String)));
+    return result;
+  }
+
+  GReviewsByIDVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GReviewsByIDVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'id':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          builder.id = fieldValue;
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.g.dart
@@ -6,50 +6,6 @@ part of 'review_by_id.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GReviewsByIDVars> _$gReviewsByIDVarsSerializer =
-    new _$GReviewsByIDVarsSerializer();
-
-class _$GReviewsByIDVarsSerializer
-    implements StructuredSerializer<GReviewsByIDVars> {
-  @override
-  final Iterable<Type> types = const [GReviewsByIDVars, _$GReviewsByIDVars];
-  @override
-  final String wireName = 'GReviewsByIDVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GReviewsByIDVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'id',
-      serializers.serialize(object.id, specifiedType: const FullType(String)),
-    ];
-
-    return result;
-  }
-
-  @override
-  GReviewsByIDVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GReviewsByIDVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'id':
-          result.id = serializers.deserialize(value,
-              specifiedType: const FullType(String))! as String;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GReviewsByIDVars extends GReviewsByIDVars {
   @override
   final String id;
@@ -78,7 +34,10 @@ class _$GReviewsByIDVars extends GReviewsByIDVars {
 
   @override
   int get hashCode {
-    return $jf($jc(0, id.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -131,4 +90,4 @@ class GReviewsByIDVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.data.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.data.gql.g.dart
@@ -198,7 +198,11 @@ class _$GReviewsData extends GReviewsData {
 
   @override
   int get hashCode {
-    return $jf($jc($jc(0, G__typename.hashCode), reviews.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, reviews.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -338,16 +342,16 @@ class _$GReviewsData_reviews extends GReviewsData_reviews {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc($jc($jc(0, G__typename.hashCode), id.hashCode),
-                        episode.hashCode),
-                    stars.hashCode),
-                commentary.hashCode),
-            createdAt.hashCode),
-        seenOn.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, G__typename.hashCode);
+    _$hash = $jc(_$hash, id.hashCode);
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jc(_$hash, createdAt.hashCode);
+    _$hash = $jc(_$hash, seenOn.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -461,4 +465,4 @@ class GReviewsData_reviewsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.g.dart
@@ -191,20 +191,18 @@ class _$GReviewsReq extends GReviewsReq {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc(
-            $jc(
-                $jc(
-                    $jc(
-                        $jc(
-                            $jc($jc($jc(0, vars.hashCode), operation.hashCode),
-                                requestId.hashCode),
-                            updateResult.hashCode),
-                        optimisticResponse.hashCode),
-                    updateCacheHandlerKey.hashCode),
-                updateCacheHandlerContext.hashCode),
-            fetchPolicy.hashCode),
-        executeOnListen.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, vars.hashCode);
+    _$hash = $jc(_$hash, operation.hashCode);
+    _$hash = $jc(_$hash, requestId.hashCode);
+    _$hash = $jc(_$hash, updateResult.hashCode);
+    _$hash = $jc(_$hash, optimisticResponse.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerKey.hashCode);
+    _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
+    _$hash = $jc(_$hash, fetchPolicy.hashCode);
+    _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -346,4 +344,4 @@ class GReviewsReqBuilder implements Builder<GReviewsReq, GReviewsReqBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.dart
@@ -7,7 +7,8 @@ import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/schema.schema.gql.dart'
     as _i1;
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i2;
+    as _i3;
+import 'package:gql_exec/value.dart' as _i2;
 
 part 'reviews.var.gql.g.dart';
 
@@ -18,17 +19,83 @@ abstract class GReviewsVars
   factory GReviewsVars([Function(GReviewsVarsBuilder b) updates]) =
       _$GReviewsVars;
 
-  _i1.GEpisode? get episode;
-  int? get first;
-  int? get offset;
-  static Serializer<GReviewsVars> get serializer => _$gReviewsVarsSerializer;
-  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
+  _i2.Value<_i1.GEpisode>? get episode;
+  _i2.Value<int>? get first;
+  _i2.Value<int>? get offset;
+  Map<String, dynamic> toJson() => (_i3.serializers.serializeWith(
         GReviewsVars.serializer,
         this,
       ) as Map<String, dynamic>);
   static GReviewsVars? fromJson(Map<String, dynamic> json) =>
-      _i2.serializers.deserializeWith(
+      _i3.serializers.deserializeWith(
         GReviewsVars.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GReviewsVars> get serializer => GReviewsVarsSerializer();
+}
+
+class GReviewsVarsSerializer extends StructuredSerializer<GReviewsVars> {
+  final String wireName = 'GReviewsVars';
+
+  final Iterable<Type> types = const [GReviewsVars, _$GReviewsVars];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GReviewsVars object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    final _$episodevalue = object.episode;
+    if (_$episodevalue != null) {
+      result.add('episode');
+      result.add(serializers.serialize(_$episodevalue!.value,
+          specifiedType: const FullType(_i1.GEpisode)));
+    }
+    final _$firstvalue = object.first;
+    if (_$firstvalue != null) {
+      result.add('first');
+      result.add(serializers.serialize(_$firstvalue!.value,
+          specifiedType: const FullType(int)));
+    }
+    final _$offsetvalue = object.offset;
+    if (_$offsetvalue != null) {
+      result.add('offset');
+      result.add(serializers.serialize(_$offsetvalue!.value,
+          specifiedType: const FullType(int)));
+    }
+    return result;
+  }
+
+  GReviewsVars deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GReviewsVarsBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'episode':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode;
+          builder.episode = _i2.Value(fieldValue);
+          break;
+        case 'first':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.first = _i2.Value(fieldValue);
+          break;
+        case 'offset':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.offset = _i2.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.g.dart
@@ -6,80 +6,13 @@ part of 'reviews.var.gql.dart';
 // BuiltValueGenerator
 // **************************************************************************
 
-Serializer<GReviewsVars> _$gReviewsVarsSerializer =
-    new _$GReviewsVarsSerializer();
-
-class _$GReviewsVarsSerializer implements StructuredSerializer<GReviewsVars> {
-  @override
-  final Iterable<Type> types = const [GReviewsVars, _$GReviewsVars];
-  @override
-  final String wireName = 'GReviewsVars';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GReviewsVars object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[];
-    Object? value;
-    value = object.episode;
-    if (value != null) {
-      result
-        ..add('episode')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(_i1.GEpisode)));
-    }
-    value = object.first;
-    if (value != null) {
-      result
-        ..add('first')
-        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
-    }
-    value = object.offset;
-    if (value != null) {
-      result
-        ..add('offset')
-        ..add(serializers.serialize(value, specifiedType: const FullType(int)));
-    }
-    return result;
-  }
-
-  @override
-  GReviewsVars deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GReviewsVarsBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'episode':
-          result.episode = serializers.deserialize(value,
-              specifiedType: const FullType(_i1.GEpisode)) as _i1.GEpisode?;
-          break;
-        case 'first':
-          result.first = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int?;
-          break;
-        case 'offset':
-          result.offset = serializers.deserialize(value,
-              specifiedType: const FullType(int)) as int?;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GReviewsVars extends GReviewsVars {
   @override
-  final _i1.GEpisode? episode;
+  final _i2.Value<_i1.GEpisode>? episode;
   @override
-  final int? first;
+  final _i2.Value<int>? first;
   @override
-  final int? offset;
+  final _i2.Value<int>? offset;
 
   factory _$GReviewsVars([void Function(GReviewsVarsBuilder)? updates]) =>
       (new GReviewsVarsBuilder()..update(updates))._build();
@@ -104,8 +37,12 @@ class _$GReviewsVars extends GReviewsVars {
 
   @override
   int get hashCode {
-    return $jf(
-        $jc($jc($jc(0, episode.hashCode), first.hashCode), offset.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, episode.hashCode);
+    _$hash = $jc(_$hash, first.hashCode);
+    _$hash = $jc(_$hash, offset.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -122,17 +59,17 @@ class GReviewsVarsBuilder
     implements Builder<GReviewsVars, GReviewsVarsBuilder> {
   _$GReviewsVars? _$v;
 
-  _i1.GEpisode? _episode;
-  _i1.GEpisode? get episode => _$this._episode;
-  set episode(_i1.GEpisode? episode) => _$this._episode = episode;
+  _i2.Value<_i1.GEpisode>? _episode;
+  _i2.Value<_i1.GEpisode>? get episode => _$this._episode;
+  set episode(_i2.Value<_i1.GEpisode>? episode) => _$this._episode = episode;
 
-  int? _first;
-  int? get first => _$this._first;
-  set first(int? first) => _$this._first = first;
+  _i2.Value<int>? _first;
+  _i2.Value<int>? get first => _$this._first;
+  set first(_i2.Value<int>? first) => _$this._first = first;
 
-  int? _offset;
-  int? get offset => _$this._offset;
-  set offset(int? offset) => _$this._offset = offset;
+  _i2.Value<int>? _offset;
+  _i2.Value<int>? get offset => _$this._offset;
+  set offset(_i2.Value<int>? offset) => _$this._offset = offset;
 
   GReviewsVarsBuilder();
 
@@ -169,4 +106,4 @@ class GReviewsVarsBuilder
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
@@ -6,9 +6,10 @@ import 'package:built_collection/built_collection.dart';
 import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
-    as _i1;
-import 'package:gql_code_builder/src/serializers/default_scalar_serializer.dart'
     as _i2;
+import 'package:gql_code_builder/src/serializers/default_scalar_serializer.dart'
+    as _i3;
+import 'package:gql_exec/value.dart' as _i1;
 
 part 'schema.schema.gql.g.dart';
 
@@ -46,19 +47,95 @@ abstract class GReviewInput
       _$GReviewInput;
 
   int get stars;
-  String? get commentary;
-  GColorInput? get favorite_color;
-  BuiltList<DateTime?>? get seenOn;
-  static Serializer<GReviewInput> get serializer => _$gReviewInputSerializer;
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+  _i1.Value<String>? get commentary;
+  _i1.Value<GColorInput>? get favorite_color;
+  _i1.Value<BuiltList<DateTime?>>? get seenOn;
+  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GReviewInput.serializer,
         this,
       ) as Map<String, dynamic>);
   static GReviewInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
+      _i2.serializers.deserializeWith(
         GReviewInput.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GReviewInput> get serializer => GReviewInputSerializer();
+}
+
+class GReviewInputSerializer extends StructuredSerializer<GReviewInput> {
+  final String wireName = 'GReviewInput';
+
+  final Iterable<Type> types = const [GReviewInput, _$GReviewInput];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GReviewInput object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('stars');
+    result.add(serializers.serialize(object.stars,
+        specifiedType: const FullType(int)));
+    final _$commentaryvalue = object.commentary;
+    if (_$commentaryvalue != null) {
+      result.add('commentary');
+      result.add(serializers.serialize(_$commentaryvalue!.value,
+          specifiedType: const FullType(String)));
+    }
+    final _$favorite_colorvalue = object.favorite_color;
+    if (_$favorite_colorvalue != null) {
+      result.add('favorite_color');
+      result.add(serializers.serialize(_$favorite_colorvalue!.value,
+          specifiedType: const FullType(GColorInput)));
+    }
+    final _$seenOnvalue = object.seenOn;
+    if (_$seenOnvalue != null) {
+      result.add('seenOn');
+      result.add(serializers.serialize(_$seenOnvalue!.value,
+          specifiedType: const FullType(BuiltList, [FullType(DateTime)])));
+    }
+    return result;
+  }
+
+  GReviewInput deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GReviewInputBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'stars':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.stars = fieldValue;
+          break;
+        case 'commentary':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(String)) as String;
+          builder.commentary = _i1.Value(fieldValue);
+          break;
+        case 'favorite_color':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(GColorInput)) as GColorInput;
+          builder.favorite_color = _i1.Value(fieldValue);
+          break;
+        case 'seenOn':
+          var fieldValue = serializers.deserialize(value,
+                  specifiedType:
+                      const FullType(BuiltList, [FullType(DateTime)]))
+              as BuiltList<DateTime>;
+          builder.seenOn = _i1.Value(fieldValue);
+          break;
+      }
+    }
+    return builder.build();
+  }
 }
 
 abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
@@ -69,16 +146,73 @@ abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
   int get red;
   int get green;
   int get blue;
-  static Serializer<GColorInput> get serializer => _$gColorInputSerializer;
-  Map<String, dynamic> toJson() => (_i1.serializers.serializeWith(
+  Map<String, dynamic> toJson() => (_i2.serializers.serializeWith(
         GColorInput.serializer,
         this,
       ) as Map<String, dynamic>);
   static GColorInput? fromJson(Map<String, dynamic> json) =>
-      _i1.serializers.deserializeWith(
+      _i2.serializers.deserializeWith(
         GColorInput.serializer,
         json,
       );
+  @BuiltValueSerializer(custom: true, serializeNulls: true)
+  static Serializer<GColorInput> get serializer => GColorInputSerializer();
+}
+
+class GColorInputSerializer extends StructuredSerializer<GColorInput> {
+  final String wireName = 'GColorInput';
+
+  final Iterable<Type> types = const [GColorInput, _$GColorInput];
+
+  Iterable<Object?> serialize(
+    Serializers serializers,
+    GColorInput object, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final result = <Object?>[];
+    result.add('red');
+    result.add(
+        serializers.serialize(object.red, specifiedType: const FullType(int)));
+    result.add('green');
+    result.add(serializers.serialize(object.green,
+        specifiedType: const FullType(int)));
+    result.add('blue');
+    result.add(
+        serializers.serialize(object.blue, specifiedType: const FullType(int)));
+    return result;
+  }
+
+  GColorInput deserialize(
+    Serializers serializers,
+    Iterable<Object?> serialized, {
+    FullType specifiedType = FullType.unspecified,
+  }) {
+    final builder = GColorInputBuilder();
+    final iterator = serialized.iterator;
+    while (iterator.moveNext()) {
+      final key = iterator.current as String;
+      iterator.moveNext();
+      final Object? value = iterator.current;
+      switch (key) {
+        case 'red':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.red = fieldValue;
+          break;
+        case 'green':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.green = fieldValue;
+          break;
+        case 'blue':
+          var fieldValue = serializers.deserialize(value,
+              specifiedType: const FullType(int)) as int;
+          builder.blue = fieldValue;
+          break;
+      }
+    }
+    return builder.build();
+  }
 }
 
 abstract class GISODate implements Built<GISODate, GISODateBuilder> {
@@ -90,7 +224,7 @@ abstract class GISODate implements Built<GISODate, GISODateBuilder> {
   String get value;
   @BuiltValueSerializer(custom: true)
   static Serializer<GISODate> get serializer =>
-      _i2.DefaultScalarSerializer<GISODate>(
+      _i3.DefaultScalarSerializer<GISODate>(
           (Object serialized) => GISODate((serialized as String?)));
 }
 

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.g.dart
@@ -52,9 +52,6 @@ final BuiltSet<GLengthUnit> _$gLengthUnitValues =
 
 Serializer<GEpisode> _$gEpisodeSerializer = new _$GEpisodeSerializer();
 Serializer<GLengthUnit> _$gLengthUnitSerializer = new _$GLengthUnitSerializer();
-Serializer<GReviewInput> _$gReviewInputSerializer =
-    new _$GReviewInputSerializer();
-Serializer<GColorInput> _$gColorInputSerializer = new _$GColorInputSerializer();
 
 class _$GEpisodeSerializer implements PrimitiveSerializer<GEpisode> {
   @override
@@ -90,142 +87,15 @@ class _$GLengthUnitSerializer implements PrimitiveSerializer<GLengthUnit> {
       GLengthUnit.valueOf(serialized as String);
 }
 
-class _$GReviewInputSerializer implements StructuredSerializer<GReviewInput> {
-  @override
-  final Iterable<Type> types = const [GReviewInput, _$GReviewInput];
-  @override
-  final String wireName = 'GReviewInput';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GReviewInput object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'stars',
-      serializers.serialize(object.stars, specifiedType: const FullType(int)),
-    ];
-    Object? value;
-    value = object.commentary;
-    if (value != null) {
-      result
-        ..add('commentary')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(String)));
-    }
-    value = object.favorite_color;
-    if (value != null) {
-      result
-        ..add('favorite_color')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(GColorInput)));
-    }
-    value = object.seenOn;
-    if (value != null) {
-      result
-        ..add('seenOn')
-        ..add(serializers.serialize(value,
-            specifiedType: const FullType(
-                BuiltList, const [const FullType.nullable(DateTime)])));
-    }
-    return result;
-  }
-
-  @override
-  GReviewInput deserialize(
-      Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GReviewInputBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'stars':
-          result.stars = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-        case 'commentary':
-          result.commentary = serializers.deserialize(value,
-              specifiedType: const FullType(String)) as String?;
-          break;
-        case 'favorite_color':
-          result.favorite_color.replace(serializers.deserialize(value,
-              specifiedType: const FullType(GColorInput))! as GColorInput);
-          break;
-        case 'seenOn':
-          result.seenOn.replace(serializers.deserialize(value,
-                  specifiedType: const FullType(
-                      BuiltList, const [const FullType.nullable(DateTime)]))!
-              as BuiltList<Object?>);
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
-class _$GColorInputSerializer implements StructuredSerializer<GColorInput> {
-  @override
-  final Iterable<Type> types = const [GColorInput, _$GColorInput];
-  @override
-  final String wireName = 'GColorInput';
-
-  @override
-  Iterable<Object?> serialize(Serializers serializers, GColorInput object,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = <Object?>[
-      'red',
-      serializers.serialize(object.red, specifiedType: const FullType(int)),
-      'green',
-      serializers.serialize(object.green, specifiedType: const FullType(int)),
-      'blue',
-      serializers.serialize(object.blue, specifiedType: const FullType(int)),
-    ];
-
-    return result;
-  }
-
-  @override
-  GColorInput deserialize(Serializers serializers, Iterable<Object?> serialized,
-      {FullType specifiedType = FullType.unspecified}) {
-    final result = new GColorInputBuilder();
-
-    final iterator = serialized.iterator;
-    while (iterator.moveNext()) {
-      final key = iterator.current! as String;
-      iterator.moveNext();
-      final Object? value = iterator.current;
-      switch (key) {
-        case 'red':
-          result.red = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-        case 'green':
-          result.green = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-        case 'blue':
-          result.blue = serializers.deserialize(value,
-              specifiedType: const FullType(int))! as int;
-          break;
-      }
-    }
-
-    return result.build();
-  }
-}
-
 class _$GReviewInput extends GReviewInput {
   @override
   final int stars;
   @override
-  final String? commentary;
+  final _i1.Value<String>? commentary;
   @override
-  final GColorInput? favorite_color;
+  final _i1.Value<GColorInput>? favorite_color;
   @override
-  final BuiltList<DateTime?>? seenOn;
+  final _i1.Value<BuiltList<DateTime?>>? seenOn;
 
   factory _$GReviewInput([void Function(GReviewInputBuilder)? updates]) =>
       (new GReviewInputBuilder()..update(updates))._build();
@@ -255,10 +125,13 @@ class _$GReviewInput extends GReviewInput {
 
   @override
   int get hashCode {
-    return $jf($jc(
-        $jc($jc($jc(0, stars.hashCode), commentary.hashCode),
-            favorite_color.hashCode),
-        seenOn.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, stars.hashCode);
+    _$hash = $jc(_$hash, commentary.hashCode);
+    _$hash = $jc(_$hash, favorite_color.hashCode);
+    _$hash = $jc(_$hash, seenOn.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -280,20 +153,20 @@ class GReviewInputBuilder
   int? get stars => _$this._stars;
   set stars(int? stars) => _$this._stars = stars;
 
-  String? _commentary;
-  String? get commentary => _$this._commentary;
-  set commentary(String? commentary) => _$this._commentary = commentary;
+  _i1.Value<String>? _commentary;
+  _i1.Value<String>? get commentary => _$this._commentary;
+  set commentary(_i1.Value<String>? commentary) =>
+      _$this._commentary = commentary;
 
-  GColorInputBuilder? _favorite_color;
-  GColorInputBuilder get favorite_color =>
-      _$this._favorite_color ??= new GColorInputBuilder();
-  set favorite_color(GColorInputBuilder? favorite_color) =>
+  _i1.Value<GColorInput>? _favorite_color;
+  _i1.Value<GColorInput>? get favorite_color => _$this._favorite_color;
+  set favorite_color(_i1.Value<GColorInput>? favorite_color) =>
       _$this._favorite_color = favorite_color;
 
-  ListBuilder<DateTime?>? _seenOn;
-  ListBuilder<DateTime?> get seenOn =>
-      _$this._seenOn ??= new ListBuilder<DateTime?>();
-  set seenOn(ListBuilder<DateTime?>? seenOn) => _$this._seenOn = seenOn;
+  _i1.Value<BuiltList<DateTime?>>? _seenOn;
+  _i1.Value<BuiltList<DateTime?>>? get seenOn => _$this._seenOn;
+  set seenOn(_i1.Value<BuiltList<DateTime?>>? seenOn) =>
+      _$this._seenOn = seenOn;
 
   GReviewInputBuilder();
 
@@ -302,8 +175,8 @@ class GReviewInputBuilder
     if ($v != null) {
       _stars = $v.stars;
       _commentary = $v.commentary;
-      _favorite_color = $v.favorite_color?.toBuilder();
-      _seenOn = $v.seenOn?.toBuilder();
+      _favorite_color = $v.favorite_color;
+      _seenOn = $v.seenOn;
       _$v = null;
     }
     return this;
@@ -324,28 +197,13 @@ class GReviewInputBuilder
   GReviewInput build() => _build();
 
   _$GReviewInput _build() {
-    _$GReviewInput _$result;
-    try {
-      _$result = _$v ??
-          new _$GReviewInput._(
-              stars: BuiltValueNullFieldError.checkNotNull(
-                  stars, r'GReviewInput', 'stars'),
-              commentary: commentary,
-              favorite_color: _favorite_color?.build(),
-              seenOn: _seenOn?.build());
-    } catch (_) {
-      late String _$failedField;
-      try {
-        _$failedField = 'favorite_color';
-        _favorite_color?.build();
-        _$failedField = 'seenOn';
-        _seenOn?.build();
-      } catch (e) {
-        throw new BuiltValueNestedFieldError(
-            r'GReviewInput', _$failedField, e.toString());
-      }
-      rethrow;
-    }
+    final _$result = _$v ??
+        new _$GReviewInput._(
+            stars: BuiltValueNullFieldError.checkNotNull(
+                stars, r'GReviewInput', 'stars'),
+            commentary: commentary,
+            favorite_color: favorite_color,
+            seenOn: seenOn);
     replace(_$result);
     return _$result;
   }
@@ -387,7 +245,12 @@ class _$GColorInput extends GColorInput {
 
   @override
   int get hashCode {
-    return $jf($jc($jc($jc(0, red.hashCode), green.hashCode), blue.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, red.hashCode);
+    _$hash = $jc(_$hash, green.hashCode);
+    _$hash = $jc(_$hash, blue.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -482,7 +345,10 @@ class _$GISODate extends GISODate {
 
   @override
   int get hashCode {
-    return $jf($jc(0, value.hashCode));
+    var _$hash = 0;
+    _$hash = $jc(_$hash, value.hashCode);
+    _$hash = $jf(_$hash);
+    return _$hash;
   }
 
   @override
@@ -534,4 +400,4 @@ class GISODateBuilder implements Builder<GISODate, GISODateBuilder> {
   }
 }
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/serializers.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/serializers.gql.g.dart
@@ -81,9 +81,6 @@ Serializers _$serializers = (new Serializers().toBuilder()
           const FullType(BuiltList, const [const FullType(DateTime)]),
           () => new ListBuilder<DateTime>())
       ..addBuilderFactory(
-          const FullType(BuiltList, const [const FullType.nullable(DateTime)]),
-          () => new ListBuilder<DateTime?>())
-      ..addBuilderFactory(
           const FullType(BuiltList, const [const FullType.nullable(GEpisode)]),
           () => new ListBuilder<GEpisode?>())
       ..addBuilderFactory(
@@ -116,4 +113,4 @@ Serializers _$serializers = (new Serializers().toBuilder()
               GcomparisonFieldsData_friendsConnection_edges?>()))
     .build();
 
-// ignore_for_file: always_put_control_body_on_new_line,always_specify_types,annotate_overrides,avoid_annotating_with_dynamic,avoid_as,avoid_catches_without_on_clauses,avoid_returning_this,deprecated_member_use_from_same_package,lines_longer_than_80_chars,no_leading_underscores_for_local_identifiers,omit_local_variable_types,prefer_expression_function_bodies,sort_constructors_first,test_types_in_equals,unnecessary_const,unnecessary_new,unnecessary_lambdas
+// ignore_for_file: deprecated_member_use_from_same_package,type=lint

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -7,14 +7,29 @@ environment:
 dependencies:
   async: ^2.0.0
   gql: '>=0.14.0 <2.0.0'
-  gql_exec: '>=0.4.0 <2.0.0'
   gql_link: '>=0.5.0 <2.0.0'
   ferry_exec: ^0.3.1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.7.0
+
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2
   pedantic: ^1.11.0
   built_value_generator: ^8.1.1
+  ferry_generator:
+
+
+dependency_overrides:
+  gql_exec:
+    git:
+      url: https://github.com/gql-dart/gql.git
+      ref: feat/triStateNull
+      path: links/gql_exec
+  gql_code_builder:
+    git:
+      url: https://github.com/gql-dart/gql.git
+      ref: feat/triStateNull
+      path: codegen/gql_code_builder
+  ferry_generator:
+    path: ../ferry_generator


### PR DESCRIPTION
Add support for serialize_nulls build config option. This option will enable that null fields are always serialized as null. Currently null fields are serialized at all.