### PR TITLE
fix(generator2)!: improve nullable copyWith ergonomics

### DIFF
--- a/packages/ferry_generator2/lib/src/emit/emitter_helpers.dart
+++ b/packages/ferry_generator2/lib/src/emit/emitter_helpers.dart
@@ -42,7 +42,7 @@ Method buildCopyWithMethod(String className, List<EmitterField> fields) {
         ),
       );
       args[field.name] = conditionalExpression(
-        refer(isSetName),
+        refer(field.name).notEqualTo(literalNull).or(refer(isSetName)),
         refer(field.name),
         refer("this").property(field.name),
       );

--- a/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/alias_var_fragment.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/alias_var_fragment.data.gql.dart
@@ -76,8 +76,10 @@ class GPostFragmentData implements GPostFragment {
   }) {
     return GPostFragmentData(
       id: id ?? this.id,
-      isFavorited: isFavoritedIsSet ? isFavorited : this.isFavorited,
-      isLiked: isLikedIsSet ? isLiked : this.isLiked,
+      isFavorited: isFavorited != null || isFavoritedIsSet
+          ? isFavorited
+          : this.isFavorited,
+      isLiked: isLiked != null || isLikedIsSet ? isLiked : this.isLiked,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -250,7 +252,7 @@ class GPostsData {
     String? G__typename,
   }) {
     return GPostsData(
-      posts: postsIsSet ? posts : this.posts,
+      posts: posts != null || postsIsSet ? posts : this.posts,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/alias_var_fragment.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/alias_var_fragment.req.gql.dart
@@ -116,20 +116,27 @@ class GPostsReq
     return GPostsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -210,7 +217,9 @@ class GPostFragmentReq
     return GPostFragmentReq(
       vars: vars ?? this.vars,
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/aliased_hero.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/aliased_hero.data.gql.dart
@@ -57,8 +57,9 @@ class GAliasedHeroData {
     String? G__typename,
   }) {
     return GAliasedHeroData(
-      empireHero: empireHeroIsSet ? empireHero : this.empireHero,
-      jediHero: jediHeroIsSet ? jediHero : this.jediHero,
+      empireHero:
+          empireHero != null || empireHeroIsSet ? empireHero : this.empireHero,
+      jediHero: jediHero != null || jediHeroIsSet ? jediHero : this.jediHero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/aliased_hero.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/aliases/__generated__/aliased_hero.req.gql.dart
@@ -108,20 +108,27 @@ class GAliasedHeroReq
   }) {
     return GAliasedHeroReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/directives/__generated__/create_review_with_directives.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/directives/__generated__/create_review_with_directives.data.gql.dart
@@ -42,7 +42,9 @@ class GCreateReviewWithDirectivesData {
     String? G__typename,
   }) {
     return GCreateReviewWithDirectivesData(
-      createReview: createReviewIsSet ? createReview : this.createReview,
+      createReview: createReview != null || createReviewIsSet
+          ? createReview
+          : this.createReview,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -117,9 +119,10 @@ class GCreateReviewWithDirectivesData_createReview {
     String? G__typename,
   }) {
     return GCreateReviewWithDirectivesData_createReview(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       stars: stars ?? this.stars,
-      commentary: commentaryIsSet ? commentary : this.commentary,
+      commentary:
+          commentary != null || commentaryIsSet ? commentary : this.commentary,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/directives/__generated__/create_review_with_directives.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/directives/__generated__/create_review_with_directives.req.gql.dart
@@ -118,20 +118,27 @@ class GCreateReviewWithDirectivesReq
     return GCreateReviewWithDirectivesReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/directives/__generated__/human_with_directives.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/directives/__generated__/human_with_directives.data.gql.dart
@@ -36,7 +36,7 @@ class GHumanWithDirectivesData {
     String? G__typename,
   }) {
     return GHumanWithDirectivesData(
-      human: humanIsSet ? human : this.human,
+      human: human != null || humanIsSet ? human : this.human,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -99,8 +99,8 @@ class GHumanWithDirectivesData_human {
     String? G__typename,
   }) {
     return GHumanWithDirectivesData_human(
-      id: idIsSet ? id : this.id,
-      name: nameIsSet ? name : this.name,
+      id: id != null || idIsSet ? id : this.id,
+      name: name != null || nameIsSet ? name : this.name,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/directives/__generated__/human_with_directives.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/directives/__generated__/human_with_directives.req.gql.dart
@@ -118,20 +118,27 @@ class GHumanWithDirectivesReq
     return GHumanWithDirectivesReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/conditional_type_fragment.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/conditional_type_fragment.data.gql.dart
@@ -95,7 +95,7 @@ class GHeroConditionalTypeFragmentData {
     String? G__typename,
   }) {
     return GHeroConditionalTypeFragmentData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/conditional_type_fragment.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/conditional_type_fragment.req.gql.dart
@@ -120,20 +120,27 @@ class GHeroConditionalTypeFragmentReq
     return GHeroConditionalTypeFragmentReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -209,7 +216,9 @@ class GHumanNameReq implements _i1.FragmentRequest<_i2.GHumanNameData, Null> {
   }) {
     return GHumanNameReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/deep_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/deep_fragments.data.gql.dart
@@ -70,7 +70,7 @@ class GFragLevel1Data implements GFragLevel1, GFragLevel3, GFragLevel2 {
     return GFragLevel1Data(
       id: id ?? this.id,
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -154,7 +154,7 @@ class GFragLevel2Data implements GFragLevel2, GFragLevel3 {
   }) {
     return GFragLevel2Data(
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -229,7 +229,7 @@ class GFragLevel3Data implements GFragLevel3 {
     String? G__typename,
   }) {
     return GFragLevel3Data(
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -357,7 +357,7 @@ class GDeepFragmentsData {
     String? G__typename,
   }) {
     return GDeepFragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/deep_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/deep_fragments.req.gql.dart
@@ -113,20 +113,27 @@ class GDeepFragmentsReq
   }) {
     return GDeepFragmentsReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -206,7 +213,9 @@ class GFragLevel1Req implements _i1.FragmentRequest<_i2.GFragLevel1Data, Null> {
   }) {
     return GFragLevel1Req(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -269,7 +278,9 @@ class GFragLevel2Req implements _i1.FragmentRequest<_i2.GFragLevel2Data, Null> {
   }) {
     return GFragLevel2Req(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -331,7 +342,9 @@ class GFragLevel3Req implements _i1.FragmentRequest<_i2.GFragLevel3Data, Null> {
   }) {
     return GFragLevel3Req(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -391,7 +404,9 @@ class GFragLevel4Req implements _i1.FragmentRequest<_i2.GFragLevel4Data, Null> {
   }) {
     return GFragLevel4Req(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/duplicate_null_checks.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/duplicate_null_checks.data.gql.dart
@@ -36,9 +36,10 @@ class GDuplicateNullChecksData {
     String? G__typename,
   }) {
     return GDuplicateNullChecksData(
-      duplicateNullChecks: duplicateNullChecksIsSet
-          ? duplicateNullChecks
-          : this.duplicateNullChecks,
+      duplicateNullChecks:
+          duplicateNullChecks != null || duplicateNullChecksIsSet
+              ? duplicateNullChecks
+              : this.duplicateNullChecks,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/duplicate_null_checks.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/duplicate_null_checks.req.gql.dart
@@ -118,20 +118,27 @@ class GDuplicateNullChecksReq
     return GDuplicateNullChecksReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/fragment_directives.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/fragment_directives.data.gql.dart
@@ -39,7 +39,7 @@ class GHeroNameData implements GHeroName {
     String? G__typename,
   }) {
     return GHeroNameData(
-      name: nameIsSet ? name : this.name,
+      name: name != null || nameIsSet ? name : this.name,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -99,7 +99,7 @@ class GHeroFragmentDirectivesData {
     String? G__typename,
   }) {
     return GHeroFragmentDirectivesData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -163,7 +163,7 @@ class GHeroFragmentDirectivesData_hero {
     return GHeroFragmentDirectivesData_hero(
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
-      name: nameIsSet ? name : this.name,
+      name: name != null || nameIsSet ? name : this.name,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/fragment_directives.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/fragment_directives.req.gql.dart
@@ -120,20 +120,27 @@ class GHeroFragmentDirectivesReq
     return GHeroFragmentDirectivesReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -209,7 +216,9 @@ class GHeroNameReq implements _i1.FragmentRequest<_i2.GHeroNameData, Null> {
   }) {
     return GHeroNameReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/human_birthday.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/human_birthday.data.gql.dart
@@ -38,7 +38,7 @@ class GHumanBirthdayData {
     String? G__typename,
   }) {
     return GHumanBirthdayData(
-      human: humanIsSet ? human : this.human,
+      human: human != null || humanIsSet ? human : this.human,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/human_birthday.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/human_birthday.req.gql.dart
@@ -115,20 +115,27 @@ class GHumanBirthdayReq
     return GHumanBirthdayReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/numeric_value.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/numeric_value.data.gql.dart
@@ -41,7 +41,9 @@ class GNumericValueData {
     String? G__typename,
   }) {
     return GNumericValueData(
-      numericValue: numericValueIsSet ? numericValue : this.numericValue,
+      numericValue: numericValue != null || numericValueIsSet
+          ? numericValue
+          : this.numericValue,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -113,9 +115,9 @@ class GNumericValueData_numericValue {
     String? G__typename,
   }) {
     return GNumericValueData_numericValue(
-      value: valueIsSet ? value : this.value,
+      value: value != null || valueIsSet ? value : this.value,
       floatValues: floatValues ?? this.floatValues,
-      intValue: intValueIsSet ? intValue : this.intValue,
+      intValue: intValue != null || intValueIsSet ? intValue : this.intValue,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/numeric_value.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/numeric_value.req.gql.dart
@@ -108,20 +108,27 @@ class GNumericValueReq
   }) {
     return GNumericValueReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/posts_by_likes.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/posts_by_likes.data.gql.dart
@@ -50,7 +50,9 @@ class GPostsByLikesData {
     String? G__typename,
   }) {
     return GPostsByLikesData(
-      postsByLikes: postsByLikesIsSet ? postsByLikes : this.postsByLikes,
+      postsByLikes: postsByLikes != null || postsByLikesIsSet
+          ? postsByLikes
+          : this.postsByLikes,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/posts_by_likes.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/posts_by_likes.req.gql.dart
@@ -115,20 +115,27 @@ class GPostsByLikesReq
     return GPostsByLikesReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/review_by_one_of.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/review_by_one_of.data.gql.dart
@@ -41,7 +41,7 @@ class GReviewByOneOfData {
     String? G__typename,
   }) {
     return GReviewByOneOfData(
-      reviewBy: reviewByIsSet ? reviewBy : this.reviewBy,
+      reviewBy: reviewBy != null || reviewByIsSet ? reviewBy : this.reviewBy,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -105,7 +105,7 @@ class GReviewByOneOfData_reviewBy {
     String? G__typename,
   }) {
     return GReviewByOneOfData_reviewBy(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       stars: stars ?? this.stars,
       G__typename: G__typename ?? this.G__typename,
     );

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/review_by_one_of.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/review_by_one_of.req.gql.dart
@@ -115,20 +115,27 @@ class GReviewByOneOfReq
     return GReviewByOneOfReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/reviews_with_defaults.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/reviews_with_defaults.data.gql.dart
@@ -52,7 +52,7 @@ class GReviewsWithDefaultsData {
     String? G__typename,
   }) {
     return GReviewsWithDefaultsData(
-      reviews: reviewsIsSet ? reviews : this.reviews,
+      reviews: reviews != null || reviewsIsSet ? reviews : this.reviews,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -110,7 +110,7 @@ class GReviewsWithDefaultsData_reviews {
     String? G__typename,
   }) {
     return GReviewsWithDefaultsData_reviews(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/reviews_with_defaults.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/reviews_with_defaults.req.gql.dart
@@ -118,20 +118,27 @@ class GReviewsWithDefaultsReq
     return GReviewsWithDefaultsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_default.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_default.data.gql.dart
@@ -49,7 +49,7 @@ class GSearchWithDefaultData {
     String? G__typename,
   }) {
     return GSearchWithDefaultData(
-      search: searchIsSet ? search : this.search,
+      search: search != null || searchIsSet ? search : this.search,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_default.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_default.req.gql.dart
@@ -117,20 +117,27 @@ class GSearchWithDefaultReq
     return GSearchWithDefaultReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_starship.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_starship.data.gql.dart
@@ -51,7 +51,7 @@ class GSearchWithStarshipData {
     String? G__typename,
   }) {
     return GSearchWithStarshipData(
-      search: searchIsSet ? search : this.search,
+      search: search != null || searchIsSet ? search : this.search,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -202,8 +202,10 @@ class GSearchWithStarshipData_search__asStarship
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      length: lengthIsSet ? length : this.length,
-      coordinates: coordinatesIsSet ? coordinates : this.coordinates,
+      length: length != null || lengthIsSet ? length : this.length,
+      coordinates: coordinates != null || coordinatesIsSet
+          ? coordinates
+          : this.coordinates,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_starship.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/search_with_starship.req.gql.dart
@@ -109,20 +109,27 @@ class GSearchWithStarshipReq
   }) {
     return GSearchWithStarshipReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/settings.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/settings.data.gql.dart
@@ -42,7 +42,7 @@ class GSettingsData {
     String? G__typename,
   }) {
     return GSettingsData(
-      settings: settingsIsSet ? settings : this.settings,
+      settings: settings != null || settingsIsSet ? settings : this.settings,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/settings.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/settings.req.gql.dart
@@ -107,20 +107,27 @@ class GSettingsReq implements _i1.OperationRequest<_i2.GSettingsData, Null> {
   }) {
     return GSettingsReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/unconditional_type_fragment.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/unconditional_type_fragment.data.gql.dart
@@ -96,7 +96,7 @@ class GHeroUnconditionalTypeFragmentData {
     String? G__typename,
   }) {
     return GHeroUnconditionalTypeFragmentData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/unconditional_type_fragment.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/unconditional_type_fragment.req.gql.dart
@@ -114,20 +114,27 @@ class GHeroUnconditionalTypeFragmentReq
   }) {
     return GHeroUnconditionalTypeFragmentReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -203,7 +210,9 @@ class GHumanNameReq implements _i1.FragmentRequest<_i2.GHumanNameData, Null> {
   }) {
     return GHumanNameReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/weird_names.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/weird_names.data.gql.dart
@@ -43,7 +43,8 @@ class GWeirdNamesData {
     String? G__typename,
   }) {
     return GWeirdNamesData(
-      weirdNames: weirdNamesIsSet ? weirdNames : this.weirdNames,
+      weirdNames:
+          weirdNames != null || weirdNamesIsSet ? weirdNames : this.weirdNames,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -172,15 +173,21 @@ class GWeirdNamesData_weirdNames {
     String? G__typename,
   }) {
     return GWeirdNamesData_weirdNames(
-      Gclass: GclassIsSet ? Gclass : this.Gclass,
-      GtoJson: GtoJsonIsSet ? GtoJson : this.GtoJson,
-      GfromJson: GfromJsonIsSet ? GfromJson : this.GfromJson,
-      GcopyWith: GcopyWithIsSet ? GcopyWith : this.GcopyWith,
-      GhashCode: GhashCodeIsSet ? GhashCode : this.GhashCode,
-      Gvalues: GvaluesIsSet ? Gvalues : this.Gvalues,
-      hasuraEnum: hasuraEnumIsSet ? hasuraEnum : this.hasuraEnum,
-      result: resultIsSet ? result : this.result,
-      GruntimeType: GruntimeTypeIsSet ? GruntimeType : this.GruntimeType,
+      Gclass: Gclass != null || GclassIsSet ? Gclass : this.Gclass,
+      GtoJson: GtoJson != null || GtoJsonIsSet ? GtoJson : this.GtoJson,
+      GfromJson:
+          GfromJson != null || GfromJsonIsSet ? GfromJson : this.GfromJson,
+      GcopyWith:
+          GcopyWith != null || GcopyWithIsSet ? GcopyWith : this.GcopyWith,
+      GhashCode:
+          GhashCode != null || GhashCodeIsSet ? GhashCode : this.GhashCode,
+      Gvalues: Gvalues != null || GvaluesIsSet ? Gvalues : this.Gvalues,
+      hasuraEnum:
+          hasuraEnum != null || hasuraEnumIsSet ? hasuraEnum : this.hasuraEnum,
+      result: result != null || resultIsSet ? result : this.result,
+      GruntimeType: GruntimeType != null || GruntimeTypeIsSet
+          ? GruntimeType
+          : this.GruntimeType,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/weird_names.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/edge_cases/__generated__/weird_names.req.gql.dart
@@ -108,20 +108,27 @@ class GWeirdNamesReq
   }) {
     return GWeirdNamesReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_friends_and_name.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_friends_and_name.data.gql.dart
@@ -116,7 +116,8 @@ class GheroFriendsAndNameData_friendsConnection
     String? G__typename,
   }) {
     return GheroFriendsAndNameData_friendsConnection(
-      totalCount: totalCountIsSet ? totalCount : this.totalCount,
+      totalCount:
+          totalCount != null || totalCountIsSet ? totalCount : this.totalCount,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_friends_and_name.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_friends_and_name.req.gql.dart
@@ -50,7 +50,9 @@ class GheroFriendsAndNameReq
   }) {
     return GheroFriendsAndNameReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_name_and_id.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_name_and_id.req.gql.dart
@@ -49,7 +49,9 @@ class GheroNameAndIdReq
   }) {
     return GheroNameAndIdReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_with_scalar_var.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_with_scalar_var.data.gql.dart
@@ -58,8 +58,9 @@ class GPostFragmentForUser1Data implements GPostFragmentForUser1 {
   }) {
     return GPostFragmentForUser1Data(
       id: id ?? this.id,
-      favoritedUsers:
-          favoritedUsersIsSet ? favoritedUsers : this.favoritedUsers,
+      favoritedUsers: favoritedUsers != null || favoritedUsersIsSet
+          ? favoritedUsers
+          : this.favoritedUsers,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -181,7 +182,7 @@ class GPostsWithFixedVariableData {
     String? G__typename,
   }) {
     return GPostsWithFixedVariableData(
-      posts: postsIsSet ? posts : this.posts,
+      posts: posts != null || postsIsSet ? posts : this.posts,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_with_scalar_var.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragment_with_scalar_var.req.gql.dart
@@ -120,20 +120,27 @@ class GPostsWithFixedVariableReq
     return GPostsWithFixedVariableReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -211,7 +218,9 @@ class GPostFragmentForUser1Req
   }) {
     return GPostFragmentForUser1Req(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragments_with_shared_transitive_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragments_with_shared_transitive_fragments.data.gql.dart
@@ -46,7 +46,7 @@ class GHeroWith2FragmentsWithSharedTransitiveFragmentsData {
     String? G__typename,
   }) {
     return GHeroWith2FragmentsWithSharedTransitiveFragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -185,7 +185,8 @@ class GHeroWith2FragmentsWithSharedTransitiveFragmentsData_hero_friendsConnectio
     String? G__typename,
   }) {
     return GHeroWith2FragmentsWithSharedTransitiveFragmentsData_hero_friendsConnection(
-      totalCount: totalCountIsSet ? totalCount : this.totalCount,
+      totalCount:
+          totalCount != null || totalCountIsSet ? totalCount : this.totalCount,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragments_with_shared_transitive_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/fragments_with_shared_transitive_fragments.req.gql.dart
@@ -126,20 +126,27 @@ class GHeroWith2FragmentsWithSharedTransitiveFragmentsReq
   }) {
     return GHeroWith2FragmentsWithSharedTransitiveFragmentsReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_fragments.data.gql.dart
@@ -208,8 +208,9 @@ class GcomparisonFieldsData_friendsConnection
     String? G__typename,
   }) {
     return GcomparisonFieldsData_friendsConnection(
-      totalCount: totalCountIsSet ? totalCount : this.totalCount,
-      edges: edgesIsSet ? edges : this.edges,
+      totalCount:
+          totalCount != null || totalCountIsSet ? totalCount : this.totalCount,
+      edges: edges != null || edgesIsSet ? edges : this.edges,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -270,7 +271,7 @@ class GcomparisonFieldsData_friendsConnection_edges
     String? G__typename,
   }) {
     return GcomparisonFieldsData_friendsConnection_edges(
-      node: nodeIsSet ? node : this.node,
+      node: node != null || nodeIsSet ? node : this.node,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -330,7 +331,7 @@ class GHeroWithFragmentsData {
     String? G__typename,
   }) {
     return GHeroWithFragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_fragments.req.gql.dart
@@ -120,20 +120,27 @@ class GHeroWithFragmentsReq
     return GHeroWithFragmentsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -209,7 +216,9 @@ class GheroDataReq implements _i1.FragmentRequest<_i2.GheroDataData, Null> {
   }) {
     return GheroDataReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -278,7 +287,9 @@ class GcomparisonFieldsReq
     return GcomparisonFieldsReq(
       vars: vars ?? this.vars,
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.data.gql.dart
@@ -162,8 +162,9 @@ class GheroFieldsFragmentData__asHuman extends GheroFieldsFragmentData
       id: id ?? this.id,
       name: name ?? this.name,
       G__typename: G__typename ?? this.G__typename,
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
-      friends: friendsIsSet ? friends : this.friends,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
     );
   }
 
@@ -309,8 +310,9 @@ class GheroFieldsFragmentData__asHuman_friends__asDroid
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
     );
   }
 
@@ -385,7 +387,8 @@ class GheroFieldsFragmentData__asHuman_friends__asHuman
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
     );
   }
 
@@ -499,8 +502,9 @@ class GheroFieldsFragmentData__asDroid extends GheroFieldsFragmentData
       id: id ?? this.id,
       name: name ?? this.name,
       G__typename: G__typename ?? this.G__typename,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
     );
   }
 
@@ -643,8 +647,9 @@ class GhumanFieldsFragmentData implements GhumanFieldsFragment {
     String? G__typename,
   }) {
     return GhumanFieldsFragmentData(
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
-      friends: friendsIsSet ? friends : this.friends,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -781,8 +786,9 @@ class GhumanFieldsFragmentData_friends__asDroid
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
     );
   }
 
@@ -855,7 +861,8 @@ class GhumanFieldsFragmentData_friends__asHuman
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
     );
   }
 
@@ -960,8 +967,9 @@ class GdroidFieldsFragmentData implements GdroidFieldsFragment {
     String? G__typename,
   }) {
     return GdroidFieldsFragmentData(
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -1022,7 +1030,7 @@ class GHeroWithInterfaceSubTypedFragmentsData {
     String? G__typename,
   }) {
     return GHeroWithInterfaceSubTypedFragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_subtyped_fragments.req.gql.dart
@@ -124,20 +124,27 @@ class GHeroWithInterfaceSubTypedFragmentsReq
     return GHeroWithInterfaceSubTypedFragmentsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -218,7 +225,9 @@ class GheroFieldsFragmentReq
   }) {
     return GheroFieldsFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -282,7 +291,9 @@ class GhumanFieldsFragmentReq
   }) {
     return GhumanFieldsFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -344,7 +355,9 @@ class GdroidFieldsFragmentReq
   }) {
     return GdroidFieldsFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_unnamed_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_unnamed_fragments.data.gql.dart
@@ -42,7 +42,7 @@ class GHeroWithInterfaceUnnamedFragmentsData {
     String? G__typename,
   }) {
     return GHeroWithInterfaceUnnamedFragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -213,8 +213,9 @@ class GHeroWithInterfaceUnnamedFragmentsData_hero__asHuman
       id: id ?? this.id,
       name: name ?? this.name,
       G__typename: G__typename ?? this.G__typename,
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
-      friends: friendsIsSet ? friends : this.friends,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
     );
   }
 
@@ -367,7 +368,8 @@ class GHeroWithInterfaceUnnamedFragmentsData_hero__asHuman_friends__asHuman
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      homePlanet: homePlanetIsSet ? homePlanet : this.homePlanet,
+      homePlanet:
+          homePlanet != null || homePlanetIsSet ? homePlanet : this.homePlanet,
     );
   }
 
@@ -441,8 +443,9 @@ class GHeroWithInterfaceUnnamedFragmentsData_hero__asHuman_friends__asDroid
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
     );
   }
 
@@ -551,8 +554,9 @@ class GHeroWithInterfaceUnnamedFragmentsData_hero__asDroid
       id: id ?? this.id,
       name: name ?? this.name,
       G__typename: G__typename ?? this.G__typename,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_unnamed_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/hero_with_interface_unnamed_fragments.req.gql.dart
@@ -120,20 +120,27 @@ class GHeroWithInterfaceUnnamedFragmentsReq
     return GHeroWithInterfaceUnnamedFragmentsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/multiple_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/multiple_fragments.data.gql.dart
@@ -157,7 +157,7 @@ class GHeroWith2FragmentsData {
     String? G__typename,
   }) {
     return GHeroWith2FragmentsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/multiple_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/multiple_fragments.req.gql.dart
@@ -112,20 +112,27 @@ class GHeroWith2FragmentsReq
   }) {
     return GHeroWith2FragmentsReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -201,7 +208,9 @@ class GheroNameReq implements _i1.FragmentRequest<_i2.GheroNameData, Null> {
   }) {
     return GheroNameReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -261,7 +270,9 @@ class GheroIdReq implements _i1.FragmentRequest<_i2.GheroIdData, Null> {
   }) {
     return GheroIdReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/nested_duplicate_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/nested_duplicate_fragments.data.gql.dart
@@ -85,7 +85,7 @@ class GCharacterDetailsData implements GCharacterDetails {
     return GCharacterDetailsData(
       id: id ?? this.id,
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       appearsIn: appearsIn ?? this.appearsIn,
       G__typename: G__typename ?? this.G__typename,
     );
@@ -242,7 +242,7 @@ class GFriendInfoData_friendsConnection
     String? G__typename,
   }) {
     return GFriendInfoData_friendsConnection(
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -379,7 +379,7 @@ class GSearchResultsQueryData {
     String? G__typename,
   }) {
     return GSearchResultsQueryData(
-      search: searchIsSet ? search : this.search,
+      search: search != null || searchIsSet ? search : this.search,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -532,7 +532,7 @@ class GSearchResultsQueryData_search__asHuman
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       appearsIn: appearsIn ?? this.appearsIn,
     );
   }
@@ -629,7 +629,7 @@ class GSearchResultsQueryData_search__asDroid
       G__typename: G__typename ?? this.G__typename,
       id: id ?? this.id,
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       appearsIn: appearsIn ?? this.appearsIn,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/nested_duplicate_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/nested_duplicate_fragments.req.gql.dart
@@ -113,20 +113,27 @@ class GSearchResultsQueryReq
   }) {
     return GSearchResultsQueryReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -207,7 +214,9 @@ class GCharacterDetailsReq
   }) {
     return GCharacterDetailsReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -269,7 +278,9 @@ class GFriendInfoReq implements _i1.FragmentRequest<_i2.GFriendInfoData, Null> {
   }) {
     return GFriendInfoReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -331,7 +342,9 @@ class GCharacterBasicReq
   }) {
     return GCharacterBasicReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment.req.gql.dart
@@ -46,7 +46,9 @@ class GSharedFragmentReq
   }) {
     return GSharedFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment_queries.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment_queries.data.gql.dart
@@ -537,8 +537,9 @@ class GSharedBookFragmentData__asTextbook extends GSharedBookFragmentData
       title: title ?? this.title,
       author: author ?? this.author,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
       courses: courses ?? this.courses,
@@ -656,8 +657,9 @@ class GSharedBookFragmentData__asColoringBook extends GSharedBookFragmentData
       title: title ?? this.title,
       author: author ?? this.author,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
       colors: colors ?? this.colors,
@@ -767,8 +769,9 @@ class GSharedBookFragmentData__unknown extends GSharedBookFragmentData
       title: title ?? this.title,
       author: author ?? this.author,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
     );

--- a/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment_queries.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/fragments/__generated__/shared_fragment_queries.req.gql.dart
@@ -111,20 +111,27 @@ class GSharedBooksAReq
   }) {
     return GSharedBooksAReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -266,20 +273,27 @@ class GSharedBooksBReq
   }) {
     return GSharedBooksBReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -357,7 +371,9 @@ class GSharedAuthorFragmentReq
   }) {
     return GSharedAuthorFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -421,7 +437,9 @@ class GSharedBookFragmentReq
   }) {
     return GSharedBookFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/hero_for_episode.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/hero_for_episode.data.gql.dart
@@ -53,9 +53,10 @@ class GDroidFragmentData implements GDroidFragment {
     String? G__typename,
   }) {
     return GDroidFragmentData(
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
-      result: resultIsSet ? result : this.result,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
+      result: result != null || resultIsSet ? result : this.result,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -116,7 +117,7 @@ class GHeroForEpisodeData {
     String? G__typename,
   }) {
     return GHeroForEpisodeData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -316,11 +317,12 @@ class GHeroForEpisodeData_hero__asDroid extends GHeroForEpisodeData_hero
   }) {
     return GHeroForEpisodeData_hero__asDroid(
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
-      primaryFunction:
-          primaryFunctionIsSet ? primaryFunction : this.primaryFunction,
-      result: resultIsSet ? result : this.result,
+      primaryFunction: primaryFunction != null || primaryFunctionIsSet
+          ? primaryFunction
+          : this.primaryFunction,
+      result: result != null || resultIsSet ? result : this.result,
     );
   }
 
@@ -385,7 +387,7 @@ class GHeroForEpisodeData_hero__unknown extends GHeroForEpisodeData_hero {
   }) {
     return GHeroForEpisodeData_hero__unknown(
       name: name ?? this.name,
-      friends: friendsIsSet ? friends : this.friends,
+      friends: friends != null || friendsIsSet ? friends : this.friends,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/hero_for_episode.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/hero_for_episode.req.gql.dart
@@ -118,20 +118,27 @@ class GHeroForEpisodeReq
     return GHeroForEpisodeReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -208,7 +215,9 @@ class GDroidFragmentReq
   }) {
     return GDroidFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces.data.gql.dart
@@ -58,9 +58,9 @@ class GMultipleInterfacesData {
     String? G__typename,
   }) {
     return GMultipleInterfacesData(
-      cThing: cThingIsSet ? cThing : this.cThing,
-      dThing: dThingIsSet ? dThing : this.dThing,
-      other: otherIsSet ? other : this.other,
+      cThing: cThing != null || cThingIsSet ? cThing : this.cThing,
+      dThing: dThing != null || dThingIsSet ? dThing : this.dThing,
+      other: other != null || otherIsSet ? other : this.other,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces.req.gql.dart
@@ -109,20 +109,27 @@ class GMultipleInterfacesReq
   }) {
     return GMultipleInterfacesReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces_plus_fragments.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces_plus_fragments.data.gql.dart
@@ -192,9 +192,9 @@ class GMultipleInterfacesData {
     String? G__typename,
   }) {
     return GMultipleInterfacesData(
-      cThing: cThingIsSet ? cThing : this.cThing,
-      dThing: dThingIsSet ? dThing : this.dThing,
-      other: otherIsSet ? other : this.other,
+      cThing: cThing != null || cThingIsSet ? cThing : this.cThing,
+      dThing: dThing != null || dThingIsSet ? dThing : this.dThing,
+      other: other != null || otherIsSet ? other : this.other,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces_plus_fragments.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/multiple_interfaces_plus_fragments.req.gql.dart
@@ -112,20 +112,27 @@ class GMultipleInterfacesReq
   }) {
     return GMultipleInterfacesReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -203,7 +210,9 @@ class GCThingFragmentReq
   }) {
     return GCThingFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -265,7 +274,9 @@ class GDThingFragmentReq
   }) {
     return GDThingFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/transitive_interface_inheritance.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/transitive_interface_inheritance.data.gql.dart
@@ -37,7 +37,7 @@ class GAThingTransitiveInterfaceInheritanceData {
     String? G__typename,
   }) {
     return GAThingTransitiveInterfaceInheritanceData(
-      aThing: aThingIsSet ? aThing : this.aThing,
+      aThing: aThing != null || aThingIsSet ? aThing : this.aThing,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -338,7 +338,7 @@ class GBThingTransitiveInterfaceInheritanceData {
     String? G__typename,
   }) {
     return GBThingTransitiveInterfaceInheritanceData(
-      bThing: bThingIsSet ? bThing : this.bThing,
+      bThing: bThing != null || bThingIsSet ? bThing : this.bThing,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/transitive_interface_inheritance.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/interfaces/__generated__/transitive_interface_inheritance.req.gql.dart
@@ -113,20 +113,27 @@ class GAThingTransitiveInterfaceInheritanceReq
   }) {
     return GAThingTransitiveInterfaceInheritanceReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -270,20 +277,27 @@ class GBThingTransitiveInterfaceInheritanceReq
   }) {
     return GBThingTransitiveInterfaceInheritanceReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/issue_610/__generated__/books.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/issue_610/__generated__/books.data.gql.dart
@@ -526,8 +526,9 @@ class GBookFragmentData__asTextbook extends GBookFragmentData
       author: author ?? this.author,
       title: title ?? this.title,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
       courses: courses ?? this.courses,
@@ -642,8 +643,9 @@ class GBookFragmentData__asColoringBook extends GBookFragmentData
       author: author ?? this.author,
       title: title ?? this.title,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
       colors: colors ?? this.colors,
@@ -750,8 +752,9 @@ class GBookFragmentData__unknown extends GBookFragmentData
       author: author ?? this.author,
       title: title ?? this.title,
       tagMatrix: tagMatrix ?? this.tagMatrix,
-      tagMatrixNullable:
-          tagMatrixNullableIsSet ? tagMatrixNullable : this.tagMatrixNullable,
+      tagMatrixNullable: tagMatrixNullable != null || tagMatrixNullableIsSet
+          ? tagMatrixNullable
+          : this.tagMatrixNullable,
       relatedBooks: relatedBooks ?? this.relatedBooks,
       G__typename: G__typename ?? this.G__typename,
     );

--- a/packages/ferry_generator2_end_to_end/lib/issue_610/__generated__/books.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/issue_610/__generated__/books.req.gql.dart
@@ -110,20 +110,27 @@ class GGetBooksReq implements _i1.OperationRequest<_i2.GGetBooksData, Null> {
   }) {
     return GGetBooksReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 
@@ -201,7 +208,9 @@ class GAuthorFragmentReq
   }) {
     return GAuthorFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }
@@ -264,7 +273,9 @@ class GBookFragmentReq
   }) {
     return GBookFragmentReq(
       document: document ?? this.document,
-      fragmentName: fragmentNameIsSet ? fragmentName : this.fragmentName,
+      fragmentName: fragmentName != null || fragmentNameIsSet
+          ? fragmentName
+          : this.fragmentName,
       idFields: idFields ?? this.idFields,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/no_vars/__generated__/hero_no_vars.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/no_vars/__generated__/hero_no_vars.data.gql.dart
@@ -37,7 +37,7 @@ class GHeroNoVarsData {
     String? G__typename,
   }) {
     return GHeroNoVarsData(
-      hero: heroIsSet ? hero : this.hero,
+      hero: hero != null || heroIsSet ? hero : this.hero,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/no_vars/__generated__/hero_no_vars.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/no_vars/__generated__/hero_no_vars.req.gql.dart
@@ -108,20 +108,27 @@ class GHeroNoVarsReq
   }) {
     return GHeroNoVarsReq(
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/scalars/__generated__/review_with_date.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/scalars/__generated__/review_with_date.data.gql.dart
@@ -45,7 +45,9 @@ class GReviewWithDateData {
     String? G__typename,
   }) {
     return GReviewWithDateData(
-      createReview: createReviewIsSet ? createReview : this.createReview,
+      createReview: createReview != null || createReviewIsSet
+          ? createReview
+          : this.createReview,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -147,10 +149,12 @@ class GReviewWithDateData_createReview {
     String? G__typename,
   }) {
     return GReviewWithDateData_createReview(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       stars: stars ?? this.stars,
-      commentary: commentaryIsSet ? commentary : this.commentary,
-      createdAt: createdAtIsSet ? createdAt : this.createdAt,
+      commentary:
+          commentary != null || commentaryIsSet ? commentary : this.commentary,
+      createdAt:
+          createdAt != null || createdAtIsSet ? createdAt : this.createdAt,
       seenOn: seenOn ?? this.seenOn,
       custom: custom ?? this.custom,
       G__typename: G__typename ?? this.G__typename,

--- a/packages/ferry_generator2_end_to_end/lib/scalars/__generated__/review_with_date.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/scalars/__generated__/review_with_date.req.gql.dart
@@ -116,20 +116,27 @@ class GReviewWithDateReq
     return GReviewWithDateReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.data.gql.dart
@@ -32,7 +32,9 @@ class GReviewAddedData {
     bool reviewAddedIsSet = false,
   }) {
     return GReviewAddedData(
-        reviewAdded: reviewAddedIsSet ? reviewAdded : this.reviewAdded);
+        reviewAdded: reviewAdded != null || reviewAddedIsSet
+            ? reviewAdded
+            : this.reviewAdded);
   }
 
   @override
@@ -102,9 +104,10 @@ class GReviewAddedData_reviewAdded {
     String? G__typename,
   }) {
     return GReviewAddedData_reviewAdded(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       stars: stars ?? this.stars,
-      commentary: commentaryIsSet ? commentary : this.commentary,
+      commentary:
+          commentary != null || commentaryIsSet ? commentary : this.commentary,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/subscriptions/__generated__/review_added.req.gql.dart
@@ -115,20 +115,27 @@ class GReviewAddedReq
     return GReviewAddedReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_custom_field.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_custom_field.data.gql.dart
@@ -36,8 +36,9 @@ class GCreateCustomFieldData {
     String? G__typename,
   }) {
     return GCreateCustomFieldData(
-      createCustomField:
-          createCustomFieldIsSet ? createCustomField : this.createCustomField,
+      createCustomField: createCustomField != null || createCustomFieldIsSet
+          ? createCustomField
+          : this.createCustomField,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_custom_field.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_custom_field.req.gql.dart
@@ -117,20 +117,27 @@ class GCreateCustomFieldReq
     return GCreateCustomFieldReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_review.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_review.data.gql.dart
@@ -42,7 +42,9 @@ class GCreateReviewData {
     String? G__typename,
   }) {
     return GCreateReviewData(
-      createReview: createReviewIsSet ? createReview : this.createReview,
+      createReview: createReview != null || createReviewIsSet
+          ? createReview
+          : this.createReview,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -116,9 +118,10 @@ class GCreateReviewData_createReview {
     String? G__typename,
   }) {
     return GCreateReviewData_createReview(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       stars: stars ?? this.stars,
-      commentary: commentaryIsSet ? commentary : this.commentary,
+      commentary:
+          commentary != null || commentaryIsSet ? commentary : this.commentary,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_review.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/create_review.req.gql.dart
@@ -115,20 +115,27 @@ class GCreateReviewReq
     return GCreateReviewReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/human_with_args.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/human_with_args.data.gql.dart
@@ -36,7 +36,7 @@ class GHumanWithArgsData {
     String? G__typename,
   }) {
     return GHumanWithArgsData(
-      human: humanIsSet ? human : this.human,
+      human: human != null || humanIsSet ? human : this.human,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -99,7 +99,7 @@ class GHumanWithArgsData_human {
   }) {
     return GHumanWithArgsData_human(
       name: name ?? this.name,
-      height: heightIsSet ? height : this.height,
+      height: height != null || heightIsSet ? height : this.height,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/human_with_args.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/human_with_args.req.gql.dart
@@ -115,20 +115,27 @@ class GHumanWithArgsReq
     return GHumanWithArgsReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/list_argument.data.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/list_argument.data.gql.dart
@@ -52,7 +52,7 @@ class GreviewsWithListArgumentData {
     String? G__typename,
   }) {
     return GreviewsWithListArgumentData(
-      reviews: reviewsIsSet ? reviews : this.reviews,
+      reviews: reviews != null || reviewsIsSet ? reviews : this.reviews,
       G__typename: G__typename ?? this.G__typename,
     );
   }
@@ -111,7 +111,7 @@ class GreviewsWithListArgumentData_reviews {
     String? G__typename,
   }) {
     return GreviewsWithListArgumentData_reviews(
-      episode: episodeIsSet ? episode : this.episode,
+      episode: episode != null || episodeIsSet ? episode : this.episode,
       G__typename: G__typename ?? this.G__typename,
     );
   }

--- a/packages/ferry_generator2_end_to_end/lib/variables/__generated__/list_argument.req.gql.dart
+++ b/packages/ferry_generator2_end_to_end/lib/variables/__generated__/list_argument.req.gql.dart
@@ -118,20 +118,27 @@ class GreviewsWithListArgumentReq
     return GreviewsWithListArgumentReq(
       vars: vars ?? this.vars,
       operation: operation ?? this.operation,
-      requestId: requestIdIsSet ? requestId : this.requestId,
-      updateResult: updateResultIsSet ? updateResult : this.updateResult,
-      optimisticResponse: optimisticResponseIsSet
+      requestId:
+          requestId != null || requestIdIsSet ? requestId : this.requestId,
+      updateResult: updateResult != null || updateResultIsSet
+          ? updateResult
+          : this.updateResult,
+      optimisticResponse: optimisticResponse != null || optimisticResponseIsSet
           ? optimisticResponse
           : this.optimisticResponse,
-      updateCacheHandlerKey: updateCacheHandlerKeyIsSet
-          ? updateCacheHandlerKey
-          : this.updateCacheHandlerKey,
-      updateCacheHandlerContext: updateCacheHandlerContextIsSet
-          ? updateCacheHandlerContext
-          : this.updateCacheHandlerContext,
-      fetchPolicy: fetchPolicyIsSet ? fetchPolicy : this.fetchPolicy,
+      updateCacheHandlerKey:
+          updateCacheHandlerKey != null || updateCacheHandlerKeyIsSet
+              ? updateCacheHandlerKey
+              : this.updateCacheHandlerKey,
+      updateCacheHandlerContext:
+          updateCacheHandlerContext != null || updateCacheHandlerContextIsSet
+              ? updateCacheHandlerContext
+              : this.updateCacheHandlerContext,
+      fetchPolicy: fetchPolicy != null || fetchPolicyIsSet
+          ? fetchPolicy
+          : this.fetchPolicy,
       executeOnListen: executeOnListen ?? this.executeOnListen,
-      context: contextIsSet ? context : this.context,
+      context: context != null || contextIsSet ? context : this.context,
     );
   }
 

--- a/packages/ferry_generator2_end_to_end/pubspec.lock
+++ b/packages/ferry_generator2_end_to_end/pubspec.lock
@@ -180,7 +180,7 @@ packages:
       path: "../ferry_generator2"
       relative: true
     source: path
-    version: "0.1.0-dev.5"
+    version: "0.1.0-dev.6"
   ferry_store:
     dependency: "direct overridden"
     description:

--- a/packages/ferry_generator2_end_to_end/test/runtime_test.dart
+++ b/packages/ferry_generator2_end_to_end/test/runtime_test.dart
@@ -1107,11 +1107,9 @@ void main() {
 
     final updated = original.copyWith(
       requestId: 'req-2',
-      requestIdIsSet: true,
       updateCacheHandlerContext: <String, dynamic>{
         'count': 2,
       },
-      updateCacheHandlerContextIsSet: true,
     );
     expect(updated.requestId, 'req-2');
     expect(
@@ -1119,11 +1117,52 @@ void main() {
       equals(<String, dynamic>{'count': 2}),
     );
 
+    final unchanged = updated.copyWith(requestId: null);
+    expect(unchanged.requestId, 'req-2');
+
     final cleared = updated.copyWith(
       requestId: null,
       requestIdIsSet: true,
     );
     expect(cleared.requestId, isNull);
+  });
+
+  test('data copyWith updates nullable fields', () {
+    const original = GDroidFragmentData(
+      primaryFunction: 'Astromech',
+      result: 'ready',
+    );
+
+    final updated = original.copyWith(primaryFunction: 'Protocol');
+    expect(updated.primaryFunction, 'Protocol');
+    expect(updated.result, 'ready');
+
+    final unchanged = updated.copyWith(primaryFunction: null);
+    expect(unchanged.primaryFunction, 'Protocol');
+
+    final cleared = updated.copyWith(
+      primaryFunction: null,
+      primaryFunctionIsSet: true,
+    );
+    expect(cleared.primaryFunction, isNull);
+
+    const named = GHeroNameData(
+      name: 'Luke',
+      G__typename: 'Human',
+    );
+    expect(named.copyWith(name: 'Leia').name, 'Leia');
+    expect(named.copyWith(name: null).name, 'Luke');
+    expect(named.copyWith(name: null, nameIsSet: true).name, isNull);
+  });
+
+  test('copyWith keeps non-null field behavior', () {
+    const original = GHumanWithArgsData_human(
+      name: 'Luke',
+      height: 1.72,
+    );
+
+    expect(original.copyWith(name: 'Leia').name, 'Leia');
+    expect(original.copyWith(name: null).name, 'Luke');
   });
 
   test('no-vars request copyWith preserves vars', () {


### PR DESCRIPTION
Summary
- Update generated nullable-field copyWith logic so non-null values replace existing values without requiring the matching IsSet flag.
- Preserve explicit null assignment through fieldIsSet: true and keep omitted/null nullable parameters preserving the old value.
- Regenerate ferry_generator2_end_to_end outputs and add runtime coverage for nullable data/request copyWith behavior and unchanged non-null fields.

Breaking Change
- Nullable generated copyWith parameters now treat non-null arguments as replacements without requiring the matching IsSet flag.

Testing
- dart test in packages/ferry_generator2
- dart test in packages/ferry_generator2_end_to_end
- git diff --check
