### PR TITLE
feat(input-create): Passing through builder options to schema builder

### DIFF
--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -129,7 +129,9 @@ class GraphqlBuilder implements Builder {
           config.enumFallbackConfig,
           generatePossibleTypesMap: config.shouldGeneratePossibleTypes,
           allocator: schemaAllocator,
-          triStateValueConfig: triStateValueConfig),
+          triStateValueConfig: triStateValueConfig,
+          generateVarsCreateFactories:
+              config.shouldGenerateVarsCreateFactories),
     };
 
     for (var entry in libs.entries) {

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -12,12 +12,7 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  #gql_code_builder: ^0.10.1
-  gql_code_builder: 
-    git:
-      url: 'https://github.com/gql-dart/gql.git'
-      ref: 'bfafca57c04e5615bb38cd74f6e6b3e71d18994f'
-      path: ./codegen/gql_code_builder
+  gql_code_builder: ^0.11.0
   gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -12,7 +12,12 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  gql_code_builder: ^0.10.0
+  #gql_code_builder: ^0.10.1
+  gql_code_builder: 
+    git:
+      url: 'https://github.com/gql-dart/gql.git'
+      ref: 'bfafca57c04e5615bb38cd74f6e6b3e71d18994f'
+      path: ./codegen/gql_code_builder
   gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -12,12 +12,7 @@ dependencies:
   ferry_exec: ^0.6.1-dev.0+1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  #gql_code_builder: ^0.10.0+1
-  gql_code_builder: 
-    git:
-      url: 'https://github.com/gql-dart/gql.git'
-      ref: 'bfafca57c04e5615bb38cd74f6e6b3e71d18994f'
-      path: ./codegen/gql_code_builder
+  gql_code_builder: ^0.11.0
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -12,7 +12,12 @@ dependencies:
   ferry_exec: ^0.6.1-dev.0+1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.10.0
+  #gql_code_builder: ^0.10.0+1
+  gql_code_builder: 
+    git:
+      url: 'https://github.com/gql-dart/gql.git'
+      ref: 'bfafca57c04e5615bb38cd74f6e6b3e71d18994f'
+      path: ./codegen/gql_code_builder
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2


### PR DESCRIPTION
This is the follow up PR for https://github.com/gql-dart/gql/pull/451 to enable passing through the builder options to the schema builder so this could be used from within the `ferry_generator`.

To avoid assuming the correct version for the 'gql_code_builder` dependency, I didn't change the pubspec.yaml yet. So this might still be a todo.

Thanks!