### PR TITLE
feat(ferry_generator): support adding  in the config of build.yaml in your graphql_builder in order to wrap nullable fields into a Value type in order to distinguish between absent and null values in inputs

### DIFF
--- a/packages/ferry_cache/pubspec.yaml
+++ b/packages/ferry_cache/pubspec.yaml
@@ -22,3 +22,4 @@ dev_dependencies:
   ferry_test_graphql2: ^0.2.4-dev.0+1
   gql_exec: ^1.0.0
   gql: ^1.0.0
+  gql_tristate_value: ^1.0.0

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -79,6 +79,24 @@ class GraphqlBuilder implements Builder {
           'When extensions require add_typenames to be true. Consider setting add_typenames to true in your build.yaml or disabling when_extensions in your build.yaml.');
     }
 
+    final triStateValueConfig = config.triStateOptionalsConfig;
+
+    final schemaOutputAsset =
+        outputAssetId(_schemaId!, schemaExtension, config.outputDir);
+
+    final schemaUrl = schemaOutputAsset.uri.toString();
+    final schemaAllocator = GqlAllocator(
+      buildStep.inputId.uri.toString(),
+      config.sourceExtension,
+      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir)
+          .uri
+          .toString(),
+      schemaUrl,
+      config.outputDir,
+    );
+
+    final varAllocator = schemaAllocator;
+
     final libs = <String, Library>{
       astExtension: buildAstLibrary(doc),
       dataExtension: buildDataLibrary(
@@ -90,29 +108,31 @@ class GraphqlBuilder implements Builder {
         config.dataClassConfig,
       ),
       varExtension: buildVarLibrary(
-        doc,
-        addTypenames(schema),
-        p.basename(generatedFilePath(buildStep.inputId, varExtension)),
-        config.typeOverrides,
-      ),
+          doc,
+          addTypenames(schema),
+          p.basename(generatedFilePath(buildStep.inputId, varExtension)),
+          config.typeOverrides,
+          varAllocator,
+          triStateValueConfig),
       reqExtension: buildReqLibrary(
         doc,
         p.basename(generatedFilePath(buildStep.inputId, reqExtension)),
       ),
       schemaExtension: buildSchemaLibrary(
-        doc,
-        p.basename(generatedFilePath(buildStep.inputId, schemaExtension)),
-        config.typeOverrides,
-        config.enumFallbackConfig,
-        generatePossibleTypesMap: config.shouldGeneratePossibleTypes,
-      ),
+          doc,
+          p.basename(generatedFilePath(buildStep.inputId, schemaExtension)),
+          config.typeOverrides,
+          config.enumFallbackConfig,
+          generatePossibleTypesMap: config.shouldGeneratePossibleTypes,
+          allocator: schemaAllocator,
+          triStateValueConfig: triStateValueConfig),
     };
 
     for (var entry in libs.entries) {
       final generatedAsset =
           outputAssetId(buildStep.inputId, entry.key, config.outputDir);
       final schemaOutputAsset =
-          outputAssetId(_schemaId!, schemaExtension, config.outputDir);
+          outputAssetId(_schemaId, schemaExtension, config.outputDir);
 
       final allocator = GqlAllocator(
         buildStep.inputId.uri.toString(),

--- a/packages/ferry_generator/lib/src/utils/config.dart
+++ b/packages/ferry_generator/lib/src/utils/config.dart
@@ -22,6 +22,7 @@ class BuilderConfig {
   final String sourceExtension;
   final InlineFragmentSpreadWhenExtensionConfig whenExtensionConfig;
   final DataClassConfig dataClassConfig;
+  final TriStateValueConfig triStateOptionalsConfig;
 
   BuilderConfig(Map<String, dynamic> config)
       : schemaId = config['schema'] == null
@@ -39,7 +40,8 @@ class BuilderConfig {
         outputDir = config['output_dir'] ?? '__generated__',
         sourceExtension = config['source_extension'] ?? '.graphql',
         whenExtensionConfig = _getWhenExtensionConfig(config),
-        dataClassConfig = _getDataClassConfig(config);
+        dataClassConfig = _getDataClassConfig(config),
+        triStateOptionalsConfig = _getTriStateOptionalsConfig(config);
 }
 
 DataClassConfig _getDataClassConfig(Map<String, dynamic> config) {
@@ -129,4 +131,16 @@ Map<String, String> _enumFallbackMap(YamlMap? enumFallbacks) {
       ),
     ),
   );
+}
+
+TriStateValueConfig _getTriStateOptionalsConfig(Map<String, dynamic>? config) {
+  final Object? configValue = config?['tristate_optionals'];
+
+  if (configValue is bool) {
+    return configValue
+        ? TriStateValueConfig.onAllNullableFields
+        : TriStateValueConfig.never;
+  }
+
+  return TriStateValueConfig.never;
 }

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -12,7 +12,8 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  gql_code_builder: ^0.8.0
+  gql_code_builder: ^0.9.1+1
+  gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0
   build: ^2.0.0

--- a/packages/ferry_test_graphql2/build.yaml
+++ b/packages/ferry_test_graphql2/build.yaml
@@ -5,6 +5,7 @@ targets:
         enabled: true
         options:
           schema: ferry_test_graphql2|lib/schema/schema.graphql
+          tristate_optionals: false
           data_class_config:
             reuse_fragments: true
           type_overrides:

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   ferry_exec: ^0.5.0-dev.0+1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.8.0
+  gql_code_builder: ^0.9.0
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2


### PR DESCRIPTION
feat(ferry_generator): support adding  in the config of build.yaml in your graphql_builder in order to wrap nullable fields into a Value type in order to distinguish between absent and null values in inputs