### PR TITLE
feat(ferry_generator): add option to disable formatting

### DIFF
--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -214,6 +214,8 @@ By default, both are disabled.
 
 `vars_create_factories`: \[bool\] Whether to generate an additional factory constructor for the variables class. In contrast to the `built_value` builders, this factory constructor respects nullability for it's parameters. Defaults to false.
 
+`format`: \[bool\] Whether to allow formatting of the generated code. When set to false, adds `// dart format off` directive to the generated files. Defaults to true.
+
 Example:
 
 ```yaml
@@ -228,6 +230,7 @@ Example:
       global_enum_fallbacks: true # add a generated fallback value to all enums
       enum_fallbacks:
          MyEnumType: OTHER   # except for the type 'MyEnumType', use the value 'OTHER' as fallback there
+      format: false  # disable dart formatting for generated code
 
 ```
 

--- a/packages/ferry_generator/lib/graphql_builder.dart
+++ b/packages/ferry_generator/lib/graphql_builder.dart
@@ -153,7 +153,8 @@ class GraphqlBuilder implements Builder {
 
       final allocator = allocators[entry.key]!;
 
-      await writeDocument(generatedAsset, entry.value, allocator, buildStep);
+      await writeDocument(
+          generatedAsset, entry.value, allocator, buildStep, config.format);
     }
   }
 }

--- a/packages/ferry_generator/lib/serializer_builder.dart
+++ b/packages/ferry_generator/lib/serializer_builder.dart
@@ -169,7 +169,7 @@ class SerializerBuilder implements Builder {
       p.joinAll(pathSegments(schemaId)),
     );
 
-    await writeDocument(outputId, library, allocator, buildStep);
+    await writeDocument(outputId, library, allocator, buildStep, config.format);
   }
 }
 

--- a/packages/ferry_generator/lib/src/utils/config.dart
+++ b/packages/ferry_generator/lib/src/utils/config.dart
@@ -25,6 +25,7 @@ class BuilderConfig {
   final DataClassConfig dataClassConfig;
   final TriStateValueConfig triStateOptionalsConfig;
   final DataToJsonMode dataToJsonMode;
+  final bool format;
 
   BuilderConfig(Map<String, dynamic> config)
       : schemaId = config['schema'] == null
@@ -46,7 +47,8 @@ class BuilderConfig {
         whenExtensionConfig = _getWhenExtensionConfig(config),
         dataClassConfig = _getDataClassConfig(config),
         triStateOptionalsConfig = _getTriStateOptionalsConfig(config),
-        dataToJsonMode = getDataToJsonModeFromConfig(config);
+        dataToJsonMode = getDataToJsonModeFromConfig(config),
+        format = config['format'] ?? true;
 }
 
 DataClassConfig _getDataClassConfig(Map<String, dynamic> config) {

--- a/packages/ferry_generator/lib/src/utils/writer.dart
+++ b/packages/ferry_generator/lib/src/utils/writer.dart
@@ -14,6 +14,7 @@ Future<void> writeDocument(
   Library library,
   Allocator allocator,
   BuildStep buildStep,
+  bool format,
 ) {
   if (library.body.isEmpty) return Future.value(null);
 
@@ -33,6 +34,7 @@ Future<void> writeDocument(
     outputId,
     '// GENERATED CODE - DO NOT MODIFY BY HAND\n'
             '// ignore_for_file: type=lint\n\n' +
+        (format ? '' : '// dart format off\n\n') +
         formatted,
   );
 }


### PR DESCRIPTION
Adds a flag to the build.xml's options to prefix the generated code with `// dart format off`.
I set the default value is true to not affect any existing output.

Do I need to make any other changes for this simple feature?