### PR TITLE
RequestControllerTypedLink return subscription streams that can end

### DIFF
--- a/packages/ferry/lib/src/request_controller_typed_link.dart
+++ b/packages/ferry/lib/src/request_controller_typed_link.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:ferry_exec/ferry_exec.dart';
+import 'package:ferry/ferry.dart';
+import 'package:gql_exec/gql_exec.dart';
 import 'package:rxdart/rxdart.dart';
 
 /// Allows multiple requests to be made by adding requests to the
@@ -57,7 +58,7 @@ class RequestControllerTypedLink extends TypedLink {
       // If no stream has been cached for this request, create a new one.
       ValueStream<OperationResponse<TData, TVars>>? prev;
       var initial = true;
-      stream = requestController.stream
+      var requestStream = requestController.stream
           .whereType<OperationRequest<TData, TVars>>()
           .where(
             (req) => req.requestId == null
@@ -71,7 +72,11 @@ class RequestControllerTypedLink extends TypedLink {
           final sub = prev?.listen(null);
           Future.delayed(Duration.zero, () => sub?.cancel());
         },
-      ).switchMap(
+      );
+      if (request.operation.getOperationType() == OperationType.subscription) {
+        requestStream = requestStream.take(1);
+      }
+      stream = requestStream.switchMap(
         (req) {
           final stream = req.updateResult == null
               ? forward!(req)

--- a/packages/ferry/lib/src/request_controller_typed_link.dart
+++ b/packages/ferry/lib/src/request_controller_typed_link.dart
@@ -73,6 +73,8 @@ class RequestControllerTypedLink extends TypedLink {
           Future.delayed(Duration.zero, () => sub?.cancel());
         },
       );
+      //Only use the first instance of the request stream for subscriptions, to ensure that a possible .done event is propagated.
+      //Note: This disables the paging and refetch feature for subscriptions.
       if (request.operation.getOperationType() == OperationType.subscription) {
         requestStream = requestStream.take(1);
       }

--- a/packages/ferry/test/typed_links/request_controller_typed_link_test.dart
+++ b/packages/ferry/test/typed_links/request_controller_typed_link_test.dart
@@ -10,6 +10,7 @@ import 'package:ferry_test_graphql2/queries/__generated__/review_by_id.req.gql.d
 import 'package:ferry_test_graphql2/queries/__generated__/reviews.data.gql.dart';
 import 'package:ferry_test_graphql2/queries/__generated__/reviews.req.gql.dart';
 import 'package:ferry_test_graphql2/queries/__generated__/reviews.var.gql.dart';
+import 'package:gql/language.dart' as gql;
 import 'package:gql_exec/gql_exec.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:test/test.dart';
@@ -466,6 +467,38 @@ void main() {
       await Future.delayed(Duration.zero);
 
       await client.dispose();
+    });
+  });
+
+  group('done event for subscriptions', () {
+    late TypedLink typedLink;
+
+    setUp(() {
+      typedLink = TypedLink.from([
+        RequestControllerTypedLink(),
+        TypedLink.function(<TData, TVars>(request, [next]) =>
+            Stream<OperationResponse<TData, TVars>>.empty()),
+      ]);
+    });
+
+    test('onDone is propagated for subscriptions', () {
+      final stream = typedLink.request(
+        JsonOperationRequest(
+          fetchPolicy: FetchPolicy.NetworkOnly,
+          vars: {},
+          operation: Operation(
+            document: gql.parseString(r'''
+            subscription Sub {
+                reviews {
+                  id
+                  stars
+                }
+            }'''),
+          ),
+        ),
+      );
+
+      expect(stream, emitsInOrder([emitsDone]));
     });
   });
 }


### PR DESCRIPTION
Update RequestControllerTypedLink so that it will not refetch and return the stream result directly.  This allows the stream to end if the server completes the stream, and the listeners `onData` will fire.

Since the requestController stream never closes the switchMap's result stream will also never reach the onDone state.  This uses only the first matching requestController emitted request when it is a subscription operation.  This allows the switchMap's resulting stream to close when the server's response stream closes as well.