### PR TITLE
fix(ferry): Properly type-constrain `ErrorTypedLink`'s forward response stream

### DIFF
--- a/packages/ferry/lib/src/error_typed_link.dart
+++ b/packages/ferry/lib/src/error_typed_link.dart
@@ -22,19 +22,21 @@ class ErrorTypedLink extends TypedLink {
     forward,
   ]) {
     try {
-      return forward!(operationRequest).transform(
-        StreamTransformer.fromHandlers(
-          handleError: (error, stackTrace, sink) => sink.add(
-            OperationResponse(
-              operationRequest: operationRequest,
-              linkException: error is LinkException
-                  ? error
-                  : TypedLinkException(error, stackTrace),
-              dataSource: DataSource.None,
+      return forward!(operationRequest)
+          .cast<OperationResponse<TData, TVars>>()
+          .transform(
+            StreamTransformer.fromHandlers(
+              handleError: (error, stackTrace, sink) => sink.add(
+                OperationResponse(
+                  operationRequest: operationRequest,
+                  linkException: error is LinkException
+                      ? error
+                      : TypedLinkException(error, stackTrace),
+                  dataSource: DataSource.None,
+                ),
+              ),
             ),
-          ),
-        ),
-      );
+          );
     } catch (error, stackTrace) {
       return Stream.value(
         OperationResponse(


### PR DESCRIPTION
In the `ErrorTypedLink`, the response stream recieved via the `forward` function is not type-constrained, thus cast it to be of the generic types `TData` and `TVars`.

This fixes an error that could sometimes occur, where the forward response stream was of a different type than `TData` and `TVars`, which mismatched with the `StreamTransformer`'s inferred types, throwing an exception.

```
LinkException(type '_StreamHandlerTransformer<OperationResponse<dynamic, dynamic>, OperationResponse<dynamic, dynamic>>' is not a subtype of type 'StreamTransformer<OperationResponse<ConcreteTypeData, ConcreteTypeVars>, OperationResponse<dynamic, dynamic>>' of 'streamTransformer',
#0      Stream.transform (dart:async/stream.dart:1007:50)
#1      ErrorTypedLink.request (package:ferry/src/error_typed_link.dart:25:41)
#2      _TypedLinkChain.request.<anonymous closure>.<anonymous closure> (package:ferry_exec/src/typed_link.dart:131:46)
#3      _TypedLinkChain.request (package:ferry_exec/src/typed_link.dart:132:9)
#4      Client.request (package:ferry/ferry.dart:80:18)
```