### PR TITLE
fix: pass context for JsonOperationRequests

### DIFF
--- a/packages/ferry_exec/lib/src/json_operation_request.dart
+++ b/packages/ferry_exec/lib/src/json_operation_request.dart
@@ -33,7 +33,10 @@ class JsonOperationRequest
   final Operation operation;
 
   @override
-  Request get execRequest => Request(operation: operation, variables: vars);
+  Request get execRequest => Request(
+      operation: operation,
+      variables: vars,
+      context: context ?? const Context());
 
   @override
   final Context? context;


### PR DESCRIPTION
I forgot to pass context in `JsonOperationRequest` in #576 