### PR TITLE
feat(ferry_generator)!: more type safety for dataToJson()

### DIFF
--- a/packages/ferry_cache/test/test/data_change_streams_test.dart
+++ b/packages/ferry_cache/test/test/data_change_streams_test.dart
@@ -24,7 +24,9 @@ final han = GHeroWithFragmentsData_hero(
     ..id = 'han'
     ..name = 'Han Solo'
     ..friendsConnection.totalCount = 1
-    ..friendsConnection.edges.add(GHeroWithFragmentsData_hero_friendsConnection_edges(
+    ..friendsConnection
+        .edges
+        .add(GHeroWithFragmentsData_hero_friendsConnection_edges(
           (b) => b..node = GheroDataData.fromJson(luke.toJson())!.toBuilder(),
         )),
 );
@@ -75,7 +77,8 @@ void main() {
     });
 
     group('root operation data changes', () {
-      test("doesn't trigger with changes to unused root operation fields", () async {
+      test("doesn't trigger with changes to unused root operation fields",
+          () async {
         final stream = operationDataChangeStream(
           heroReq,
           true,
@@ -226,7 +229,9 @@ void main() {
     });
 
     group('optimistic patch changes', () {
-      test("doesn't trigger with optimistic patches that don't affect operation root", () async {
+      test(
+          "doesn't trigger with optimistic patches that don't affect operation root",
+          () async {
         final stream = operationDataChangeStream(
           heroReq,
           true,
@@ -257,7 +262,8 @@ void main() {
         await cache.dispose();
       });
 
-      test('triggers with optimistic patches that affect operation root', () async {
+      test('triggers with optimistic patches that affect operation root',
+          () async {
         final stream = operationDataChangeStream(
           heroReq,
           true,
@@ -294,7 +300,8 @@ void main() {
         await cache.dispose();
       });
 
-      test('triggers with optimistic patches that affect referenced entities', () async {
+      test('triggers with optimistic patches that affect referenced entities',
+          () async {
         final stream = operationDataChangeStream(
           heroReq,
           true,
@@ -406,7 +413,8 @@ void main() {
         await Future.delayed(Duration.zero);
         cache.writeFragment<GheroDataData, GheroDataVars>(
           lukeFragment,
-          GheroDataData.fromJson(luke.toJson())!.rebuild((b) => b..name = 'Luca'),
+          GheroDataData.fromJson(luke.toJson())!
+              .rebuild((b) => b..name = 'Luca'),
         );
 
         await Future.delayed(Duration.zero);
@@ -447,8 +455,10 @@ void main() {
         await cache.dispose();
       });
 
-      test('triggers when a change is made on an object that was added later', () async {
-        final lukeAndFriends = GcomparisonFieldsReq((b) => b..idFields = {'id': 'luke'});
+      test('triggers when a change is made on an object that was added later',
+          () async {
+        final lukeAndFriends =
+            GcomparisonFieldsReq((b) => b..idFields = {'id': 'luke'});
         final stream = fragmentDataChangeStream(
           lukeAndFriends,
           true,
@@ -475,16 +485,19 @@ void main() {
         cache.writeFragment<GcomparisonFieldsData, GcomparisonFieldsVars>(
             lukeAndFriends,
             GcomparisonFieldsData.fromJson(luke
-                .rebuild((data) => data.friendsConnection.edges
-                        .add(GHeroWithFragmentsData_hero_friendsConnection_edges(
-                      (b) => b..node = GheroDataData.fromJson(vader.toJson())!.toBuilder(),
+                .rebuild((data) => data.friendsConnection.edges.add(
+                        GHeroWithFragmentsData_hero_friendsConnection_edges(
+                      (b) => b
+                        ..node =
+                            GheroDataData.fromJson(vader.toJson())!.toBuilder(),
                     )))
                 .toJson())!);
 
         await Future.delayed(Duration.zero);
         cache.writeFragment<GheroDataData, GheroDataVars>(
             GheroDataReq((b) => b..idFields = {'id': 'vader'}),
-            GheroDataData.fromJson(vader.rebuild((data) => data.name = 'Daddy <3').toJson())!);
+            GheroDataData.fromJson(
+                vader.rebuild((data) => data.name = 'Daddy <3').toJson())!);
 
         await Future.delayed(Duration.zero);
         await cache.dispose();

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -17,7 +17,9 @@ import 'src/utils/add_introspection.dart';
 import 'src/codegen/req.dart';
 import 'src/allocators/gql_allocator.dart';
 
-Builder graphqlBuilder(BuilderOptions options,) =>
+Builder graphqlBuilder(
+  BuilderOptions options,
+) =>
     GraphqlBuilder(options.config);
 
 class GraphqlBuilder implements Builder {
@@ -34,11 +36,10 @@ class GraphqlBuilder implements Builder {
   ];
 
   @override
-  Map<String, List<String>> get buildExtensions =>
-      {
+  Map<String, List<String>> get buildExtensions => {
         '{{dir}}/{{file}}${config.sourceExtension}': [
-          ...localFileExtensions
-              .map((extension) => '{{dir}}/${config.outputDir}/{{file}}$extension')
+          ...localFileExtensions.map(
+              (extension) => '{{dir}}/${config.outputDir}/{{file}}$extension')
         ],
       };
 
@@ -51,8 +52,10 @@ class GraphqlBuilder implements Builder {
     final docDirPath = p.dirname(buildStep.inputId.path);
     if (config.schemaIds != null) {
       for (final schemaId in config.schemaIds!) {
-        if (docPackage == schemaId.package && docDirPath.contains(p.dirname(schemaId.path))) {
-          schema = await readDocument(buildStep, config.sourceExtension, schemaId);
+        if (docPackage == schemaId.package &&
+            docDirPath.contains(p.dirname(schemaId.path))) {
+          schema =
+              await readDocument(buildStep, config.sourceExtension, schemaId);
           _schemaId = schemaId;
           break;
         }
@@ -60,7 +63,8 @@ class GraphqlBuilder implements Builder {
     }
 
     if (schema == null && config.schemaId != null) {
-      schema = await readDocument(buildStep, config.sourceExtension, config.schemaId);
+      schema = await readDocument(
+          buildStep, config.sourceExtension, config.schemaId);
       _schemaId = config.schemaId!;
     }
 
@@ -69,7 +73,7 @@ class GraphqlBuilder implements Builder {
     }
 
     if ((config.whenExtensionConfig.generateMaybeWhenExtensionMethod ||
-        config.whenExtensionConfig.generateWhenExtensionMethod) &&
+            config.whenExtensionConfig.generateWhenExtensionMethod) &&
         !config.shouldAddTypenames) {
       throw StateError(
           'When extensions require add_typenames to be true. Consider setting add_typenames to true in your build.yaml or disabling when_extensions in your build.yaml.');
@@ -77,13 +81,16 @@ class GraphqlBuilder implements Builder {
 
     final triStateValueConfig = config.triStateOptionalsConfig;
 
-    final schemaOutputAsset = outputAssetId(_schemaId!, schemaExtension, config.outputDir);
+    final schemaOutputAsset =
+        outputAssetId(_schemaId!, schemaExtension, config.outputDir);
 
     final schemaUrl = schemaOutputAsset.uri.toString();
     final schemaAllocator = GqlAllocator(
       buildStep.inputId.uri.toString(),
       config.sourceExtension,
-      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir).uri.toString(),
+      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir)
+          .uri
+          .toString(),
       schemaUrl,
       config.outputDir,
     );
@@ -125,8 +132,10 @@ class GraphqlBuilder implements Builder {
     };
 
     for (var entry in libs.entries) {
-      final generatedAsset = outputAssetId(buildStep.inputId, entry.key, config.outputDir);
-      final schemaOutputAsset = outputAssetId(_schemaId, schemaExtension, config.outputDir);
+      final generatedAsset =
+          outputAssetId(buildStep.inputId, entry.key, config.outputDir);
+      final schemaOutputAsset =
+          outputAssetId(_schemaId, schemaExtension, config.outputDir);
 
       final allocator = GqlAllocator(
         buildStep.inputId.uri.toString(),

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -17,9 +17,7 @@ import 'src/utils/add_introspection.dart';
 import 'src/codegen/req.dart';
 import 'src/allocators/gql_allocator.dart';
 
-Builder graphqlBuilder(
-  BuilderOptions options,
-) =>
+Builder graphqlBuilder(BuilderOptions options,) =>
     GraphqlBuilder(options.config);
 
 class GraphqlBuilder implements Builder {
@@ -36,10 +34,11 @@ class GraphqlBuilder implements Builder {
   ];
 
   @override
-  Map<String, List<String>> get buildExtensions => {
+  Map<String, List<String>> get buildExtensions =>
+      {
         '{{dir}}/{{file}}${config.sourceExtension}': [
-          ...localFileExtensions.map(
-              (extension) => '{{dir}}/${config.outputDir}/{{file}}$extension')
+          ...localFileExtensions
+              .map((extension) => '{{dir}}/${config.outputDir}/{{file}}$extension')
         ],
       };
 
@@ -52,10 +51,8 @@ class GraphqlBuilder implements Builder {
     final docDirPath = p.dirname(buildStep.inputId.path);
     if (config.schemaIds != null) {
       for (final schemaId in config.schemaIds!) {
-        if (docPackage == schemaId.package &&
-            docDirPath.contains(p.dirname(schemaId.path))) {
-          schema =
-              await readDocument(buildStep, config.sourceExtension, schemaId);
+        if (docPackage == schemaId.package && docDirPath.contains(p.dirname(schemaId.path))) {
+          schema = await readDocument(buildStep, config.sourceExtension, schemaId);
           _schemaId = schemaId;
           break;
         }
@@ -63,8 +60,7 @@ class GraphqlBuilder implements Builder {
     }
 
     if (schema == null && config.schemaId != null) {
-      schema = await readDocument(
-          buildStep, config.sourceExtension, config.schemaId);
+      schema = await readDocument(buildStep, config.sourceExtension, config.schemaId);
       _schemaId = config.schemaId!;
     }
 
@@ -73,7 +69,7 @@ class GraphqlBuilder implements Builder {
     }
 
     if ((config.whenExtensionConfig.generateMaybeWhenExtensionMethod ||
-            config.whenExtensionConfig.generateWhenExtensionMethod) &&
+        config.whenExtensionConfig.generateWhenExtensionMethod) &&
         !config.shouldAddTypenames) {
       throw StateError(
           'When extensions require add_typenames to be true. Consider setting add_typenames to true in your build.yaml or disabling when_extensions in your build.yaml.');
@@ -81,21 +77,20 @@ class GraphqlBuilder implements Builder {
 
     final triStateValueConfig = config.triStateOptionalsConfig;
 
-    final schemaOutputAsset =
-        outputAssetId(_schemaId!, schemaExtension, config.outputDir);
+    final schemaOutputAsset = outputAssetId(_schemaId!, schemaExtension, config.outputDir);
 
     final schemaUrl = schemaOutputAsset.uri.toString();
     final schemaAllocator = GqlAllocator(
       buildStep.inputId.uri.toString(),
       config.sourceExtension,
-      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir)
-          .uri
-          .toString(),
+      outputAssetId(buildStep.inputId, schemaExtension, config.outputDir).uri.toString(),
       schemaUrl,
       config.outputDir,
     );
 
     final varAllocator = schemaAllocator;
+
+    final dataToVarsMode = config.dataToJsonMode;
 
     final libs = <String, Library>{
       astExtension: buildAstLibrary(doc),
@@ -117,6 +112,7 @@ class GraphqlBuilder implements Builder {
       reqExtension: buildReqLibrary(
         doc,
         p.basename(generatedFilePath(buildStep.inputId, reqExtension)),
+        dataToVarsMode,
       ),
       schemaExtension: buildSchemaLibrary(
           doc,
@@ -129,10 +125,8 @@ class GraphqlBuilder implements Builder {
     };
 
     for (var entry in libs.entries) {
-      final generatedAsset =
-          outputAssetId(buildStep.inputId, entry.key, config.outputDir);
-      final schemaOutputAsset =
-          outputAssetId(_schemaId, schemaExtension, config.outputDir);
+      final generatedAsset = outputAssetId(buildStep.inputId, entry.key, config.outputDir);
+      final schemaOutputAsset = outputAssetId(_schemaId, schemaExtension, config.outputDir);
 
       final allocator = GqlAllocator(
         buildStep.inputId.uri.toString(),

--- a/packages/ferry_generator/lib/src/codegen/fragment_req.dart
+++ b/packages/ferry_generator/lib/src/codegen/fragment_req.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:ferry_generator/src/utils/config.dart';
 import 'package:gql/ast.dart';
 import 'package:gql_code_builder/source.dart';
 import 'package:gql_code_builder/src/built_class.dart';
@@ -6,14 +7,16 @@ import 'package:gql_code_builder/src/common.dart';
 
 List<Class> buildFragmentReqClasses(
   SourceNode docSource,
+  DataToJsonMode dataToVarsMode,
 ) =>
     docSource.document.definitions
         .whereType<FragmentDefinitionNode>()
-        .map(_buildFragmentReqClass)
+        .map((node) => _buildFragmentReqClass(node, dataToVarsMode))
         .toList();
 
 Class _buildFragmentReqClass(
   FragmentDefinitionNode node,
+  DataToJsonMode dataToVarsMode,
 ) {
   final dataTypeRef = refer('${builtClassName(node.name.value)}Data', '#data');
   final varTypeRef = refer('${builtClassName(node.name.value)}Vars', '#var');
@@ -91,7 +94,7 @@ Class _buildFragmentReqClass(
           ..name = 'dataToJson'
           ..requiredParameters.add(Parameter(
             (b) => b
-              ..type = refer('dynamic')
+              ..type = dataToVarsMode.getDataToJsonParamType(dataTypeRef)
               ..name = 'data',
           ))
           ..lambda = true

--- a/packages/ferry_generator/lib/src/codegen/operation_req.dart
+++ b/packages/ferry_generator/lib/src/codegen/operation_req.dart
@@ -82,7 +82,8 @@ Class _buildOperationReqClass(
         (b) => b
           ..annotations.addAll([
             refer('override'),
-            refer('BuiltValueField', 'package:built_value/built_value.dart').call([], {
+            refer('BuiltValueField', 'package:built_value/built_value.dart')
+                .call([], {
               'serialize': refer('false'),
             }),
           ])
@@ -192,8 +193,10 @@ Class _buildOperationReqClass(
             Parameter(
               (b) => b
                 ..type = FunctionType((b) => b
-                  ..returnType = refer('Operation', 'package:gql_exec/gql_exec.dart')
-                  ..requiredParameters.add(refer('Operation', 'package:gql_exec/gql_exec.dart')))
+                  ..returnType =
+                      refer('Operation', 'package:gql_exec/gql_exec.dart')
+                  ..requiredParameters.add(
+                      refer('Operation', 'package:gql_exec/gql_exec.dart')))
                 ..name = 'transform',
             ),
           )

--- a/packages/ferry_generator/lib/src/codegen/req.dart
+++ b/packages/ferry_generator/lib/src/codegen/req.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:ferry_generator/src/utils/config.dart';
 import 'package:gql_code_builder/source.dart';
 
 import './operation_req.dart';
@@ -7,6 +8,7 @@ import './fragment_req.dart';
 Library buildReqLibrary(
   SourceNode docSource,
   String partUrl,
+  DataToJsonMode dataToVarsMode,
 ) =>
     Library(
       (b) => b
@@ -15,9 +17,11 @@ Library buildReqLibrary(
           [
             ...buildOperationReqClasses(
               docSource,
+              dataToVarsMode,
             ),
             ...buildFragmentReqClasses(
               docSource,
+              dataToVarsMode,
             )
           ],
         ),

--- a/packages/ferry_generator/lib/src/utils/config.dart
+++ b/packages/ferry_generator/lib/src/utils/config.dart
@@ -26,13 +26,16 @@ class BuilderConfig {
   final DataToJsonMode dataToJsonMode;
 
   BuilderConfig(Map<String, dynamic> config)
-      : schemaId = config['schema'] == null ? null : AssetId.parse(config['schema'] as String),
+      : schemaId = config['schema'] == null
+            ? null
+            : AssetId.parse(config['schema'] as String),
         schemaIds = (config['schemas'] as YamlList?)
             ?.map((dynamic schema) => AssetId.parse(schema as String))
             .toList(),
         shouldAddTypenames = config['add_typenames'] ?? true,
         typeOverrides = _getTypeOverrides(config['type_overrides']),
-        shouldGeneratePossibleTypes = config['generate_possible_types_map'] ?? true,
+        shouldGeneratePossibleTypes =
+            config['generate_possible_types_map'] ?? true,
         customSerializers = _getCustomSerializers(config['custom_serializers']),
         enumFallbackConfig = _getEnumFallbackConfig(config),
         outputDir = config['output_dir'] ?? '__generated__',
@@ -57,7 +60,8 @@ DataClassConfig _getDataClassConfig(Map<String, dynamic> config) {
   return dataClassConfig;
 }
 
-InlineFragmentSpreadWhenExtensionConfig _getWhenExtensionConfig(Map<String, dynamic> config) {
+InlineFragmentSpreadWhenExtensionConfig _getWhenExtensionConfig(
+    Map<String, dynamic> config) {
   if (config['when_extensions'] == null) {
     return const InlineFragmentSpreadWhenExtensionConfig(
       generateMaybeWhenExtensionMethod: false,
@@ -66,7 +70,8 @@ InlineFragmentSpreadWhenExtensionConfig _getWhenExtensionConfig(Map<String, dyna
   }
   final whenExtensionYamlMap = config['when_extensions'] as YamlMap;
   return InlineFragmentSpreadWhenExtensionConfig(
-    generateMaybeWhenExtensionMethod: whenExtensionYamlMap['maybeWhen'] ?? false,
+    generateMaybeWhenExtensionMethod:
+        whenExtensionYamlMap['maybeWhen'] ?? false,
     generateWhenExtensionMethod: whenExtensionYamlMap['when'] ?? false,
   );
 }
@@ -110,7 +115,8 @@ EnumFallbackConfig _getEnumFallbackConfig(Map<String, dynamic>? config) {
   }
 
   return EnumFallbackConfig(
-    globalEnumFallbackName: (config['global_enum_fallback_name'] ?? 'gUnknownEnumValue') as String,
+    globalEnumFallbackName:
+        (config['global_enum_fallback_name'] ?? 'gUnknownEnumValue') as String,
     generateFallbackValuesGlobally: config['global_enum_fallbacks'] == true,
     fallbackValueMap: _enumFallbackMap(config['enum_fallbacks']),
   );
@@ -133,7 +139,9 @@ TriStateValueConfig _getTriStateOptionalsConfig(Map<String, dynamic>? config) {
   final Object? configValue = config?['tristate_optionals'];
 
   if (configValue is bool) {
-    return configValue ? TriStateValueConfig.onAllNullableFields : TriStateValueConfig.never;
+    return configValue
+        ? TriStateValueConfig.onAllNullableFields
+        : TriStateValueConfig.never;
   }
 
   return TriStateValueConfig.never;

--- a/packages/ferry_test_graphql2/build.yaml
+++ b/packages/ferry_test_graphql2/build.yaml
@@ -8,6 +8,7 @@ targets:
           tristate_optionals: false
           data_class_config:
             reuse_fragments: true
+          data_to_json: type_safe
           type_overrides:
             Date:
               name: DateTime

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.dart
@@ -46,7 +46,8 @@ abstract class GReviewFragmentReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GReviewFragmentData data) =>
+      data.toJson();
 
   static Serializer<GReviewFragmentReq> get serializer =>
       _$gReviewFragmentReqSerializer;

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.dart
@@ -69,7 +69,7 @@ abstract class GCreateReviewReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GCreateReviewData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GCreateReviewData, _i3.GCreateReviewVars>

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.dart
@@ -69,7 +69,8 @@ abstract class GReviewWithDateReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GReviewWithDateData data) =>
+      data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GReviewWithDateData, _i3.GReviewWithDateVars>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.dart
@@ -69,7 +69,7 @@ abstract class GAliasedHeroReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GAliasedHeroData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GAliasedHeroData, _i3.GAliasedHeroVars>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.dart
@@ -69,7 +69,7 @@ abstract class GHeroNoVarsReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GHeroNoVarsData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GHeroNoVarsData, _i3.GHeroNoVarsVars>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.dart
@@ -72,7 +72,8 @@ abstract class GHeroWithFragmentsReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GHeroWithFragmentsData data) =>
+      data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GHeroWithFragmentsData, _i3.GHeroWithFragmentsVars>
@@ -123,7 +124,7 @@ abstract class GheroDataReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GheroDataData data) => data.toJson();
 
   static Serializer<GheroDataReq> get serializer => _$gheroDataReqSerializer;
 
@@ -170,7 +171,8 @@ abstract class GcomparisonFieldsReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GcomparisonFieldsData data) =>
+      data.toJson();
 
   static Serializer<GcomparisonFieldsReq> get serializer =>
       _$gcomparisonFieldsReqSerializer;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.dart
@@ -70,7 +70,8 @@ abstract class GHeroForEpisodeReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GHeroForEpisodeData data) =>
+      data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GHeroForEpisodeData, _i3.GHeroForEpisodeVars>
@@ -121,7 +122,7 @@ abstract class GDroidFragmentReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GDroidFragmentData data) => data.toJson();
 
   static Serializer<GDroidFragmentReq> get serializer =>
       _$gDroidFragmentReqSerializer;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.dart
@@ -69,7 +69,7 @@ abstract class GHumanWithArgsReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GHumanWithArgsData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GHumanWithArgsData, _i3.GHumanWithArgsVars>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.dart
@@ -69,7 +69,7 @@ abstract class GReviewsByIDReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GReviewsByIDData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GReviewsByIDData, _i3.GReviewsByIDVars>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.dart
@@ -68,7 +68,7 @@ abstract class GReviewsReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GReviewsData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GReviewsData, _i3.GReviewsVars> transformOperation(


### PR DESCRIPTION
- feat(ferry_generator)!: make dataToJson() method type safe by using the generic data type instead of dynamic. To opt-out of this new behaviour, pass `data_to_json: dynamic_param` to your build.yaml
- test(ferry_cache): fix tests to support new ferry_generator version with better type safety
