### PR TITLE
fix: support analyzer v7 APIs

### DIFF
--- a/packages/ferry_generator/lib/serializer_builder.dart
+++ b/packages/ferry_generator/lib/serializer_builder.dart
@@ -191,14 +191,14 @@ String _externalSchemaSerializersImport(
 bool hasSerializer(ClassElement2 c) => c.fields2.any((field) =>
     field.isStatic &&
     field.name3 == 'serializer' &&
-    field.type.element?.name == 'Serializer' &&
-    field.type.element?.source?.uri.toString() ==
+    field.type.element3?.name3 == 'Serializer' &&
+    field.type.element3?.library2?.uri.toString() ==
         'package:built_value/serializer.dart');
 
 bool isBuiltValue(ClassElement2 c) => c.allSupertypes.any((interface) =>
-    (interface.element.name == 'Built' ||
-        interface.element.name == 'EnumClass') &&
-    interface.element.source.uri.toString() ==
+    (interface.element3.name3 == 'Built' ||
+        interface.element3.name3 == 'EnumClass') &&
+    interface.element3.library2.uri.toString() ==
         'package:built_value/built_value.dart');
 
 typedef ClassesToGenerateSerializersFor = ({

--- a/packages/ferry_generator/pubspec.yaml
+++ b/packages/ferry_generator/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   glob: ^2.0.1
   built_value_generator: ^8.1.1
   built_value: ^8.1.2
-  analyzer: ">=4.2.0 <8.0.0"
+  analyzer: ">=7.0.0 <9.0.0"
 dev_dependencies:
   test: ^1.16.8
   build_runner: ^2.0.2


### PR DESCRIPTION
## Summary
- migrate serializer builder to analyzer v7 element APIs
- relax analyzer dependency range to allow >=7 <9

## Testing
- not run (not requested)
