### PR TITLE
feat(ferry_store): add flush method to allow persistent stores to write pending data to disk

### DIFF
--- a/packages/ferry_store/lib/src/store.dart
+++ b/packages/ferry_store/lib/src/store.dart
@@ -16,4 +16,7 @@ abstract class Store {
   void clear();
 
   Future<void> dispose() async => null;
+
+  /// Flushes any pending writes to disk.
+  Future<void> flush() async => null;
 }


### PR DESCRIPTION
-
