### PR TITLE
feat(ferry_generator)!: update to gql_code_builders 0.12.0. this extr…

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,6 +13,8 @@ Add the following to your `pubspec.yaml`:
 dependencies:
   ferry: #[latest-version]
   gql_http_link: #[latest-version]
+  # common serializers, which the code generator will assume are available
+  gql_code_builder_serializers: #[latest-version]
 
 dev_dependencies:
   ferry_generator: #[latest-version]

--- a/packages/ferry/lib/ferry_isolate.dart
+++ b/packages/ferry/lib/ferry_isolate.dart
@@ -322,7 +322,7 @@ class IsolateClient extends TypedLink {
 
   /// adds a request to the requestController of the client on the isolate
   /// this is useful for re-fetch and pagination
-  /// see https://ferrygraphql.com/docs/pagination
+  /// see https://ferry.gql-dart.dev/docs/pagination
   Future<void> addRequestToRequestController<TData, TVars>(
       OperationRequest<TData, TVars> request) {
     _debugAssertUpdateResultTransferrable(request);

--- a/packages/ferry/pubspec.yaml
+++ b/packages/ferry/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry
 version: 0.16.0-dev.2
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: Ferry is a simple, powerful GraphQL Client for Flutter and Dart.
 repository: https://github.com/gql-dart/ferry
 environment:

--- a/packages/ferry_cache/pubspec.yaml
+++ b/packages/ferry_cache/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry_cache
 version: 0.9.0-dev.1
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: A normalized, strongly typed, optimistic cache for GraphQL Operations and Fragments
 repository: https://github.com/gql-dart/ferry
 environment:

--- a/packages/ferry_exec/pubspec.yaml
+++ b/packages/ferry_exec/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry_exec
 version: 0.6.1-dev.0+1
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: A strongly typed execution interface for GraphQL operations
 repository: https://github.com/gql-dart/ferry
 environment:

--- a/packages/ferry_flutter/pubspec.yaml
+++ b/packages/ferry_flutter/pubspec.yaml
@@ -1,10 +1,10 @@
 name: ferry_flutter
 version: 0.9.0-dev.3
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: Flutter widgets for the Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
 topics:
   - graphql
   - gql

--- a/packages/ferry_generator/lib/serializer_builder.dart
+++ b/packages/ferry_generator/lib/serializer_builder.dart
@@ -131,7 +131,7 @@ class SerializerBuilder implements Builder {
       // GraphQL Operation serializer
       refer(
         'OperationSerializer',
-        'package:gql_code_builder/src/serializers/operation_serializer.dart',
+        'package:gql_code_builder_serializers/gql_code_builder_serializers.dart',
       ).call([]),
       // User-defined custom serializers
       ...config.customSerializers.map((ref) => ref.call([])),

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry_generator
 version: 0.10.0-dev.2
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: Generated types for Ferry GraphQL Client
 repository: https://github.com/gql-dart/ferry
 environment:
@@ -12,7 +12,8 @@ topics:
   - codegen
 dependencies:
   gql: '>=0.14.0 <2.0.0'
-  gql_code_builder: ^0.11.0
+  gql_code_builder: ^0.12.0
+  gql_code_builder_serializers: ^0.1.0
   gql_tristate_value: ^1.0.0
   built_collection: ^5.0.0
   code_builder: ^4.3.0

--- a/packages/ferry_hive_store/pubspec.yaml
+++ b/packages/ferry_hive_store/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry_hive_store
 version: 0.5.2
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: Hive-based Store implementation for Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
 environment:

--- a/packages/ferry_store/pubspec.yaml
+++ b/packages/ferry_store/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ferry_store
 version: 0.5.3+1
-homepage: https://ferrygraphql.com/
+homepage: https://ferry.gql-dart.dev
 description: Default Store for Ferry GraphQL client
 repository: https://github.com/gql-dart/ferry
 environment:

--- a/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
+++ b/packages/ferry_test_graphql2/lib/queries/__generated__/hero_with_inline_fragment.data.gql.dart
@@ -6,7 +6,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
     as _i1;
-import 'package:gql_code_builder/src/serializers/inline_fragment_serializer.dart'
+import 'package:gql_code_builder_serializers/gql_code_builder_serializers.dart'
     as _i2;
 
 part 'hero_with_inline_fragment.data.gql.g.dart';

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/schema.schema.gql.dart
@@ -7,7 +7,7 @@ import 'package:built_value/built_value.dart';
 import 'package:built_value/serializer.dart';
 import 'package:ferry_test_graphql2/schema/__generated__/serializers.gql.dart'
     as _i1;
-import 'package:gql_code_builder/src/serializers/default_scalar_serializer.dart'
+import 'package:gql_code_builder_serializers/gql_code_builder_serializers.dart'
     as _i2;
 
 part 'schema.schema.gql.g.dart';

--- a/packages/ferry_test_graphql2/lib/schema/__generated__/serializers.gql.dart
+++ b/packages/ferry_test_graphql2/lib/schema/__generated__/serializers.gql.dart
@@ -88,7 +88,7 @@ import 'package:ferry_test_graphql2/queries/__generated__/reviews.var.gql.dart'
     show GReviewsVars;
 import 'package:ferry_test_graphql2/schema/__generated__/schema.schema.gql.dart'
     show GColorInput, GEpisode, GISODate, GLengthUnit, GReviewInput;
-import 'package:gql_code_builder/src/serializers/operation_serializer.dart'
+import 'package:gql_code_builder_serializers/gql_code_builder_serializers.dart'
     show OperationSerializer;
 
 part 'serializers.gql.g.dart';

--- a/packages/ferry_test_graphql2/pubspec.yaml
+++ b/packages/ferry_test_graphql2/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   ferry_exec: ^0.6.1-dev.0+1
   built_value: ^8.0.4
   built_collection: ^5.0.0
-  gql_code_builder: ^0.11.0
+  gql_code_builder_serializers: ^0.1.0
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2

--- a/website/netlify.toml
+++ b/website/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../docs"


### PR DESCRIPTION
…acted the common serializers to a separate package. clients need to add gql_code_builder_serializers to their dependencies if they use ferry_generator.