### PR TITLE
fix(generator2): skip root __typename on subscriptions

### DIFF
--- a/packages/ferry_generator2/lib/src/selection/add_typenames.dart
+++ b/packages/ferry_generator2/lib/src/selection/add_typenames.dart
@@ -19,7 +19,10 @@ DefinitionNode _addTypenameDefinition(DefinitionNode definition) {
       name: definition.name,
       variableDefinitions: definition.variableDefinitions,
       directives: definition.directives,
-      selectionSet: _addTypenameSelectionSet(definition.selectionSet),
+      selectionSet: _addTypenameSelectionSet(
+        definition.selectionSet,
+        includeTypename: definition.type != OperationType.subscription,
+      ),
     );
   }
 
@@ -35,10 +38,13 @@ DefinitionNode _addTypenameDefinition(DefinitionNode definition) {
   return definition;
 }
 
-SelectionSetNode _addTypenameSelectionSet(SelectionSetNode selectionSet) {
+SelectionSetNode _addTypenameSelectionSet(
+  SelectionSetNode selectionSet, {
+  bool includeTypename = true,
+}) {
   final selections =
       selectionSet.selections.map(_addTypenameSelection).toList();
-  if (!_hasTypename(selections)) {
+  if (includeTypename && !_hasTypename(selections)) {
     selections.add(
       FieldNode(
         name: NameNode(value: "__typename"),

--- a/packages/ferry_generator2/test/add_typenames_test.dart
+++ b/packages/ferry_generator2/test/add_typenames_test.dart
@@ -1,0 +1,52 @@
+import "package:ferry_generator2/src/selection/add_typenames.dart";
+import "package:gql/ast.dart";
+import "package:gql/language.dart";
+import "package:test/test.dart";
+
+void main() {
+  test("query roots still get __typename", () {
+    final document = parseString("""
+      query Hero {
+        hero {
+          id
+        }
+      }
+    """);
+
+    final transformed = addTypenames(document);
+    final operation = transformed.definitions.single as OperationDefinitionNode;
+
+    expect(_fieldNames(operation.selectionSet), contains("__typename"));
+    final heroField = operation.selectionSet.selections.singleWhere(
+      (selection) => selection is FieldNode && selection.name.value == "hero",
+    ) as FieldNode;
+    expect(_fieldNames(heroField.selectionSet!), contains("__typename"));
+  });
+
+  test("subscription roots skip __typename but nested payloads still get it",
+      () {
+    final document = parseString("""
+      subscription ReviewAdded {
+        reviewAdded {
+          stars
+        }
+      }
+    """);
+
+    final transformed = addTypenames(document);
+    final operation = transformed.definitions.single as OperationDefinitionNode;
+
+    expect(_fieldNames(operation.selectionSet), isNot(contains("__typename")));
+    final reviewAddedField =
+        operation.selectionSet.selections.single as FieldNode;
+    expect(_fieldNames(reviewAddedField.selectionSet!), contains("__typename"));
+  });
+}
+
+Iterable<String> _fieldNames(SelectionSetNode selectionSet) sync* {
+  for (final selection in selectionSet.selections) {
+    if (selection is FieldNode) {
+      yield selection.name.value;
+    }
+  }
+}

--- a/packages/ferry_generator2/test/build_test_subscription_req_document_test.dart
+++ b/packages/ferry_generator2/test/build_test_subscription_req_document_test.dart
@@ -1,0 +1,128 @@
+@TestOn("vm")
+
+import "package:analyzer/dart/constant/value.dart";
+import "package:build/build.dart";
+import "package:build_test/build_test.dart";
+import "package:ferry_generator2/ferry_generator2.dart";
+import "package:test/test.dart";
+import "test_utils.dart";
+
+const _package = "ferry_generator2";
+const _schemaPath = "$_package|lib/schema.graphql";
+const _documentPath = "$_package|lib/subscription.graphql";
+const _reqPath = "$_package|lib/__generated__/subscription.req.gql.dart";
+
+const _schema = r"""
+schema {
+  query: Query
+  subscription: Subscription
+}
+
+type Query {
+  _noop: Boolean
+}
+
+type Review {
+  stars: Int!
+}
+
+type Subscription {
+  reviewAdded: Review
+}
+""";
+
+const _document = r"""
+subscription ReviewAdded {
+  reviewAdded {
+    stars
+  }
+}
+""";
+
+void main() {
+  test("subscription request document skips root __typename", () async {
+    final assets = <String, String>{
+      _schemaPath: _schema,
+      _documentPath: _document,
+    };
+
+    final builder = graphqlBuilder(
+      BuilderOptions({
+        "schema": {
+          "file": _schemaPath,
+          "add_typenames": true,
+        },
+      }),
+    );
+
+    final result = await testBuilder(
+      builder,
+      assets,
+      rootPackage: _package,
+      generateFor: {_documentPath},
+    );
+
+    expect(result.succeeded, isTrue);
+
+    final sources = extractGeneratedDartSources(result.readerWriter, _package);
+    final document = await _resolveRequestDocument(sources);
+    final operation = document.getField("definitions")?.toListValue()?.single;
+    if (operation == null) {
+      throw StateError("Missing operation definition");
+    }
+
+    final rootSelectionSet = operation.getField("selectionSet");
+    if (rootSelectionSet == null) {
+      throw StateError("Missing operation selection set");
+    }
+
+    expect(_selectionNames(rootSelectionSet), equals(["reviewAdded"]));
+
+    final reviewAdded =
+        rootSelectionSet.getField("selections")!.toListValue()!.single;
+    final nestedSelectionSet = reviewAdded.getField("selectionSet");
+    if (nestedSelectionSet == null) {
+      throw StateError("Missing nested selection set");
+    }
+    expect(
+      _selectionNames(nestedSelectionSet),
+      equals(["stars", "__typename"]),
+    );
+  });
+}
+
+Future<DartObject> _resolveRequestDocument(Map<String, String> sources) {
+  return resolveSources(
+    sources,
+    (resolver) async {
+      final library = await resolver.libraryFor(AssetId.parse(_reqPath));
+      final reqClass = library.getClass("GReviewAddedReq");
+      if (reqClass == null) {
+        throw StateError("Missing request class in resolved library");
+      }
+
+      final documentField =
+          reqClass.fields.singleWhere((field) => field.name == "_document");
+      final documentValue = documentField.computeConstantValue();
+      if (documentValue == null) {
+        throw StateError("Failed to evaluate _document const value");
+      }
+      return documentValue;
+    },
+    rootPackage: _package,
+    readAllSourcesFromFilesystem: true,
+  );
+}
+
+List<String> _selectionNames(DartObject selectionSet) {
+  final selections = selectionSet.getField("selections")?.toListValue();
+  if (selections == null) {
+    throw StateError("Missing selections in SelectionSetNode");
+  }
+
+  return [
+    for (final selection in selections)
+      selection.getField("name")?.getField("value")?.toStringValue() ??
+          (throw StateError("Selection is missing a name")),
+  ];
+}

--- a/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.ast.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.ast.gql.dart
@@ -60,14 +60,7 @@ const ReviewAdded = _i1.OperationDefinitionNode(
           selectionSet: null,
         ),
       ]),
-    ),
-    _i1.FieldNode(
-      name: _i1.NameNode(value: '__typename'),
-      alias: null,
-      arguments: [],
-      directives: [],
-      selectionSet: null,
-    ),
+    )
   ]),
 );
 const document = _i1.DocumentNode(definitions: [ReviewAdded]);

--- a/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.data.gql.dart
@@ -7,61 +7,48 @@ import 'package:ferry_generator2_end_to_end/graphql/__generated__/schema.schema.
 
 /// The subscription type for the schema.
 class GReviewAddedData {
-  const GReviewAddedData({
-    this.reviewAdded,
-    this.G__typename = 'Subscription',
-  });
+  const GReviewAddedData({this.reviewAdded});
 
   factory GReviewAddedData.fromJson(Map<String, dynamic> json) {
     return GReviewAddedData(
-      reviewAdded: json['reviewAdded'] == null
-          ? null
-          : GReviewAddedData_reviewAdded.fromJson(
-              (json['reviewAdded'] as Map<String, dynamic>)),
-      G__typename: (json['__typename'] as String),
-    );
+        reviewAdded: json['reviewAdded'] == null
+            ? null
+            : GReviewAddedData_reviewAdded.fromJson(
+                (json['reviewAdded'] as Map<String, dynamic>)));
   }
 
   final GReviewAddedData_reviewAdded? reviewAdded;
-
-  final String G__typename;
 
   Map<String, dynamic> toJson() {
     final _$result = <String, dynamic>{};
     final _$reviewAddedValue = this.reviewAdded;
     _$result['reviewAdded'] =
         _$reviewAddedValue == null ? null : _$reviewAddedValue.toJson();
-    _$result['__typename'] = this.G__typename;
     return _$result;
   }
 
   GReviewAddedData copyWith({
     GReviewAddedData_reviewAdded? reviewAdded,
     bool reviewAddedIsSet = false,
-    String? G__typename,
   }) {
     return GReviewAddedData(
-      reviewAdded: reviewAddedIsSet ? reviewAdded : this.reviewAdded,
-      G__typename: G__typename ?? this.G__typename,
-    );
+        reviewAdded: reviewAddedIsSet ? reviewAdded : this.reviewAdded);
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
-        (other is GReviewAddedData &&
-            reviewAdded == other.reviewAdded &&
-            G__typename == other.G__typename);
+        (other is GReviewAddedData && reviewAdded == other.reviewAdded);
   }
 
   @override
   int get hashCode {
-    return Object.hash(runtimeType, reviewAdded, G__typename);
+    return Object.hash(runtimeType, reviewAdded);
   }
 
   @override
   String toString() {
-    return 'GReviewAddedData(reviewAdded: $reviewAdded, G__typename: $G__typename)';
+    return 'GReviewAddedData(reviewAdded: $reviewAdded)';
   }
 }
 

--- a/packages/ferry_generator2_end_to_end/pubspec.lock
+++ b/packages/ferry_generator2_end_to_end/pubspec.lock
@@ -180,7 +180,7 @@ packages:
       path: "../ferry_generator2"
       relative: true
     source: path
-    version: "0.1.0-dev.3"
+    version: "0.1.0-dev.4"
   ferry_store:
     dependency: "direct overridden"
     description:

--- a/packages/ferry_generator2_end_to_end/test/runtime_test.dart
+++ b/packages/ferry_generator2_end_to_end/test/runtime_test.dart
@@ -48,6 +48,7 @@ import 'package:ferry_generator2_end_to_end/variables/__generated__/create_revie
 import 'package:ferry_generator2_end_to_end/variables/__generated__/human_with_args.data.gql.dart';
 import 'package:ferry_generator2_end_to_end/graphql/__generated__/schema.schema.gql.dart'
     as _schema;
+import 'package:gql/ast.dart' as _i1;
 import 'package:gql_tristate_value/gql_tristate_value.dart';
 import 'package:test/test.dart';
 
@@ -964,7 +965,6 @@ void main() {
 
   test('review added subscription round-trips and vars serialize', () {
     final input = {
-      '__typename': 'Subscription',
       'reviewAdded': {
         '__typename': 'Review',
         'episode': 'EMPIRE',
@@ -987,6 +987,17 @@ void main() {
     final req = GReviewAddedReq(vars: vars);
     expect(req.execRequest.variables, equals(varsJson));
     expect(req.dataToJson(GReviewAddedData.fromJson(input)), equals(input));
+
+    final operation = req.operation.document.definitions.single
+        as _i1.OperationDefinitionNode;
+    expect(
+      operation.selectionSet.selections.whereType<_i1.FieldNode>().length,
+      1,
+    );
+    expect(
+      (operation.selectionSet.selections.single as _i1.FieldNode).name.value,
+      'reviewAdded',
+    );
   });
 
   test('operation request parseData and vars serialize', () {


### PR DESCRIPTION
Summary
- skip adding `__typename` to the root selection set of subscription operations
- keep nested subscription payload selections annotated with `__typename`
- add generator and end-to-end regression coverage for subscription request documents
- refresh the checked-in end-to-end lockfile to match the current `ferry_generator2` version

Testing
- dart test test/add_typenames_test.dart test/build_test_subscription_req_document_test.dart test/end_to_end_mirror_test.dart
- dart test test/runtime_test.dart
- dart analyze
