### PR TITLE
feat(ferr_cache): add evict operation

### DIFF
--- a/packages/ferry_cache/pubspec.yaml
+++ b/packages/ferry_cache/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   pedantic: ^1.11.0
 dev_dependencies:
   test: ^1.16.8
-  ferry_test_graphql2: ^0.4.0
+  ferry_test_graphql2: 
   gql_exec: ^1.0.0
   gql: ^1.0.0
   gql_tristate_value: ^1.0.0

--- a/packages/ferry_cache/test/eviction_test.dart
+++ b/packages/ferry_cache/test/eviction_test.dart
@@ -122,6 +122,7 @@ void main() {
         hanReq.rebuild((b) => b..vars.friendsAfter = 'chewie'),
         hanData,
       );
+
       final entityId = cache.identify(hanData.human)!;
       final keyLuke =
           FieldKey.from('friendsConnection', {'first': 10, 'after': 'luke'});
@@ -168,6 +169,52 @@ void main() {
       cache.gc();
       expect(cache.store.get('Human:luke'), isNotNull);
       expect(cache.store.get('Human:chewie'), isNull);
+    });
+  });
+
+  group('evictOperation', () {
+    test('can evict Operation', () {
+      final cache = Cache();
+      addTearDown(() {
+        cache.dispose();
+      });
+      cache.writeQuery(
+        hanReq,
+        hanData,
+      );
+
+      cache.evictOperation(hanReq);
+
+      expect(cache.readQuery(hanReq), equals(null));
+
+      final gcResult = cache.gc();
+
+      expect(gcResult, equals({'Human:luke', 'Human:chewie', 'Human:han'}));
+
+      expect(cache.store.get('Query'), equals({'__typename': 'Query'}));
+
+      expect(cache.store.keys, equals({'Query'}));
+    });
+
+    test('only evicts given operation', () {
+      final cache = Cache();
+      addTearDown(() {
+        cache.dispose();
+      });
+      cache.writeQuery(
+        hanReq,
+        hanData,
+      );
+
+      cache.writeQuery(
+        chewieReq,
+        chewieData,
+      );
+
+      cache.evictOperation(hanReq);
+
+      expect(cache.readQuery(hanReq), equals(null));
+      expect(cache.readQuery(chewieReq), equals(chewieData));
     });
   });
 }


### PR DESCRIPTION
allow evicting the root fields of an operation

helps with #618 