### PR TITLE
feat(ferry_exec): Pass context to GQL Links

### DIFF
--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.data.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.data.gql.dart
@@ -15,7 +15,7 @@ abstract class GAllPokemonData
     implements Built<GAllPokemonData, GAllPokemonDataBuilder> {
   GAllPokemonData._();
 
-  factory GAllPokemonData([Function(GAllPokemonDataBuilder b) updates]) =
+  factory GAllPokemonData([void Function(GAllPokemonDataBuilder b) updates]) =
       _$GAllPokemonData;
 
   static void _initializeBuilder(GAllPokemonDataBuilder b) =>
@@ -45,7 +45,7 @@ abstract class GAllPokemonData_pokemons
   GAllPokemonData_pokemons._();
 
   factory GAllPokemonData_pokemons(
-          [Function(GAllPokemonData_pokemonsBuilder b) updates]) =
+          [void Function(GAllPokemonData_pokemonsBuilder b) updates]) =
       _$GAllPokemonData_pokemons;
 
   static void _initializeBuilder(GAllPokemonData_pokemonsBuilder b) =>
@@ -77,7 +77,7 @@ abstract class GAllPokemonData_pokemons_results
   GAllPokemonData_pokemons_results._();
 
   factory GAllPokemonData_pokemons_results(
-          [Function(GAllPokemonData_pokemons_resultsBuilder b) updates]) =
+          [void Function(GAllPokemonData_pokemons_resultsBuilder b) updates]) =
       _$GAllPokemonData_pokemons_results;
 
   static void _initializeBuilder(GAllPokemonData_pokemons_resultsBuilder b) =>
@@ -121,7 +121,7 @@ abstract class GAllPokemonData_pokemons_results_height
   GAllPokemonData_pokemons_results_height._();
 
   factory GAllPokemonData_pokemons_results_height(
-      [Function(GAllPokemonData_pokemons_results_heightBuilder b)
+      [void Function(GAllPokemonData_pokemons_results_heightBuilder b)
           updates]) = _$GAllPokemonData_pokemons_results_height;
 
   static void _initializeBuilder(
@@ -158,7 +158,7 @@ abstract class GAllPokemonData_pokemons_results_weight
   GAllPokemonData_pokemons_results_weight._();
 
   factory GAllPokemonData_pokemons_results_weight(
-      [Function(GAllPokemonData_pokemons_results_weightBuilder b)
+      [void Function(GAllPokemonData_pokemons_results_weightBuilder b)
           updates]) = _$GAllPokemonData_pokemons_results_weight;
 
   static void _initializeBuilder(

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.req.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.req.gql.dart
@@ -22,7 +22,7 @@ abstract class GAllPokemonReq
         _i1.OperationRequest<_i2.GAllPokemonData, _i3.GAllPokemonVars> {
   GAllPokemonReq._();
 
-  factory GAllPokemonReq([Function(GAllPokemonReqBuilder b) updates]) =
+  factory GAllPokemonReq([void Function(GAllPokemonReqBuilder b) updates]) =
       _$GAllPokemonReq;
 
   static void _initializeBuilder(GAllPokemonReqBuilder b) => b
@@ -40,6 +40,7 @@ abstract class GAllPokemonReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +62,9 @@ abstract class GAllPokemonReq
   @override
   bool get executeOnListen;
   @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
+  @override
   _i2.GAllPokemonData? parseData(Map<String, dynamic> json) =>
       _i2.GAllPokemonData.fromJson(json);
 
@@ -68,7 +72,7 @@ abstract class GAllPokemonReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GAllPokemonData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GAllPokemonData, _i3.GAllPokemonVars>

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.req.gql.g.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GAllPokemonReq extends GAllPokemonReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GAllPokemonReq([void Function(GAllPokemonReqBuilder)? updates]) =>
       (new GAllPokemonReqBuilder()..update(updates))._build();
@@ -160,7 +162,8 @@ class _$GAllPokemonReq extends GAllPokemonReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GAllPokemonReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -190,7 +193,8 @@ class _$GAllPokemonReq extends GAllPokemonReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -205,6 +209,7 @@ class _$GAllPokemonReq extends GAllPokemonReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -220,7 +225,8 @@ class _$GAllPokemonReq extends GAllPokemonReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -280,6 +286,10 @@ class GAllPokemonReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GAllPokemonReqBuilder() {
     GAllPokemonReq._initializeBuilder(this);
   }
@@ -296,6 +306,7 @@ class GAllPokemonReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -330,7 +341,8 @@ class GAllPokemonReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GAllPokemonReq', 'executeOnListen'));
+                  executeOnListen, r'GAllPokemonReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.var.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/all_pokemon.var.gql.dart
@@ -12,7 +12,7 @@ abstract class GAllPokemonVars
     implements Built<GAllPokemonVars, GAllPokemonVarsBuilder> {
   GAllPokemonVars._();
 
-  factory GAllPokemonVars([Function(GAllPokemonVarsBuilder b) updates]) =
+  factory GAllPokemonVars([void Function(GAllPokemonVarsBuilder b) updates]) =
       _$GAllPokemonVars;
 
   int get limit;

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.data.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.data.gql.dart
@@ -23,7 +23,8 @@ abstract class GNestedFragmentData
   GNestedFragmentData._();
 
   factory GNestedFragmentData(
-      [Function(GNestedFragmentDataBuilder b) updates]) = _$GNestedFragmentData;
+          [void Function(GNestedFragmentDataBuilder b) updates]) =
+      _$GNestedFragmentData;
 
   static void _initializeBuilder(GNestedFragmentDataBuilder b) =>
       b..G__typename = 'Pokemon';
@@ -87,7 +88,7 @@ abstract class GPokemonCardData
         GNestedFragment {
   GPokemonCardData._();
 
-  factory GPokemonCardData([Function(GPokemonCardDataBuilder b) updates]) =
+  factory GPokemonCardData([void Function(GPokemonCardDataBuilder b) updates]) =
       _$GPokemonCardData;
 
   static void _initializeBuilder(GPokemonCardDataBuilder b) =>
@@ -129,7 +130,7 @@ abstract class GPokemonCardData_height
   GPokemonCardData_height._();
 
   factory GPokemonCardData_height(
-          [Function(GPokemonCardData_heightBuilder b) updates]) =
+          [void Function(GPokemonCardData_heightBuilder b) updates]) =
       _$GPokemonCardData_height;
 
   static void _initializeBuilder(GPokemonCardData_heightBuilder b) =>
@@ -163,7 +164,7 @@ abstract class GPokemonCardData_weight
   GPokemonCardData_weight._();
 
   factory GPokemonCardData_weight(
-          [Function(GPokemonCardData_weightBuilder b) updates]) =
+          [void Function(GPokemonCardData_weightBuilder b) updates]) =
       _$GPokemonCardData_weight;
 
   static void _initializeBuilder(GPokemonCardData_weightBuilder b) =>

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.req.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.req.gql.dart
@@ -22,7 +22,8 @@ abstract class GNestedFragmentReq
         _i1.FragmentRequest<_i2.GNestedFragmentData, _i3.GNestedFragmentVars> {
   GNestedFragmentReq._();
 
-  factory GNestedFragmentReq([Function(GNestedFragmentReqBuilder b) updates]) =
+  factory GNestedFragmentReq(
+          [void Function(GNestedFragmentReqBuilder b) updates]) =
       _$GNestedFragmentReq;
 
   static void _initializeBuilder(GNestedFragmentReqBuilder b) => b
@@ -45,7 +46,8 @@ abstract class GNestedFragmentReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GNestedFragmentData data) =>
+      data.toJson();
 
   static Serializer<GNestedFragmentReq> get serializer =>
       _$gNestedFragmentReqSerializer;
@@ -68,7 +70,7 @@ abstract class GPokemonCardReq
         _i1.FragmentRequest<_i2.GPokemonCardData, _i3.GPokemonCardVars> {
   GPokemonCardReq._();
 
-  factory GPokemonCardReq([Function(GPokemonCardReqBuilder b) updates]) =
+  factory GPokemonCardReq([void Function(GPokemonCardReqBuilder b) updates]) =
       _$GPokemonCardReq;
 
   static void _initializeBuilder(GPokemonCardReqBuilder b) => b
@@ -91,7 +93,7 @@ abstract class GPokemonCardReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GPokemonCardData data) => data.toJson();
 
   static Serializer<GPokemonCardReq> get serializer =>
       _$gPokemonCardReqSerializer;

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.var.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_card_fragment.var.gql.dart
@@ -13,7 +13,8 @@ abstract class GNestedFragmentVars
   GNestedFragmentVars._();
 
   factory GNestedFragmentVars(
-      [Function(GNestedFragmentVarsBuilder b) updates]) = _$GNestedFragmentVars;
+          [void Function(GNestedFragmentVarsBuilder b) updates]) =
+      _$GNestedFragmentVars;
 
   static Serializer<GNestedFragmentVars> get serializer =>
       _$gNestedFragmentVarsSerializer;
@@ -34,7 +35,7 @@ abstract class GPokemonCardVars
     implements Built<GPokemonCardVars, GPokemonCardVarsBuilder> {
   GPokemonCardVars._();
 
-  factory GPokemonCardVars([Function(GPokemonCardVarsBuilder b) updates]) =
+  factory GPokemonCardVars([void Function(GPokemonCardVarsBuilder b) updates]) =
       _$GPokemonCardVars;
 
   static Serializer<GPokemonCardVars> get serializer =>

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.data.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.data.gql.dart
@@ -15,7 +15,8 @@ abstract class GPokemonDetailData
     implements Built<GPokemonDetailData, GPokemonDetailDataBuilder> {
   GPokemonDetailData._();
 
-  factory GPokemonDetailData([Function(GPokemonDetailDataBuilder b) updates]) =
+  factory GPokemonDetailData(
+          [void Function(GPokemonDetailDataBuilder b) updates]) =
       _$GPokemonDetailData;
 
   static void _initializeBuilder(GPokemonDetailDataBuilder b) =>
@@ -46,7 +47,7 @@ abstract class GPokemonDetailData_pokemon
   GPokemonDetailData_pokemon._();
 
   factory GPokemonDetailData_pokemon(
-          [Function(GPokemonDetailData_pokemonBuilder b) updates]) =
+          [void Function(GPokemonDetailData_pokemonBuilder b) updates]) =
       _$GPokemonDetailData_pokemon;
 
   static void _initializeBuilder(GPokemonDetailData_pokemonBuilder b) =>
@@ -90,7 +91,7 @@ abstract class GPokemonDetailData_pokemon_height
   GPokemonDetailData_pokemon_height._();
 
   factory GPokemonDetailData_pokemon_height(
-          [Function(GPokemonDetailData_pokemon_heightBuilder b) updates]) =
+          [void Function(GPokemonDetailData_pokemon_heightBuilder b) updates]) =
       _$GPokemonDetailData_pokemon_height;
 
   static void _initializeBuilder(GPokemonDetailData_pokemon_heightBuilder b) =>
@@ -126,7 +127,7 @@ abstract class GPokemonDetailData_pokemon_weight
   GPokemonDetailData_pokemon_weight._();
 
   factory GPokemonDetailData_pokemon_weight(
-          [Function(GPokemonDetailData_pokemon_weightBuilder b) updates]) =
+          [void Function(GPokemonDetailData_pokemon_weightBuilder b) updates]) =
       _$GPokemonDetailData_pokemon_weight;
 
   static void _initializeBuilder(GPokemonDetailData_pokemon_weightBuilder b) =>
@@ -161,7 +162,7 @@ abstract class GPokemonDetailData_pokemon_stats
   GPokemonDetailData_pokemon_stats._();
 
   factory GPokemonDetailData_pokemon_stats(
-          [Function(GPokemonDetailData_pokemon_statsBuilder b) updates]) =
+          [void Function(GPokemonDetailData_pokemon_statsBuilder b) updates]) =
       _$GPokemonDetailData_pokemon_stats;
 
   static void _initializeBuilder(GPokemonDetailData_pokemon_statsBuilder b) =>

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.req.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.req.gql.dart
@@ -22,7 +22,8 @@ abstract class GPokemonDetailReq
         _i1.OperationRequest<_i2.GPokemonDetailData, _i3.GPokemonDetailVars> {
   GPokemonDetailReq._();
 
-  factory GPokemonDetailReq([Function(GPokemonDetailReqBuilder b) updates]) =
+  factory GPokemonDetailReq(
+          [void Function(GPokemonDetailReqBuilder b) updates]) =
       _$GPokemonDetailReq;
 
   static void _initializeBuilder(GPokemonDetailReqBuilder b) => b
@@ -40,6 +41,7 @@ abstract class GPokemonDetailReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +63,9 @@ abstract class GPokemonDetailReq
   @override
   bool get executeOnListen;
   @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
+  @override
   _i2.GPokemonDetailData? parseData(Map<String, dynamic> json) =>
       _i2.GPokemonDetailData.fromJson(json);
 
@@ -68,7 +73,7 @@ abstract class GPokemonDetailReq
   Map<String, dynamic> varsToJson() => vars.toJson();
 
   @override
-  Map<String, dynamic> dataToJson(dynamic data) => data.toJson();
+  Map<String, dynamic> dataToJson(_i2.GPokemonDetailData data) => data.toJson();
 
   @override
   _i1.OperationRequest<_i2.GPokemonDetailData, _i3.GPokemonDetailVars>

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.req.gql.g.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GPokemonDetailReq extends GPokemonDetailReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GPokemonDetailReq(
           [void Function(GPokemonDetailReqBuilder)? updates]) =>
@@ -161,7 +163,8 @@ class _$GPokemonDetailReq extends GPokemonDetailReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GPokemonDetailReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -191,7 +194,8 @@ class _$GPokemonDetailReq extends GPokemonDetailReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -206,6 +210,7 @@ class _$GPokemonDetailReq extends GPokemonDetailReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -221,7 +226,8 @@ class _$GPokemonDetailReq extends GPokemonDetailReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -282,6 +288,10 @@ class GPokemonDetailReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GPokemonDetailReqBuilder() {
     GPokemonDetailReq._initializeBuilder(this);
   }
@@ -298,6 +308,7 @@ class GPokemonDetailReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -332,7 +343,8 @@ class GPokemonDetailReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GPokemonDetailReq', 'executeOnListen'));
+                  executeOnListen, r'GPokemonDetailReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.var.gql.dart
+++ b/examples/pokemon_explorer/lib/src/graphql/__generated__/pokemon_detail.var.gql.dart
@@ -12,7 +12,8 @@ abstract class GPokemonDetailVars
     implements Built<GPokemonDetailVars, GPokemonDetailVarsBuilder> {
   GPokemonDetailVars._();
 
-  factory GPokemonDetailVars([Function(GPokemonDetailVarsBuilder b) updates]) =
+  factory GPokemonDetailVars(
+          [void Function(GPokemonDetailVarsBuilder b) updates]) =
       _$GPokemonDetailVars;
 
   String get id;

--- a/packages/ferry/test/client/context_test.dart
+++ b/packages/ferry/test/client/context_test.dart
@@ -1,0 +1,47 @@
+import 'package:ferry/ferry.dart';
+import 'package:ferry_test_graphql2/queries/__generated__/reviews.data.gql.dart';
+import 'package:ferry_test_graphql2/queries/__generated__/reviews.req.gql.dart';
+import 'package:gql_exec/gql_exec.dart';
+import 'package:test/test.dart';
+
+class _TestContextEntry implements ContextEntry {
+  final String test;
+  _TestContextEntry({required this.test});
+
+  @override
+  List<Object?> get fieldsForEquality => [test];
+}
+
+void main() {
+  test('passes context to links', () async {
+    // network response
+    final link = Link.function((request, [forward]) {
+      final contextTest = request.context.entry<_TestContextEntry>()!.test;
+      final data = GReviewsData((b) => b
+        ..reviews.addAll([
+          GReviewsData_reviews((b) => b
+            ..id = '1'
+            ..commentary = contextTest
+            ..stars = 5),
+        ])).toJson();
+
+      return Stream.value(Response(
+        errors: [],
+        data: data,
+        response: data,
+      ));
+    });
+
+    final client = Client(link: link);
+
+    final req = GReviewsReq((b) => b
+      ..vars.first = 3
+      ..vars.offset = 0
+      ..context =
+          Context.fromList([_TestContextEntry(test: 'some contextual value')]));
+
+    final result = await client.request(req).first;
+
+    expect(result.data!.reviews!.first!.commentary, 'some contextual value');
+  });
+}

--- a/packages/ferry_exec/lib/src/json_operation_request.dart
+++ b/packages/ferry_exec/lib/src/json_operation_request.dart
@@ -35,6 +35,9 @@ class JsonOperationRequest
   @override
   Request get execRequest => Request(operation: operation, variables: vars);
 
+  @override
+  final Context? context;
+
   JsonOperationRequest(
       {required this.operation,
       required this.fetchPolicy,
@@ -44,7 +47,8 @@ class JsonOperationRequest
       this.executeOnListen = true,
       required this.vars,
       this.updateResult,
-      this.optimisticResponse});
+      this.optimisticResponse,
+      this.context});
 
   @override
   Map<String, dynamic> parseData(Map<String, dynamic> json) => json;
@@ -93,15 +97,15 @@ class JsonOperationRequest
   JsonOperationRequest transformOperation(
       Operation Function(Operation) transform) {
     return JsonOperationRequest(
-      operation: transform(operation),
-      fetchPolicy: fetchPolicy,
-      vars: vars,
-      requestId: requestId,
-      updateCacheHandlerKey: updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContext,
-      executeOnListen: executeOnListen,
-      updateResult: updateResult,
-      optimisticResponse: optimisticResponse,
-    );
+        operation: transform(operation),
+        fetchPolicy: fetchPolicy,
+        vars: vars,
+        requestId: requestId,
+        updateCacheHandlerKey: updateCacheHandlerKey,
+        updateCacheHandlerContext: updateCacheHandlerContext,
+        executeOnListen: executeOnListen,
+        updateResult: updateResult,
+        optimisticResponse: optimisticResponse,
+        context: context);
   }
 }

--- a/packages/ferry_exec/lib/src/operation_request.dart
+++ b/packages/ferry_exec/lib/src/operation_request.dart
@@ -36,6 +36,9 @@ abstract interface class OperationRequest<TData, TVars> {
   /// controller when the stream returned by `request()` is listened to
   bool get executeOnListen;
 
+  /// The [Context] to be passed to links.
+  Context? get context;
+
   /// Parses data into a concrete type for the given operation
   ///
   /// This is a simple wrapper on the static fromJson method on the generated class.

--- a/packages/ferry_generator/lib/src/codegen/operation_req.dart
+++ b/packages/ferry_generator/lib/src/codegen/operation_req.dart
@@ -65,6 +65,10 @@ Class _buildOperationReqClass(
           ).call([], {
             'operation': refer('operation'),
             'variables': refer('vars').property('toJson').call([]),
+            'context': refer('context').ifNullThen(refer(
+              'Context',
+              'package:gql_exec/gql_exec.dart',
+            ).constInstance([])),
           }).code,
       ),
       Method(
@@ -146,6 +150,24 @@ Class _buildOperationReqClass(
           ..returns = refer('bool')
           ..type = MethodType.getter
           ..name = 'executeOnListen',
+      ),
+      Method(
+        (b) => b
+          ..annotations.addAll([
+            refer('override'),
+            refer('BuiltValueField', 'package:built_value/built_value.dart')
+                .call([], {
+              'serialize': refer('false'),
+            }),
+          ])
+          ..returns = TypeReference(
+            (b) => b
+              ..symbol = 'Context'
+              ..url = 'package:gql_exec/gql_exec.dart'
+              ..isNullable = true,
+          )
+          ..type = MethodType.getter
+          ..name = 'context',
       ),
       Method(
         (b) => b

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.data.gql.dart
@@ -23,7 +23,8 @@ abstract class GReviewFragmentData
   GReviewFragmentData._();
 
   factory GReviewFragmentData(
-      [Function(GReviewFragmentDataBuilder b) updates]) = _$GReviewFragmentData;
+          [void Function(GReviewFragmentDataBuilder b) updates]) =
+      _$GReviewFragmentData;
 
   static void _initializeBuilder(GReviewFragmentDataBuilder b) =>
       b..G__typename = 'Review';

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GReviewFragmentReq
         _i1.FragmentRequest<_i2.GReviewFragmentData, _i3.GReviewFragmentVars> {
   GReviewFragmentReq._();
 
-  factory GReviewFragmentReq([Function(GReviewFragmentReqBuilder b) updates]) =
+  factory GReviewFragmentReq(
+          [void Function(GReviewFragmentReqBuilder b) updates]) =
       _$GReviewFragmentReq;
 
   static void _initializeBuilder(GReviewFragmentReqBuilder b) => b

--- a/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/fragments/__generated__/review_fragment.var.gql.dart
@@ -14,7 +14,8 @@ abstract class GReviewFragmentVars
   GReviewFragmentVars._();
 
   factory GReviewFragmentVars(
-      [Function(GReviewFragmentVarsBuilder b) updates]) = _$GReviewFragmentVars;
+          [void Function(GReviewFragmentVarsBuilder b) updates]) =
+      _$GReviewFragmentVars;
 
   static Serializer<GReviewFragmentVars> get serializer =>
       _$gReviewFragmentVarsSerializer;

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.data.gql.dart
@@ -15,7 +15,8 @@ abstract class GCreateReviewData
     implements Built<GCreateReviewData, GCreateReviewDataBuilder> {
   GCreateReviewData._();
 
-  factory GCreateReviewData([Function(GCreateReviewDataBuilder b) updates]) =
+  factory GCreateReviewData(
+          [void Function(GCreateReviewDataBuilder b) updates]) =
       _$GCreateReviewData;
 
   static void _initializeBuilder(GCreateReviewDataBuilder b) =>
@@ -46,7 +47,7 @@ abstract class GCreateReviewData_createReview
   GCreateReviewData_createReview._();
 
   factory GCreateReviewData_createReview(
-          [Function(GCreateReviewData_createReviewBuilder b) updates]) =
+          [void Function(GCreateReviewData_createReviewBuilder b) updates]) =
       _$GCreateReviewData_createReview;
 
   static void _initializeBuilder(GCreateReviewData_createReviewBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.dart
@@ -23,7 +23,7 @@ abstract class GCreateReviewReq
         _i1.OperationRequest<_i2.GCreateReviewData, _i3.GCreateReviewVars> {
   GCreateReviewReq._();
 
-  factory GCreateReviewReq([Function(GCreateReviewReqBuilder b) updates]) =
+  factory GCreateReviewReq([void Function(GCreateReviewReqBuilder b) updates]) =
       _$GCreateReviewReq;
 
   static void _initializeBuilder(GCreateReviewReqBuilder b) => b
@@ -41,6 +41,7 @@ abstract class GCreateReviewReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +62,9 @@ abstract class GCreateReviewReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GCreateReviewData? parseData(Map<String, dynamic> json) =>
       _i2.GCreateReviewData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GCreateReviewReq extends GCreateReviewReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GCreateReviewReq(
           [void Function(GCreateReviewReqBuilder)? updates]) =>
@@ -161,7 +163,8 @@ class _$GCreateReviewReq extends GCreateReviewReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GCreateReviewReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -191,7 +194,8 @@ class _$GCreateReviewReq extends GCreateReviewReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -206,6 +210,7 @@ class _$GCreateReviewReq extends GCreateReviewReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -221,7 +226,8 @@ class _$GCreateReviewReq extends GCreateReviewReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -282,6 +288,10 @@ class GCreateReviewReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GCreateReviewReqBuilder() {
     GCreateReviewReq._initializeBuilder(this);
   }
@@ -298,6 +308,7 @@ class GCreateReviewReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -332,7 +343,8 @@ class GCreateReviewReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GCreateReviewReq', 'executeOnListen'));
+                  executeOnListen, r'GCreateReviewReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/create_review.var.gql.dart
@@ -15,7 +15,8 @@ abstract class GCreateReviewVars
     implements Built<GCreateReviewVars, GCreateReviewVarsBuilder> {
   GCreateReviewVars._();
 
-  factory GCreateReviewVars([Function(GCreateReviewVarsBuilder b) updates]) =
+  factory GCreateReviewVars(
+          [void Function(GCreateReviewVarsBuilder b) updates]) =
       _$GCreateReviewVars;
 
   _i1.GEpisode? get episode;

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.data.gql.dart
@@ -17,7 +17,8 @@ abstract class GReviewWithDateData
   GReviewWithDateData._();
 
   factory GReviewWithDateData(
-      [Function(GReviewWithDateDataBuilder b) updates]) = _$GReviewWithDateData;
+          [void Function(GReviewWithDateDataBuilder b) updates]) =
+      _$GReviewWithDateData;
 
   static void _initializeBuilder(GReviewWithDateDataBuilder b) =>
       b..G__typename = 'Mutation';
@@ -47,7 +48,7 @@ abstract class GReviewWithDateData_createReview
   GReviewWithDateData_createReview._();
 
   factory GReviewWithDateData_createReview(
-          [Function(GReviewWithDateData_createReviewBuilder b) updates]) =
+          [void Function(GReviewWithDateData_createReviewBuilder b) updates]) =
       _$GReviewWithDateData_createReview;
 
   static void _initializeBuilder(GReviewWithDateData_createReviewBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GReviewWithDateReq
         _i1.OperationRequest<_i2.GReviewWithDateData, _i3.GReviewWithDateVars> {
   GReviewWithDateReq._();
 
-  factory GReviewWithDateReq([Function(GReviewWithDateReqBuilder b) updates]) =
+  factory GReviewWithDateReq(
+          [void Function(GReviewWithDateReqBuilder b) updates]) =
       _$GReviewWithDateReq;
 
   static void _initializeBuilder(GReviewWithDateReqBuilder b) => b
@@ -41,6 +42,7 @@ abstract class GReviewWithDateReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +63,9 @@ abstract class GReviewWithDateReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GReviewWithDateData? parseData(Map<String, dynamic> json) =>
       _i2.GReviewWithDateData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.req.gql.g.dart
@@ -148,6 +148,8 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GReviewWithDateReq(
           [void Function(GReviewWithDateReqBuilder)? updates]) =>
@@ -162,7 +164,8 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GReviewWithDateReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -193,7 +196,8 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -208,6 +212,7 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -223,7 +228,8 @@ class _$GReviewWithDateReq extends GReviewWithDateReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -284,6 +290,10 @@ class GReviewWithDateReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GReviewWithDateReqBuilder() {
     GReviewWithDateReq._initializeBuilder(this);
   }
@@ -300,6 +310,7 @@ class GReviewWithDateReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -334,7 +345,8 @@ class GReviewWithDateReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GReviewWithDateReq', 'executeOnListen'));
+                  executeOnListen, r'GReviewWithDateReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/mutations/__generated__/review_with_date_scalar.var.gql.dart
@@ -16,7 +16,8 @@ abstract class GReviewWithDateVars
   GReviewWithDateVars._();
 
   factory GReviewWithDateVars(
-      [Function(GReviewWithDateVarsBuilder b) updates]) = _$GReviewWithDateVars;
+          [void Function(GReviewWithDateVarsBuilder b) updates]) =
+      _$GReviewWithDateVars;
 
   _i1.GEpisode? get episode;
   _i1.GReviewInput get review;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.data.gql.dart
@@ -16,7 +16,7 @@ abstract class GAliasedHeroData
     implements Built<GAliasedHeroData, GAliasedHeroDataBuilder> {
   GAliasedHeroData._();
 
-  factory GAliasedHeroData([Function(GAliasedHeroDataBuilder b) updates]) =
+  factory GAliasedHeroData([void Function(GAliasedHeroDataBuilder b) updates]) =
       _$GAliasedHeroData;
 
   static void _initializeBuilder(GAliasedHeroDataBuilder b) =>
@@ -47,7 +47,7 @@ abstract class GAliasedHeroData_empireHero
   GAliasedHeroData_empireHero._();
 
   factory GAliasedHeroData_empireHero(
-          [Function(GAliasedHeroData_empireHeroBuilder b) updates]) =
+          [void Function(GAliasedHeroData_empireHeroBuilder b) updates]) =
       _$GAliasedHeroData_empireHero;
 
   static void _initializeBuilder(GAliasedHeroData_empireHeroBuilder b) =>
@@ -79,7 +79,7 @@ abstract class GAliasedHeroData_jediHero
   GAliasedHeroData_jediHero._();
 
   factory GAliasedHeroData_jediHero(
-          [Function(GAliasedHeroData_jediHeroBuilder b) updates]) =
+          [void Function(GAliasedHeroData_jediHeroBuilder b) updates]) =
       _$GAliasedHeroData_jediHero;
 
   static void _initializeBuilder(GAliasedHeroData_jediHeroBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.dart
@@ -23,7 +23,7 @@ abstract class GAliasedHeroReq
         _i1.OperationRequest<_i2.GAliasedHeroData, _i3.GAliasedHeroVars> {
   GAliasedHeroReq._();
 
-  factory GAliasedHeroReq([Function(GAliasedHeroReqBuilder b) updates]) =
+  factory GAliasedHeroReq([void Function(GAliasedHeroReqBuilder b) updates]) =
       _$GAliasedHeroReq;
 
   static void _initializeBuilder(GAliasedHeroReqBuilder b) => b
@@ -41,6 +41,7 @@ abstract class GAliasedHeroReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +62,9 @@ abstract class GAliasedHeroReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GAliasedHeroData? parseData(Map<String, dynamic> json) =>
       _i2.GAliasedHeroData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GAliasedHeroReq([void Function(GAliasedHeroReqBuilder)? updates]) =>
       (new GAliasedHeroReqBuilder()..update(updates))._build();
@@ -160,7 +162,8 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GAliasedHeroReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -190,7 +193,8 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -205,6 +209,7 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -220,7 +225,8 @@ class _$GAliasedHeroReq extends GAliasedHeroReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -280,6 +286,10 @@ class GAliasedHeroReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GAliasedHeroReqBuilder() {
     GAliasedHeroReq._initializeBuilder(this);
   }
@@ -296,6 +306,7 @@ class GAliasedHeroReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -330,7 +341,8 @@ class GAliasedHeroReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GAliasedHeroReq', 'executeOnListen'));
+                  executeOnListen, r'GAliasedHeroReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/aliased_hero.var.gql.dart
@@ -15,7 +15,7 @@ abstract class GAliasedHeroVars
     implements Built<GAliasedHeroVars, GAliasedHeroVarsBuilder> {
   GAliasedHeroVars._();
 
-  factory GAliasedHeroVars([Function(GAliasedHeroVarsBuilder b) updates]) =
+  factory GAliasedHeroVars([void Function(GAliasedHeroVarsBuilder b) updates]) =
       _$GAliasedHeroVars;
 
   _i1.GEpisode get ep;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.data.gql.dart
@@ -13,7 +13,7 @@ abstract class GHeroNoVarsData
     implements Built<GHeroNoVarsData, GHeroNoVarsDataBuilder> {
   GHeroNoVarsData._();
 
-  factory GHeroNoVarsData([Function(GHeroNoVarsDataBuilder b) updates]) =
+  factory GHeroNoVarsData([void Function(GHeroNoVarsDataBuilder b) updates]) =
       _$GHeroNoVarsData;
 
   static void _initializeBuilder(GHeroNoVarsDataBuilder b) =>
@@ -42,7 +42,7 @@ abstract class GHeroNoVarsData_hero
   GHeroNoVarsData_hero._();
 
   factory GHeroNoVarsData_hero(
-          [Function(GHeroNoVarsData_heroBuilder b) updates]) =
+          [void Function(GHeroNoVarsData_heroBuilder b) updates]) =
       _$GHeroNoVarsData_hero;
 
   static void _initializeBuilder(GHeroNoVarsData_heroBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.dart
@@ -23,7 +23,7 @@ abstract class GHeroNoVarsReq
         _i1.OperationRequest<_i2.GHeroNoVarsData, _i3.GHeroNoVarsVars> {
   GHeroNoVarsReq._();
 
-  factory GHeroNoVarsReq([Function(GHeroNoVarsReqBuilder b) updates]) =
+  factory GHeroNoVarsReq([void Function(GHeroNoVarsReqBuilder b) updates]) =
       _$GHeroNoVarsReq;
 
   static void _initializeBuilder(GHeroNoVarsReqBuilder b) => b
@@ -41,6 +41,7 @@ abstract class GHeroNoVarsReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +62,9 @@ abstract class GHeroNoVarsReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GHeroNoVarsData? parseData(Map<String, dynamic> json) =>
       _i2.GHeroNoVarsData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GHeroNoVarsReq([void Function(GHeroNoVarsReqBuilder)? updates]) =>
       (new GHeroNoVarsReqBuilder()..update(updates))._build();
@@ -160,7 +162,8 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GHeroNoVarsReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -190,7 +193,8 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -205,6 +209,7 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -220,7 +225,8 @@ class _$GHeroNoVarsReq extends GHeroNoVarsReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -280,6 +286,10 @@ class GHeroNoVarsReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GHeroNoVarsReqBuilder() {
     GHeroNoVarsReq._initializeBuilder(this);
   }
@@ -296,6 +306,7 @@ class GHeroNoVarsReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -330,7 +341,8 @@ class GHeroNoVarsReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GHeroNoVarsReq', 'executeOnListen'));
+                  executeOnListen, r'GHeroNoVarsReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_no_vars.var.gql.dart
@@ -13,7 +13,7 @@ abstract class GHeroNoVarsVars
     implements Built<GHeroNoVarsVars, GHeroNoVarsVarsBuilder> {
   GHeroNoVarsVars._();
 
-  factory GHeroNoVarsVars([Function(GHeroNoVarsVarsBuilder b) updates]) =
+  factory GHeroNoVarsVars([void Function(GHeroNoVarsVarsBuilder b) updates]) =
       _$GHeroNoVarsVars;
 
   static Serializer<GHeroNoVarsVars> get serializer =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.data.gql.dart
@@ -15,7 +15,7 @@ abstract class GHeroWithFragmentsData
   GHeroWithFragmentsData._();
 
   factory GHeroWithFragmentsData(
-          [Function(GHeroWithFragmentsDataBuilder b) updates]) =
+          [void Function(GHeroWithFragmentsDataBuilder b) updates]) =
       _$GHeroWithFragmentsData;
 
   static void _initializeBuilder(GHeroWithFragmentsDataBuilder b) =>
@@ -46,7 +46,7 @@ abstract class GHeroWithFragmentsData_hero
   GHeroWithFragmentsData_hero._();
 
   factory GHeroWithFragmentsData_hero(
-          [Function(GHeroWithFragmentsData_heroBuilder b) updates]) =
+          [void Function(GHeroWithFragmentsData_heroBuilder b) updates]) =
       _$GHeroWithFragmentsData_hero;
 
   static void _initializeBuilder(GHeroWithFragmentsData_heroBuilder b) =>
@@ -85,7 +85,7 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection
   GHeroWithFragmentsData_hero_friendsConnection._();
 
   factory GHeroWithFragmentsData_hero_friendsConnection(
-      [Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder b)
+      [void Function(GHeroWithFragmentsData_hero_friendsConnectionBuilder b)
           updates]) = _$GHeroWithFragmentsData_hero_friendsConnection;
 
   static void _initializeBuilder(
@@ -124,7 +124,8 @@ abstract class GHeroWithFragmentsData_hero_friendsConnection_edges
   GHeroWithFragmentsData_hero_friendsConnection_edges._();
 
   factory GHeroWithFragmentsData_hero_friendsConnection_edges(
-      [Function(GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder b)
+      [void Function(
+              GHeroWithFragmentsData_hero_friendsConnection_edgesBuilder b)
           updates]) = _$GHeroWithFragmentsData_hero_friendsConnection_edges;
 
   static void _initializeBuilder(
@@ -165,7 +166,7 @@ abstract class GheroDataData
     implements Built<GheroDataData, GheroDataDataBuilder>, GheroData {
   GheroDataData._();
 
-  factory GheroDataData([Function(GheroDataDataBuilder b) updates]) =
+  factory GheroDataData([void Function(GheroDataDataBuilder b) updates]) =
       _$GheroDataData;
 
   static void _initializeBuilder(GheroDataDataBuilder b) =>
@@ -226,7 +227,7 @@ abstract class GcomparisonFieldsData
   GcomparisonFieldsData._();
 
   factory GcomparisonFieldsData(
-          [Function(GcomparisonFieldsDataBuilder b) updates]) =
+          [void Function(GcomparisonFieldsDataBuilder b) updates]) =
       _$GcomparisonFieldsData;
 
   static void _initializeBuilder(GcomparisonFieldsDataBuilder b) =>
@@ -265,7 +266,7 @@ abstract class GcomparisonFieldsData_friendsConnection
   GcomparisonFieldsData_friendsConnection._();
 
   factory GcomparisonFieldsData_friendsConnection(
-      [Function(GcomparisonFieldsData_friendsConnectionBuilder b)
+      [void Function(GcomparisonFieldsData_friendsConnectionBuilder b)
           updates]) = _$GcomparisonFieldsData_friendsConnection;
 
   static void _initializeBuilder(
@@ -304,7 +305,7 @@ abstract class GcomparisonFieldsData_friendsConnection_edges
   GcomparisonFieldsData_friendsConnection_edges._();
 
   factory GcomparisonFieldsData_friendsConnection_edges(
-      [Function(GcomparisonFieldsData_friendsConnection_edgesBuilder b)
+      [void Function(GcomparisonFieldsData_friendsConnection_edgesBuilder b)
           updates]) = _$GcomparisonFieldsData_friendsConnection_edges;
 
   static void _initializeBuilder(

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.dart
@@ -26,7 +26,7 @@ abstract class GHeroWithFragmentsReq
   GHeroWithFragmentsReq._();
 
   factory GHeroWithFragmentsReq(
-          [Function(GHeroWithFragmentsReqBuilder b) updates]) =
+          [void Function(GHeroWithFragmentsReqBuilder b) updates]) =
       _$GHeroWithFragmentsReq;
 
   static void _initializeBuilder(GHeroWithFragmentsReqBuilder b) => b
@@ -44,6 +44,7 @@ abstract class GHeroWithFragmentsReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -64,6 +65,9 @@ abstract class GHeroWithFragmentsReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GHeroWithFragmentsData? parseData(Map<String, dynamic> json) =>
       _i2.GHeroWithFragmentsData.fromJson(json);
@@ -101,7 +105,7 @@ abstract class GheroDataReq
         _i1.FragmentRequest<_i2.GheroDataData, _i3.GheroDataVars> {
   GheroDataReq._();
 
-  factory GheroDataReq([Function(GheroDataReqBuilder b) updates]) =
+  factory GheroDataReq([void Function(GheroDataReqBuilder b) updates]) =
       _$GheroDataReq;
 
   static void _initializeBuilder(GheroDataReqBuilder b) => b
@@ -148,7 +152,7 @@ abstract class GcomparisonFieldsReq
   GcomparisonFieldsReq._();
 
   factory GcomparisonFieldsReq(
-          [Function(GcomparisonFieldsReqBuilder b) updates]) =
+          [void Function(GcomparisonFieldsReqBuilder b) updates]) =
       _$GcomparisonFieldsReq;
 
   static void _initializeBuilder(GcomparisonFieldsReqBuilder b) => b

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.req.gql.g.dart
@@ -304,6 +304,8 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GHeroWithFragmentsReq(
           [void Function(GHeroWithFragmentsReqBuilder)? updates]) =>
@@ -318,7 +320,8 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(
         vars, r'GHeroWithFragmentsReq', 'vars');
@@ -350,7 +353,8 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -365,6 +369,7 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -380,7 +385,8 @@ class _$GHeroWithFragmentsReq extends GHeroWithFragmentsReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -442,6 +448,10 @@ class GHeroWithFragmentsReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GHeroWithFragmentsReqBuilder() {
     GHeroWithFragmentsReq._initializeBuilder(this);
   }
@@ -458,6 +468,7 @@ class GHeroWithFragmentsReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -492,9 +503,8 @@ class GHeroWithFragmentsReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen,
-                  r'GHeroWithFragmentsReq',
-                  'executeOnListen'));
+                  executeOnListen, r'GHeroWithFragmentsReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_fragments.var.gql.dart
@@ -16,7 +16,7 @@ abstract class GHeroWithFragmentsVars
   GHeroWithFragmentsVars._();
 
   factory GHeroWithFragmentsVars(
-          [Function(GHeroWithFragmentsVarsBuilder b) updates]) =
+          [void Function(GHeroWithFragmentsVarsBuilder b) updates]) =
       _$GHeroWithFragmentsVars;
 
   _i1.GEpisode? get episode;
@@ -39,7 +39,7 @@ abstract class GheroDataVars
     implements Built<GheroDataVars, GheroDataVarsBuilder> {
   GheroDataVars._();
 
-  factory GheroDataVars([Function(GheroDataVarsBuilder b) updates]) =
+  factory GheroDataVars([void Function(GheroDataVarsBuilder b) updates]) =
       _$GheroDataVars;
 
   static Serializer<GheroDataVars> get serializer => _$gheroDataVarsSerializer;
@@ -61,7 +61,7 @@ abstract class GcomparisonFieldsVars
   GcomparisonFieldsVars._();
 
   factory GcomparisonFieldsVars(
-          [Function(GcomparisonFieldsVarsBuilder b) updates]) =
+          [void Function(GcomparisonFieldsVarsBuilder b) updates]) =
       _$GcomparisonFieldsVars;
 
   int? get first;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
@@ -16,7 +16,8 @@ abstract class GHeroForEpisodeData
   GHeroForEpisodeData._();
 
   factory GHeroForEpisodeData(
-      [Function(GHeroForEpisodeDataBuilder b) updates]) = _$GHeroForEpisodeData;
+          [void Function(GHeroForEpisodeDataBuilder b) updates]) =
+      _$GHeroForEpisodeData;
 
   static void _initializeBuilder(GHeroForEpisodeDataBuilder b) =>
       b..G__typename = 'Query';
@@ -70,7 +71,7 @@ abstract class GHeroForEpisodeData_hero__base
   GHeroForEpisodeData_hero__base._();
 
   factory GHeroForEpisodeData_hero__base(
-          [Function(GHeroForEpisodeData_hero__baseBuilder b) updates]) =
+          [void Function(GHeroForEpisodeData_hero__baseBuilder b) updates]) =
       _$GHeroForEpisodeData_hero__base;
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__baseBuilder b) =>
@@ -106,7 +107,7 @@ abstract class GHeroForEpisodeData_hero__asDroid
   GHeroForEpisodeData_hero__asDroid._();
 
   factory GHeroForEpisodeData_hero__asDroid(
-          [Function(GHeroForEpisodeData_hero__asDroidBuilder b) updates]) =
+          [void Function(GHeroForEpisodeData_hero__asDroidBuilder b) updates]) =
       _$GHeroForEpisodeData_hero__asDroid;
 
   static void _initializeBuilder(GHeroForEpisodeData_hero__asDroidBuilder b) =>
@@ -148,7 +149,8 @@ abstract class GDroidFragmentData
         GDroidFragment {
   GDroidFragmentData._();
 
-  factory GDroidFragmentData([Function(GDroidFragmentDataBuilder b) updates]) =
+  factory GDroidFragmentData(
+          [void Function(GDroidFragmentDataBuilder b) updates]) =
       _$GDroidFragmentData;
 
   static void _initializeBuilder(GDroidFragmentDataBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.dart
@@ -24,7 +24,8 @@ abstract class GHeroForEpisodeReq
         _i1.OperationRequest<_i2.GHeroForEpisodeData, _i3.GHeroForEpisodeVars> {
   GHeroForEpisodeReq._();
 
-  factory GHeroForEpisodeReq([Function(GHeroForEpisodeReqBuilder b) updates]) =
+  factory GHeroForEpisodeReq(
+          [void Function(GHeroForEpisodeReqBuilder b) updates]) =
       _$GHeroForEpisodeReq;
 
   static void _initializeBuilder(GHeroForEpisodeReqBuilder b) => b
@@ -42,6 +43,7 @@ abstract class GHeroForEpisodeReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -62,6 +64,9 @@ abstract class GHeroForEpisodeReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GHeroForEpisodeData? parseData(Map<String, dynamic> json) =>
       _i2.GHeroForEpisodeData.fromJson(json);
@@ -99,7 +104,8 @@ abstract class GDroidFragmentReq
         _i1.FragmentRequest<_i2.GDroidFragmentData, _i3.GDroidFragmentVars> {
   GDroidFragmentReq._();
 
-  factory GDroidFragmentReq([Function(GDroidFragmentReqBuilder b) updates]) =
+  factory GDroidFragmentReq(
+          [void Function(GDroidFragmentReqBuilder b) updates]) =
       _$GDroidFragmentReq;
 
   static void _initializeBuilder(GDroidFragmentReqBuilder b) => b

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.req.gql.g.dart
@@ -223,6 +223,8 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GHeroForEpisodeReq(
           [void Function(GHeroForEpisodeReqBuilder)? updates]) =>
@@ -237,7 +239,8 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GHeroForEpisodeReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -268,7 +271,8 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -283,6 +287,7 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -298,7 +303,8 @@ class _$GHeroForEpisodeReq extends GHeroForEpisodeReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -359,6 +365,10 @@ class GHeroForEpisodeReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GHeroForEpisodeReqBuilder() {
     GHeroForEpisodeReq._initializeBuilder(this);
   }
@@ -375,6 +385,7 @@ class GHeroForEpisodeReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -409,7 +420,8 @@ class GHeroForEpisodeReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GHeroForEpisodeReq', 'executeOnListen'));
+                  executeOnListen, r'GHeroForEpisodeReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.var.gql.dart
@@ -16,7 +16,8 @@ abstract class GHeroForEpisodeVars
   GHeroForEpisodeVars._();
 
   factory GHeroForEpisodeVars(
-      [Function(GHeroForEpisodeVarsBuilder b) updates]) = _$GHeroForEpisodeVars;
+          [void Function(GHeroForEpisodeVarsBuilder b) updates]) =
+      _$GHeroForEpisodeVars;
 
   _i1.GEpisode get ep;
   static Serializer<GHeroForEpisodeVars> get serializer =>
@@ -38,7 +39,8 @@ abstract class GDroidFragmentVars
     implements Built<GDroidFragmentVars, GDroidFragmentVarsBuilder> {
   GDroidFragmentVars._();
 
-  factory GDroidFragmentVars([Function(GDroidFragmentVarsBuilder b) updates]) =
+  factory GDroidFragmentVars(
+          [void Function(GDroidFragmentVarsBuilder b) updates]) =
       _$GDroidFragmentVars;
 
   static Serializer<GDroidFragmentVars> get serializer =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.data.gql.dart
@@ -14,7 +14,8 @@ abstract class GHumanWithArgsData
     implements Built<GHumanWithArgsData, GHumanWithArgsDataBuilder> {
   GHumanWithArgsData._();
 
-  factory GHumanWithArgsData([Function(GHumanWithArgsDataBuilder b) updates]) =
+  factory GHumanWithArgsData(
+          [void Function(GHumanWithArgsDataBuilder b) updates]) =
       _$GHumanWithArgsData;
 
   static void _initializeBuilder(GHumanWithArgsDataBuilder b) =>
@@ -44,7 +45,7 @@ abstract class GHumanWithArgsData_human
   GHumanWithArgsData_human._();
 
   factory GHumanWithArgsData_human(
-          [Function(GHumanWithArgsData_humanBuilder b) updates]) =
+          [void Function(GHumanWithArgsData_humanBuilder b) updates]) =
       _$GHumanWithArgsData_human;
 
   static void _initializeBuilder(GHumanWithArgsData_humanBuilder b) =>
@@ -78,7 +79,7 @@ abstract class GHumanWithArgsData_human_friendsConnection
   GHumanWithArgsData_human_friendsConnection._();
 
   factory GHumanWithArgsData_human_friendsConnection(
-      [Function(GHumanWithArgsData_human_friendsConnectionBuilder b)
+      [void Function(GHumanWithArgsData_human_friendsConnectionBuilder b)
           updates]) = _$GHumanWithArgsData_human_friendsConnection;
 
   static void _initializeBuilder(
@@ -111,7 +112,8 @@ abstract class GHumanWithArgsData_human_friendsConnection_friends
   GHumanWithArgsData_human_friendsConnection_friends._();
 
   factory GHumanWithArgsData_human_friendsConnection_friends(
-      [Function(GHumanWithArgsData_human_friendsConnection_friendsBuilder b)
+      [void Function(
+              GHumanWithArgsData_human_friendsConnection_friendsBuilder b)
           updates]) = _$GHumanWithArgsData_human_friendsConnection_friends;
 
   static void _initializeBuilder(

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GHumanWithArgsReq
         _i1.OperationRequest<_i2.GHumanWithArgsData, _i3.GHumanWithArgsVars> {
   GHumanWithArgsReq._();
 
-  factory GHumanWithArgsReq([Function(GHumanWithArgsReqBuilder b) updates]) =
+  factory GHumanWithArgsReq(
+          [void Function(GHumanWithArgsReqBuilder b) updates]) =
       _$GHumanWithArgsReq;
 
   static void _initializeBuilder(GHumanWithArgsReqBuilder b) => b
@@ -41,6 +42,7 @@ abstract class GHumanWithArgsReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +63,9 @@ abstract class GHumanWithArgsReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GHumanWithArgsData? parseData(Map<String, dynamic> json) =>
       _i2.GHumanWithArgsData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GHumanWithArgsReq(
           [void Function(GHumanWithArgsReqBuilder)? updates]) =>
@@ -161,7 +163,8 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GHumanWithArgsReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -191,7 +194,8 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -206,6 +210,7 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -221,7 +226,8 @@ class _$GHumanWithArgsReq extends GHumanWithArgsReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -282,6 +288,10 @@ class GHumanWithArgsReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GHumanWithArgsReqBuilder() {
     GHumanWithArgsReq._initializeBuilder(this);
   }
@@ -298,6 +308,7 @@ class GHumanWithArgsReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -332,7 +343,8 @@ class GHumanWithArgsReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GHumanWithArgsReq', 'executeOnListen'));
+                  executeOnListen, r'GHumanWithArgsReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/human_with_args.var.gql.dart
@@ -13,7 +13,8 @@ abstract class GHumanWithArgsVars
     implements Built<GHumanWithArgsVars, GHumanWithArgsVarsBuilder> {
   GHumanWithArgsVars._();
 
-  factory GHumanWithArgsVars([Function(GHumanWithArgsVarsBuilder b) updates]) =
+  factory GHumanWithArgsVars(
+          [void Function(GHumanWithArgsVarsBuilder b) updates]) =
       _$GHumanWithArgsVars;
 
   String get id;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.data.gql.dart
@@ -16,7 +16,7 @@ abstract class GReviewsByIDData
     implements Built<GReviewsByIDData, GReviewsByIDDataBuilder> {
   GReviewsByIDData._();
 
-  factory GReviewsByIDData([Function(GReviewsByIDDataBuilder b) updates]) =
+  factory GReviewsByIDData([void Function(GReviewsByIDDataBuilder b) updates]) =
       _$GReviewsByIDData;
 
   static void _initializeBuilder(GReviewsByIDDataBuilder b) =>
@@ -45,7 +45,7 @@ abstract class GReviewsByIDData_review
   GReviewsByIDData_review._();
 
   factory GReviewsByIDData_review(
-          [Function(GReviewsByIDData_reviewBuilder b) updates]) =
+          [void Function(GReviewsByIDData_reviewBuilder b) updates]) =
       _$GReviewsByIDData_review;
 
   static void _initializeBuilder(GReviewsByIDData_reviewBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.dart
@@ -23,7 +23,7 @@ abstract class GReviewsByIDReq
         _i1.OperationRequest<_i2.GReviewsByIDData, _i3.GReviewsByIDVars> {
   GReviewsByIDReq._();
 
-  factory GReviewsByIDReq([Function(GReviewsByIDReqBuilder b) updates]) =
+  factory GReviewsByIDReq([void Function(GReviewsByIDReqBuilder b) updates]) =
       _$GReviewsByIDReq;
 
   static void _initializeBuilder(GReviewsByIDReqBuilder b) => b
@@ -41,6 +41,7 @@ abstract class GReviewsByIDReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -61,6 +62,9 @@ abstract class GReviewsByIDReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GReviewsByIDData? parseData(Map<String, dynamic> json) =>
       _i2.GReviewsByIDData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.req.gql.g.dart
@@ -147,6 +147,8 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GReviewsByIDReq([void Function(GReviewsByIDReqBuilder)? updates]) =>
       (new GReviewsByIDReqBuilder()..update(updates))._build();
@@ -160,7 +162,8 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GReviewsByIDReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -190,7 +193,8 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -205,6 +209,7 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -220,7 +225,8 @@ class _$GReviewsByIDReq extends GReviewsByIDReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -280,6 +286,10 @@ class GReviewsByIDReqBuilder
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GReviewsByIDReqBuilder() {
     GReviewsByIDReq._initializeBuilder(this);
   }
@@ -296,6 +306,7 @@ class GReviewsByIDReqBuilder
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -330,7 +341,8 @@ class GReviewsByIDReqBuilder
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GReviewsByIDReq', 'executeOnListen'));
+                  executeOnListen, r'GReviewsByIDReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/review_by_id.var.gql.dart
@@ -13,7 +13,7 @@ abstract class GReviewsByIDVars
     implements Built<GReviewsByIDVars, GReviewsByIDVarsBuilder> {
   GReviewsByIDVars._();
 
-  factory GReviewsByIDVars([Function(GReviewsByIDVarsBuilder b) updates]) =
+  factory GReviewsByIDVars([void Function(GReviewsByIDVarsBuilder b) updates]) =
       _$GReviewsByIDVars;
 
   String get id;

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.data.gql.dart
@@ -16,7 +16,7 @@ abstract class GReviewsData
     implements Built<GReviewsData, GReviewsDataBuilder> {
   GReviewsData._();
 
-  factory GReviewsData([Function(GReviewsDataBuilder b) updates]) =
+  factory GReviewsData([void Function(GReviewsDataBuilder b) updates]) =
       _$GReviewsData;
 
   static void _initializeBuilder(GReviewsDataBuilder b) =>
@@ -44,7 +44,7 @@ abstract class GReviewsData_reviews
   GReviewsData_reviews._();
 
   factory GReviewsData_reviews(
-          [Function(GReviewsData_reviewsBuilder b) updates]) =
+          [void Function(GReviewsData_reviewsBuilder b) updates]) =
       _$GReviewsData_reviews;
 
   static void _initializeBuilder(GReviewsData_reviewsBuilder b) =>

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.dart
@@ -23,7 +23,8 @@ abstract class GReviewsReq
         _i1.OperationRequest<_i2.GReviewsData, _i3.GReviewsVars> {
   GReviewsReq._();
 
-  factory GReviewsReq([Function(GReviewsReqBuilder b) updates]) = _$GReviewsReq;
+  factory GReviewsReq([void Function(GReviewsReqBuilder b) updates]) =
+      _$GReviewsReq;
 
   static void _initializeBuilder(GReviewsReqBuilder b) => b
     ..operation = _i4.Operation(
@@ -40,6 +41,7 @@ abstract class GReviewsReq
   _i4.Request get execRequest => _i4.Request(
         operation: operation,
         variables: vars.toJson(),
+        context: context ?? const _i4.Context(),
       );
 
   @override
@@ -60,6 +62,9 @@ abstract class GReviewsReq
   _i1.FetchPolicy? get fetchPolicy;
   @override
   bool get executeOnListen;
+  @override
+  @BuiltValueField(serialize: false)
+  _i4.Context? get context;
   @override
   _i2.GReviewsData? parseData(Map<String, dynamic> json) =>
       _i2.GReviewsData.fromJson(json);

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.g.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.req.gql.g.dart
@@ -144,6 +144,8 @@ class _$GReviewsReq extends GReviewsReq {
   final _i1.FetchPolicy? fetchPolicy;
   @override
   final bool executeOnListen;
+  @override
+  final _i4.Context? context;
 
   factory _$GReviewsReq([void Function(GReviewsReqBuilder)? updates]) =>
       (new GReviewsReqBuilder()..update(updates))._build();
@@ -157,7 +159,8 @@ class _$GReviewsReq extends GReviewsReq {
       this.updateCacheHandlerKey,
       this.updateCacheHandlerContext,
       this.fetchPolicy,
-      required this.executeOnListen})
+      required this.executeOnListen,
+      this.context})
       : super._() {
     BuiltValueNullFieldError.checkNotNull(vars, r'GReviewsReq', 'vars');
     BuiltValueNullFieldError.checkNotNull(
@@ -186,7 +189,8 @@ class _$GReviewsReq extends GReviewsReq {
         updateCacheHandlerKey == other.updateCacheHandlerKey &&
         updateCacheHandlerContext == other.updateCacheHandlerContext &&
         fetchPolicy == other.fetchPolicy &&
-        executeOnListen == other.executeOnListen;
+        executeOnListen == other.executeOnListen &&
+        context == other.context;
   }
 
   @override
@@ -201,6 +205,7 @@ class _$GReviewsReq extends GReviewsReq {
     _$hash = $jc(_$hash, updateCacheHandlerContext.hashCode);
     _$hash = $jc(_$hash, fetchPolicy.hashCode);
     _$hash = $jc(_$hash, executeOnListen.hashCode);
+    _$hash = $jc(_$hash, context.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -216,7 +221,8 @@ class _$GReviewsReq extends GReviewsReq {
           ..add('updateCacheHandlerKey', updateCacheHandlerKey)
           ..add('updateCacheHandlerContext', updateCacheHandlerContext)
           ..add('fetchPolicy', fetchPolicy)
-          ..add('executeOnListen', executeOnListen))
+          ..add('executeOnListen', executeOnListen)
+          ..add('context', context))
         .toString();
   }
 }
@@ -274,6 +280,10 @@ class GReviewsReqBuilder implements Builder<GReviewsReq, GReviewsReqBuilder> {
   set executeOnListen(bool? executeOnListen) =>
       _$this._executeOnListen = executeOnListen;
 
+  _i4.Context? _context;
+  _i4.Context? get context => _$this._context;
+  set context(_i4.Context? context) => _$this._context = context;
+
   GReviewsReqBuilder() {
     GReviewsReq._initializeBuilder(this);
   }
@@ -290,6 +300,7 @@ class GReviewsReqBuilder implements Builder<GReviewsReq, GReviewsReqBuilder> {
       _updateCacheHandlerContext = $v.updateCacheHandlerContext;
       _fetchPolicy = $v.fetchPolicy;
       _executeOnListen = $v.executeOnListen;
+      _context = $v.context;
       _$v = null;
     }
     return this;
@@ -324,7 +335,8 @@ class GReviewsReqBuilder implements Builder<GReviewsReq, GReviewsReqBuilder> {
               updateCacheHandlerContext: updateCacheHandlerContext,
               fetchPolicy: fetchPolicy,
               executeOnListen: BuiltValueNullFieldError.checkNotNull(
-                  executeOnListen, r'GReviewsReq', 'executeOnListen'));
+                  executeOnListen, r'GReviewsReq', 'executeOnListen'),
+              context: context);
     } catch (_) {
       late String _$failedField;
       try {

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/reviews.var.gql.dart
@@ -15,7 +15,7 @@ abstract class GReviewsVars
     implements Built<GReviewsVars, GReviewsVarsBuilder> {
   GReviewsVars._();
 
-  factory GReviewsVars([Function(GReviewsVarsBuilder b) updates]) =
+  factory GReviewsVars([void Function(GReviewsVarsBuilder b) updates]) =
       _$GReviewsVars;
 
   _i1.GEpisode? get episode;

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
@@ -46,7 +46,7 @@ abstract class GReviewInput
     implements Built<GReviewInput, GReviewInputBuilder> {
   GReviewInput._();
 
-  factory GReviewInput([Function(GReviewInputBuilder b) updates]) =
+  factory GReviewInput([void Function(GReviewInputBuilder b) updates]) =
       _$GReviewInput;
 
   int get stars;
@@ -70,7 +70,8 @@ abstract class GReviewInput
 abstract class GColorInput implements Built<GColorInput, GColorInputBuilder> {
   GColorInput._();
 
-  factory GColorInput([Function(GColorInputBuilder b) updates]) = _$GColorInput;
+  factory GColorInput([void Function(GColorInputBuilder b) updates]) =
+      _$GColorInput;
 
   int get red;
   int get green;


### PR DESCRIPTION
- feat: pass context to gql links
- feat: update generated code

> Generated code was updated with "void" statements. I am not sure why

Feature request: #575 
> In order to create advanced `Link`s that can execute custom logic per request, we need a way to extend request with `ContextEntries`.
> 
> Currently, generated code for a request is:
> 
> ```dart
>   @override
>   Request get execRequest => Request(
>     operation: operation,
>     variables: vars.toJson(),
>     // no passed context. Thus, the default is `context = const Context()`
>   );
> ```
> 
> `gql_exec` has a method `.withContextEntry` on `Operation` that we could use.
> 
> I'd be happy to contribute if you think it is a good issue 🙂
> 
> _(😅 Hope I did not miss something in the API that already allows us to create context entries)_ _Reference:_ #556

