### PR TITLE
feat(vars-builder-generator): Adding `vars_create_factories` to ferry_generator|graphql_builder

### DIFF
--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -210,6 +210,10 @@ Supported keys are `when` and `maybeWhen`, and the values are booleans indicatin
 generation of the extension method not.
 By default, both are disabled.
 
+`tristate_optionals`: \[bool\] Whether to use tristate optionals for nullable variables and input types. A Value class is used to represent the three possible states: absence of a value, presence of a value that is null, and presence of a non-null value. This class is used by the generated code for GraphQL variables and input types that are nullable in order to distinguish between the absence of a value and the presence of a null value, typically used for "update" Mutations. Defaults to false.
+
+`vars_create_factories`: \[bool\] Whether to generate an additional factory constructor for the variables class. In contrast to the `built_value` builders, this factory constructor respects nullability for it's parameters. Defaults to false.
+
 Example:
 
 ```yaml

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -115,7 +115,8 @@ class GraphqlBuilder implements Builder {
           p.basename(generatedFilePath(buildStep.inputId, varExtension)),
           config.typeOverrides,
           varAllocator,
-          triStateValueConfig),
+          triStateValueConfig,
+          config.shouldGenerateVarsCreateFactories),
       reqExtension: buildReqLibrary(
         doc,
         p.basename(generatedFilePath(buildStep.inputId, reqExtension)),

--- a/packages/ferry_generator/lib/src/utils/config.dart
+++ b/packages/ferry_generator/lib/src/utils/config.dart
@@ -15,6 +15,7 @@ class BuilderConfig {
   final List<AssetId>? schemaIds;
   final bool shouldAddTypenames;
   final bool shouldGeneratePossibleTypes;
+  final bool shouldGenerateVarsCreateFactories;
   final Map<String, Reference> typeOverrides;
   final Set<Reference> customSerializers;
   final EnumFallbackConfig enumFallbackConfig;
@@ -33,6 +34,8 @@ class BuilderConfig {
             ?.map((dynamic schema) => AssetId.parse(schema as String))
             .toList(),
         shouldAddTypenames = config['add_typenames'] ?? true,
+        shouldGenerateVarsCreateFactories =
+            config['vars_create_factories'] ?? false,
         typeOverrides = _getTypeOverrides(config['type_overrides']),
         shouldGeneratePossibleTypes =
             config['generate_possible_types_map'] ?? true,

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  gql_code_builder: ^0.9.2
+  gql_code_builder: ^0.10.0
   gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -12,7 +12,7 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  gql_code_builder: ^0.9.1+1
+  gql_code_builder: ^0.9.2
   gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0

--- a/packages/ferry_test_graphql2/build.yaml
+++ b/packages/ferry_test_graphql2/build.yaml
@@ -6,6 +6,7 @@ targets:
         options:
           schema: ferry_test_graphql2|lib/schema/schema.graphql
           tristate_optionals: false
+          vars_create_factories: false
           data_class_config:
             reuse_fragments: true
           data_to_json: type_safe

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   ferry_exec: ^0.5.0-dev.0+1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.9.0
+  gql_code_builder: ^0.10.0
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2


### PR DESCRIPTION
Hello/Hallo/Servus/Grüß Gott @knaeckeKami,

Now that https://github.com/gql-dart/gql/pull/434 is merged, I thought I'll hold true to my word and open this PR to hover up the newly introduced `vars_create_factories` option to Ferry!

This PR relies on a new version release of the `gql` package though, that still needs to be released and assumes it's going to be version 0.9.2 - let me know if you you prefer a different way of doing this.

While writing the docs for this new version, I also noticed that the new `tristate_optionals` option was missing in the docs, so I took the liberty to add that as well - hope you don't mind! 

Let me know if anything else needs to be changed! 

Thanks!